### PR TITLE
feat(director-notes): bring the File Preview table of contents to both reading modes

### DIFF
--- a/docs/agent-guides/UI-PATTERNS.md
+++ b/docs/agent-guides/UI-PATTERNS.md
@@ -1052,6 +1052,28 @@ The second case is the one that gets missed: an SVG appended with `appendChild` 
 
 ---
 
+## Table of Contents (`components/Toc`)
+
+Any long scrollable surface that wants a jump list uses the shared TOC. Do NOT re-implement the floating button, the panel, or its keyboard handling: users have muscle memory from File Preview, and a second copy drifts from it.
+
+| Piece               | Location                            | Responsibility                                                                      |
+| ------------------- | ----------------------------------- | ----------------------------------------------------------------------------------- |
+| `<TocOverlay>`      | `components/Toc/TocOverlay.tsx`     | The button + panel, entry rendering, Arrow/Home/End navigation, focus-first-on-open |
+| `useTocOverlay()`   | `hooks/ui/useTocOverlay.ts`         | Open state, toggle hotkey, Escape, click-outside, focus restore on close            |
+| `computeTocWidth()` | `components/Toc/tocWidth.ts`        | Panel width from the longest entry (clamped 200-500px)                              |
+| `extractHeadings()` | `components/Toc/extractHeadings.ts` | Markdown headings -> `TocEntry[]`, code-fence aware, `github-slugger` slugs         |
+
+Consumers: `FilePreviewToc` (markdown files) and `AIOverviewTab` (Director's Notes, both reading modes).
+
+Two things a host must get right:
+
+- **Anchors have to exist.** The default scroll path is `containerRef.querySelector('#slug')`. For rendered markdown that means passing `rehype-slug` so headings carry ids matching `extractHeadings`' slugs. For non-heading targets (Director's Notes' `SectionCard`s, the virtualized Fast tier) either put a matching `id` on the target or pass `onSelectEntry` and handle the scroll yourself.
+- **The keydown must reach the hook.** `handleKeyDown` fires from the element that has DOM focus, and keys bubble UP. If an ancestor owns focus, the hook never sees the hotkey. Focus the scroll region itself - in Director's Notes the tab exposes a `TabFocusHandle` whose `focus()` targets the content region for exactly this reason.
+
+Escape ordering is the host's call. On a layer-stack modal, delegate to `closeIfOpen()` first and only close the modal when it returns false, so Escape dismisses the panel before the modal.
+
+---
+
 ## Tab System
 
 Each agent supports multiple AI tabs within its workspace. Tab management hooks live in `src/renderer/hooks/tabs/`.

--- a/docs/director-notes.md
+++ b/docs/director-notes.md
@@ -101,6 +101,18 @@ The AI Overview renders the same synopsis two ways, switchable with the **Rich /
 
 You can set which mode opens by default in **Settings > Encore Features > Director's Notes**; the in-tab toggle overrides it for the current session.
 
+#### Jumping between sections
+
+Both reading modes carry the same table of contents as the Markdown file preview, in the same place (the round button at the bottom right) with the same behavior:
+
+- Toggle it with the **Table of Contents** shortcut (<kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>\</kbd>) or by clicking the button.
+- The first entry is focused when it opens, so <kbd>↑</kbd> / <kbd>↓</kbd> (plus <kbd>Home</kbd> / <kbd>End</kbd>) move through sections and scroll as you go.
+- Clicking an entry scrolls to that section and leaves the panel open, so you can jump a few times in a row.
+- **Top** and **Bottom** jump to the ends of the report.
+- <kbd>Esc</kbd> or a click outside dismisses it, leaving Director's Notes open.
+
+Rich mode lists the dashboard widgets followed by the narrative sections; Plain mode lists the narrative headings.
+
 #### When the AI's output cannot be parsed
 
 The synopsis agent returns a structured narrative, and both reading modes render from it. If a run comes back malformed (cut off mid-response, or with formatting the parser rejects), Maestro salvages the readable portion and shows it with a banner saying what had to be recovered - a partial report is never presented as a complete one. When nothing usable survives, both modes show a parse-failure banner with the raw output preserved behind **View raw output**. Neither mode ever renders the raw structured output as if it were the report.

--- a/src/__tests__/renderer/components/DirectorNotes/AIOverviewTab.test.tsx
+++ b/src/__tests__/renderer/components/DirectorNotes/AIOverviewTab.test.tsx
@@ -17,6 +17,15 @@ const settingsMock = vi.hoisted(() => ({
 			defaultMode: undefined as 'rich' | 'plain' | undefined,
 		},
 		bionifyReadingMode: false,
+		// The table-of-contents hotkey is matched against the user's configured
+		// shortcuts, so the mock has to carry the binding the real settings do.
+		shortcuts: {
+			toggleFilePreviewToc: {
+				id: 'toggleFilePreviewToc',
+				label: 'Toggle Table of Contents (Markdown Preview)',
+				keys: ['Meta', '\\'],
+			},
+		},
 	},
 }));
 vi.mock('../../../../renderer/hooks/settings/useSettings', () => ({
@@ -959,6 +968,126 @@ describe('AIOverviewTab', () => {
 			const copied = mockWriteText.mock.calls[0][0] as string;
 			expect(copied).toContain('- Recovered bullet');
 			expect(copied).not.toContain('"version"');
+		});
+	});
+
+	// The TOC is the File Preview control, reused. These pin the behavior a user
+	// has muscle memory for: the same hotkey toggles it, Escape dismisses it (and
+	// is reported as consumed so the modal stays open), and the jump list matches
+	// whichever reading mode is showing.
+	describe('table of contents', () => {
+		const narrative = {
+			version: 1 as const,
+			sections: [
+				{
+					kind: 'accomplishments' as const,
+					title: 'Accomplishments',
+					items: [{ text: 'Shipped the TOC' }],
+				},
+				{ kind: 'challenges' as const, title: 'Challenges', items: [{ text: 'A blocker' }] },
+			],
+		};
+
+		beforeEach(() => {
+			mockGenerateSynopsis.mockResolvedValue({
+				success: true,
+				synopsis: JSON.stringify(narrative),
+				narrative,
+				stats: { agentCount: 2, entryCount: 9, durationMs: 5000 },
+			});
+		});
+
+		/** The content region owns the keydown, matching File Preview's container. */
+		const contentRegion = () => document.querySelector('.scrollbar-thin') as HTMLElement;
+
+		const pressToggle = () =>
+			fireEvent.keyDown(contentRegion(), { key: '\\', metaKey: true, code: 'Backslash' });
+
+		async function renderReady(ref?: React.Ref<{ onEscape?: () => boolean; focus: () => void }>) {
+			render(<AIOverviewTab ref={ref as never} theme={mockTheme} />);
+			await waitFor(() => {
+				expect(screen.getByTestId('rich-overview')).toBeInTheDocument();
+			});
+		}
+
+		it('shows the toggle button once there is something to jump to', async () => {
+			await renderReady();
+			expect(screen.getByTitle('Table of Contents')).toBeInTheDocument();
+		});
+
+		it('opens and closes on the same hotkey File Preview uses', async () => {
+			await renderReady();
+			expect(screen.queryByText('Contents')).not.toBeInTheDocument();
+
+			pressToggle();
+			expect(screen.getByText('Contents')).toBeInTheDocument();
+
+			pressToggle();
+			expect(screen.queryByText('Contents')).not.toBeInTheDocument();
+		});
+
+		it('lists the Rich Mode sections: widgets then narrative', async () => {
+			await renderReady();
+			pressToggle();
+
+			// The entry list sits between the two boundary sashes.
+			const entryList = screen.getByTestId('toc-top-button').nextElementSibling as HTMLElement;
+			const labels = Array.from(entryList.querySelectorAll('button[title]')).map((b) =>
+				b.getAttribute('title')
+			);
+			expect(labels).toEqual([
+				'Activity Timeline',
+				'Success vs Failure',
+				'Source Breakdown',
+				'Agent Activity',
+				'Accomplishments',
+				'Challenges',
+			]);
+		});
+
+		it('lists the narrative headings in Plain Mode', async () => {
+			await renderReady();
+			fireEvent.click(screen.getByRole('button', { name: /^plain$/i }));
+			pressToggle();
+
+			expect(screen.getByTitle('Accomplishments')).toBeInTheDocument();
+			expect(screen.getByTitle('Challenges')).toBeInTheDocument();
+			// The widget cards don't exist in Plain Mode, so they aren't offered.
+			expect(screen.queryByTitle('Activity Timeline')).not.toBeInTheDocument();
+		});
+
+		it('offers Top and Bottom sashes', async () => {
+			await renderReady();
+			pressToggle();
+			expect(screen.getByTestId('toc-top-button')).toBeInTheDocument();
+			expect(screen.getByTestId('toc-bottom-button')).toBeInTheDocument();
+		});
+
+		it('dismisses on Escape and reports the key as consumed', async () => {
+			const ref = React.createRef<{ onEscape?: () => boolean; focus: () => void }>();
+			await renderReady(ref);
+			pressToggle();
+			expect(screen.getByText('Contents')).toBeInTheDocument();
+
+			// The modal delegates Escape to the tab first: true means "I handled it",
+			// which is what keeps Escape from closing Director's Notes outright.
+			expect(ref.current?.onEscape?.()).toBe(true);
+			await waitFor(() => {
+				expect(screen.queryByText('Contents')).not.toBeInTheDocument();
+			});
+		});
+
+		it('leaves Escape to the modal when the panel is closed', async () => {
+			const ref = React.createRef<{ onEscape?: () => boolean; focus: () => void }>();
+			await renderReady(ref);
+			expect(ref.current?.onEscape?.()).toBe(false);
+		});
+
+		it('exposes focus() so the modal can hand keys to the content region', async () => {
+			const ref = React.createRef<{ onEscape?: () => boolean; focus: () => void }>();
+			await renderReady(ref);
+			ref.current?.focus();
+			expect(document.activeElement).toBe(contentRegion());
 		});
 	});
 });

--- a/src/__tests__/renderer/components/DirectorNotes/directorNotesToc.test.ts
+++ b/src/__tests__/renderer/components/DirectorNotes/directorNotesToc.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the Director's Notes table-of-contents entry builders.
+ *
+ * The invariant that matters: the anchors these produce must match the ids
+ * actually rendered on the page, or a TOC click scrolls nowhere.
+ * - Rich Mode entries must match the `id` `SectionCard` receives, which comes
+ *   from the same `richSectionId()` helper.
+ * - Plain Mode entries must match what `rehype-slug` puts on the headings,
+ *   which is why extraction goes through the shared `github-slugger` path.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	buildRichTocEntries,
+	buildPlainTocEntries,
+	richSectionId,
+	RICH_WIDGET_SECTION_TITLES,
+} from '../../../../renderer/components/DirectorNotes/directorNotesToc';
+import type { DirectorNotesNarrative } from '../../../../shared/directorNotesNarrative';
+
+const NARRATIVE: DirectorNotesNarrative = {
+	version: 1,
+	sections: [
+		{ kind: 'accomplishments', title: 'Accomplishments', items: [{ text: 'Shipped' }] },
+		{ kind: 'challenges', title: 'Challenges', items: [] },
+		{ kind: 'nextSteps', title: 'Next Steps', items: [{ text: 'Keep going' }] },
+	],
+};
+
+describe('richSectionId', () => {
+	it('produces a namespaced, slugified anchor', () => {
+		expect(richSectionId('Success vs Failure')).toBe('dn-section-success-vs-failure');
+	});
+
+	it('is stable for the same title', () => {
+		expect(richSectionId('Agent Activity')).toBe(richSectionId('Agent Activity'));
+	});
+
+	it('does not collide across different titles', () => {
+		expect(richSectionId('Accomplishments')).not.toBe(richSectionId('Challenges'));
+	});
+});
+
+describe('buildRichTocEntries', () => {
+	it('lists the widget cards followed by the narrative sections', () => {
+		const entries = buildRichTocEntries(NARRATIVE);
+		expect(entries.map((e) => e.text)).toEqual([
+			...RICH_WIDGET_SECTION_TITLES,
+			'Accomplishments',
+			'Challenges',
+			'Next Steps',
+		]);
+	});
+
+	it('anchors every entry to the id its SectionCard will carry', () => {
+		for (const entry of buildRichTocEntries(NARRATIVE)) {
+			expect(entry.slug).toBe(richSectionId(entry.text));
+		}
+	});
+
+	it('lists only the widget cards when there is no narrative', () => {
+		for (const narrative of [null, undefined]) {
+			const entries = buildRichTocEntries(narrative);
+			expect(entries.map((e) => e.text)).toEqual([...RICH_WIDGET_SECTION_TITLES]);
+		}
+	});
+
+	it('includes an empty narrative section so it can still be jumped to', () => {
+		const entries = buildRichTocEntries(NARRATIVE);
+		expect(entries.map((e) => e.text)).toContain('Challenges');
+	});
+
+	it('gives every entry the same level - the report sections are peers', () => {
+		const levels = new Set(buildRichTocEntries(NARRATIVE).map((e) => e.level));
+		expect(levels.size).toBe(1);
+	});
+});
+
+describe('buildPlainTocEntries', () => {
+	it('extracts the narrative headings from the rendered markdown', () => {
+		const md = '## Accomplishments\n\n- Did a thing\n\n## Challenges\n\n- A blocker\n';
+		expect(buildPlainTocEntries(md)).toEqual([
+			{ level: 2, text: 'Accomplishments', slug: 'accomplishments' },
+			{ level: 2, text: 'Challenges', slug: 'challenges' },
+		]);
+	});
+
+	it('returns nothing for empty content', () => {
+		expect(buildPlainTocEntries('')).toEqual([]);
+	});
+
+	it('ignores headings inside code fences', () => {
+		const md = '## Real\n\n```\n## Not A Heading\n```\n';
+		expect(buildPlainTocEntries(md).map((e) => e.text)).toEqual(['Real']);
+	});
+
+	it('disambiguates duplicate headings the way rehype-slug does', () => {
+		const entries = buildPlainTocEntries('## Notes\n\n## Notes\n');
+		expect(entries.map((e) => e.slug)).toEqual(['notes', 'notes-1']);
+	});
+});

--- a/src/renderer/components/DirectorNotes/AIOverviewTab.tsx
+++ b/src/renderer/components/DirectorNotes/AIOverviewTab.tsx
@@ -1,4 +1,12 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import {
+	useState,
+	useEffect,
+	useCallback,
+	useRef,
+	useMemo,
+	forwardRef,
+	useImperativeHandle,
+} from 'react';
 import {
 	RefreshCw,
 	Save,
@@ -11,12 +19,17 @@ import {
 	AArrowUp,
 	AArrowDown,
 } from 'lucide-react';
+import rehypeSlug from 'rehype-slug';
 import { Spinner } from '../ui/Spinner';
 import type { Theme } from '../../types';
 import { MarkdownRenderer } from '../MarkdownRenderer';
 import { RichOverview } from './RichOverview';
+import type { TabFocusHandle } from './OverviewTab';
 import { NarrativeParseError } from './NarrativeParseError';
 import { SaveMarkdownModal } from '../SaveMarkdownModal';
+import { TocOverlay, computeTocWidth } from '../Toc';
+import { buildRichTocEntries, buildPlainTocEntries } from './directorNotesToc';
+import { useTocOverlay } from '../../hooks/ui/useTocOverlay';
 import { useSettings } from '../../hooks';
 import { generateTerminalProseStyles } from '../../utils/markdownConfig';
 import { safeClipboardWrite } from '../../utils/clipboard';
@@ -80,6 +93,13 @@ function loadViewMode(persistedDefault: ViewMode): ViewMode {
 	return raw === 'rich' || raw === 'plain' ? raw : persistedDefault;
 }
 
+/**
+ * Gives Plain-mode headings the `id`s the table of contents scrolls to. Module
+ * scope so the plugin array is referentially stable across renders (a fresh
+ * array would rebuild the markdown processor on every render).
+ */
+const MARKDOWN_SLUG_PLUGINS = [rehypeSlug];
+
 // Module-level cache so synopsis survives tab switches (unmount/remount)
 let cachedSynopsis: {
 	content: string;
@@ -121,8 +141,11 @@ function fireSynopsisReadyToast() {
 	});
 }
 
-export function AIOverviewTab({ theme, onSynopsisReady }: AIOverviewTabProps) {
-	const { directorNotesSettings, bionifyReadingMode } = useSettings();
+export const AIOverviewTab = forwardRef<TabFocusHandle, AIOverviewTabProps>(function AIOverviewTab(
+	{ theme, onSynopsisReady },
+	ref
+) {
+	const { directorNotesSettings, bionifyReadingMode, shortcuts } = useSettings();
 	const [lookbackDays, setLookbackDays] = useState(directorNotesSettings.defaultLookbackDays);
 	const [synopsis, setSynopsis] = useState<string>(cachedSynopsis?.content ?? '');
 	// Structured narrative and its overt parse-failure detail, both derived from
@@ -153,6 +176,8 @@ export function AIOverviewTab({ theme, onSynopsisReady }: AIOverviewTabProps) {
 		loadViewMode(directorNotesSettings.defaultMode ?? VIEW_MODE_DEFAULT)
 	);
 	const mountedRef = useRef(true);
+	/** Scrollable notes region: the TOC's scroll target and keyboard host. */
+	const contentRef = useRef<HTMLDivElement>(null);
 
 	// Adjust the synopsis font size and persist the new scale.
 	const adjustFontScale = useCallback((direction: -1 | 1) => {
@@ -239,6 +264,55 @@ export function AIOverviewTab({ theme, onSynopsisReady }: AIOverviewTabProps) {
 	const plainContent = useMemo(
 		() => (narrative ? narrativeToMarkdown(narrative) : isStructuredShaped ? '' : synopsis),
 		[narrative, synopsis, isStructuredShaped]
+	);
+
+	// --- Table of contents ---------------------------------------------------
+	// Same control, hotkey, and keyboard behavior as the File Preview's, from
+	// the shared `components/Toc` library. Both reading modes offer the same
+	// jump list; only the anchors differ (rendered heading ids in Plain, section
+	// card ids in Rich).
+	const tocEntries = useMemo(
+		() =>
+			viewMode === 'rich' ? buildRichTocEntries(narrative) : buildPlainTocEntries(plainContent),
+		[viewMode, narrative, plainContent]
+	);
+	const tocWidth = useMemo(() => computeTocWidth(tocEntries), [tocEntries]);
+
+	const toc = useTocOverlay({
+		shortcuts,
+		containerRef: contentRef,
+		enabled: tocEntries.length > 0,
+	});
+
+	const scrollContentToBoundary = useCallback((direction: 'top' | 'bottom') => {
+		const container = contentRef.current;
+		if (!container) return;
+		container.scrollTo({
+			top: direction === 'top' ? 0 : container.scrollHeight,
+			behavior: 'smooth',
+		});
+	}, []);
+
+	// The TOC hotkey reaches the hook via the content region's own keydown, which
+	// is why the modal focuses THIS element (through the handle below) rather
+	// than an ancestor wrapper: a key pressed on an ancestor bubbles up, never
+	// down into here.
+	const handleContentKeyDown = useCallback(
+		(e: React.KeyboardEvent) => {
+			toc.handleKeyDown(e);
+		},
+		[toc]
+	);
+
+	// The modal owns Escape (it's a layer-stack modal) and delegates to the
+	// active tab first, so closing the TOC takes priority over closing the modal.
+	useImperativeHandle(
+		ref,
+		() => ({
+			focus: () => contentRef.current?.focus(),
+			onEscape: () => toc.closeIfOpen(),
+		}),
+		[toc]
 	);
 
 	// Copy the readable synopsis markdown to clipboard
@@ -564,80 +638,106 @@ export function AIOverviewTab({ theme, onSynopsisReady }: AIOverviewTabProps) {
 				</div>
 			)}
 
-			{/* Content - old notes stay visible and scrollable during regeneration */}
-			<div className="flex-1 overflow-y-auto p-6 scrollbar-thin">
-				{/* Font-scale override - applies to both Plain and Rich narratives. */}
-				<style>{proseScaleRule}</style>
-				{/* Error banner - shown above content so old notes remain readable */}
-				{error && (
-					<div
-						className={`p-4 rounded border ${synopsis ? 'mb-4' : ''}`}
-						style={{
-							backgroundColor: theme.colors.error + '10',
-							borderColor: theme.colors.error + '40',
-							color: theme.colors.error,
-						}}
-					>
-						{error}
-					</div>
-				)}
-				{synopsis ? (
-					viewMode === 'rich' ? (
-						<RichOverview
-							theme={theme}
-							stats={stats}
-							synopsis={synopsis}
-							narrative={narrative}
-							narrativeError={narrativeError}
-							narrativeRecovery={narrativeRecovery}
-							lookbackDays={lookbackDays}
-							enableBionifyReadingMode={bionifyReadingMode}
-							chatMath
-						/>
-					) : (
-						// Content-driven AI output: opt back into text selection under
-						// the modal's select-none (see CLAUDE.md modal text rules).
-						<div className="director-notes-content select-text flex flex-col gap-4">
-							<style>{proseStyles}</style>
-							{/* Plain Mode fails as loudly as Rich Mode. Dumping the raw
-							    structured output into the markdown renderer would show a
-							    wall of JSON where a report should be. Shown whenever the
-							    output is JSON-shaped but produced no narrative - including
-							    when no error came back at all, which is how a stale cached
-							    result used to fall through to the raw string. */}
-							{(narrativeError || (!narrative && isStructuredShaped)) && (
-								<NarrativeParseError
-									theme={theme}
-									error={narrativeError ?? STRUCTURED_OUTPUT_UNPARSED_MESSAGE}
-									rawOutput={synopsis}
-									recovery={narrativeRecovery}
-								/>
-							)}
-							{/* Prose from the narrative, or the raw string when the output is
-							    not JSON-shaped - a markdown synopsis from a markdown-contract
-							    prompt, or the "no history files" message. Gated on shape, not
-							    on the error, so raw JSON can never reach the renderer. */}
-							{(narrative || !isStructuredShaped) && (
-								<MarkdownRenderer
-									content={plainContent}
-									theme={theme}
-									onCopy={(text) => safeClipboardWrite(text)}
-									enableBionifyReadingMode={bionifyReadingMode}
-									chatMath
-								/>
-							)}
+			{/* Content region. The wrapper is the TOC's positioning context: the
+			    overlay must pin to the visible panel, so it cannot live inside the
+			    scroller (absolute children of a scroll box scroll with content). */}
+			<div className="flex-1 min-h-0 relative flex flex-col">
+				{/* Old notes stay visible and scrollable during regeneration */}
+				<div
+					ref={contentRef}
+					tabIndex={-1}
+					onKeyDown={handleContentKeyDown}
+					className="flex-1 overflow-y-auto p-6 scrollbar-thin outline-none"
+				>
+					{/* Font-scale override - applies to both Plain and Rich narratives. */}
+					<style>{proseScaleRule}</style>
+					{/* Error banner - shown above content so old notes remain readable */}
+					{error && (
+						<div
+							className={`p-4 rounded border ${synopsis ? 'mb-4' : ''}`}
+							style={{
+								backgroundColor: theme.colors.error + '10',
+								borderColor: theme.colors.error + '40',
+								color: theme.colors.error,
+							}}
+						>
+							{error}
 						</div>
-					)
-				) : isGenerating ? (
-					<div className="flex items-center justify-center h-full">
-						<div className="flex items-center gap-3">
-							<Spinner size={24} color={theme.colors.accent} />
-							<p className="text-sm" style={{ color: theme.colors.textDim }}>
-								Generating…
-							</p>
+					)}
+					{synopsis ? (
+						viewMode === 'rich' ? (
+							<RichOverview
+								theme={theme}
+								stats={stats}
+								synopsis={synopsis}
+								narrative={narrative}
+								narrativeError={narrativeError}
+								narrativeRecovery={narrativeRecovery}
+								lookbackDays={lookbackDays}
+								enableBionifyReadingMode={bionifyReadingMode}
+								chatMath
+							/>
+						) : (
+							// Content-driven AI output: opt back into text selection under
+							// the modal's select-none (see CLAUDE.md modal text rules).
+							<div className="director-notes-content select-text flex flex-col gap-4">
+								<style>{proseStyles}</style>
+								{/* Plain Mode fails as loudly as Rich Mode. Dumping the raw
+								    structured output into the markdown renderer would show a
+								    wall of JSON where a report should be. Shown whenever the
+								    output is JSON-shaped but produced no narrative - including
+								    when no error came back at all, which is how a stale cached
+								    result used to fall through to the raw string. */}
+								{(narrativeError || (!narrative && isStructuredShaped)) && (
+									<NarrativeParseError
+										theme={theme}
+										error={narrativeError ?? STRUCTURED_OUTPUT_UNPARSED_MESSAGE}
+										rawOutput={synopsis}
+										recovery={narrativeRecovery}
+									/>
+								)}
+								{/* Prose from the narrative, or the raw string when the output is
+								    not JSON-shaped - a markdown synopsis from a markdown-contract
+								    prompt, or the "no history files" message. Gated on shape, not
+								    on the error, so raw JSON can never reach the renderer. */}
+								{(narrative || !isStructuredShaped) && (
+									<MarkdownRenderer
+										content={plainContent}
+										theme={theme}
+										onCopy={(text) => safeClipboardWrite(text)}
+										enableBionifyReadingMode={bionifyReadingMode}
+										chatMath
+										// Heading anchors for the table of contents' jump list.
+										extraRehypePlugins={MARKDOWN_SLUG_PLUGINS}
+									/>
+								)}
+							</div>
+						)
+					) : isGenerating ? (
+						<div className="flex items-center justify-center h-full">
+							<div className="flex items-center gap-3">
+								<Spinner size={24} color={theme.colors.accent} />
+								<p className="text-sm" style={{ color: theme.colors.textDim }}>
+									Generating…
+								</p>
+							</div>
 						</div>
-					</div>
-				) : null}
+					) : null}
+				</div>
+
+				{/* Table of Contents - same control, hotkey, and keyboard
+				    behavior as the File Preview's (see components/Toc). */}
+				<TocOverlay
+					theme={theme}
+					entries={tocEntries}
+					width={tocWidth}
+					open={toc.open}
+					onOpenChange={toc.setOpen}
+					onScrollToBoundary={scrollContentToBoundary}
+					containerRef={contentRef}
+					buttonRef={toc.buttonRef}
+					overlayRef={toc.overlayRef}
+				/>
 			</div>
 
 			{/* Save Modal */}
@@ -651,4 +751,4 @@ export function AIOverviewTab({ theme, onSynopsisReady }: AIOverviewTabProps) {
 			)}
 		</div>
 	);
-}
+});

--- a/src/renderer/components/DirectorNotes/DirectorNotesModal.tsx
+++ b/src/renderer/components/DirectorNotes/DirectorNotesModal.tsx
@@ -71,7 +71,7 @@ export function DirectorNotesModal({
 	// Tab content refs for focus management
 	const overviewTabRef = useRef<TabFocusHandle>(null);
 	const historyTabRef = useRef<TabFocusHandle>(null);
-	const aiOverviewContentRef = useRef<HTMLDivElement>(null);
+	const aiOverviewTabRef = useRef<TabFocusHandle>(null);
 
 	// Focus the active tab's content area
 	const focusActiveTab = useCallback(
@@ -81,7 +81,9 @@ export function DirectorNotesModal({
 			requestAnimationFrame(() => {
 				if (target === 'overview') overviewTabRef.current?.focus();
 				else if (target === 'history') historyTabRef.current?.focus();
-				else if (target === 'ai-overview') aiOverviewContentRef.current?.focus();
+				// Focuses the tab's own scroll region, not a wrapper: its table-of-
+				// contents hotkey is handled there, and keys don't travel downward.
+				else if (target === 'ai-overview') aiOverviewTabRef.current?.focus();
 			});
 		},
 		[activeTab]
@@ -106,7 +108,9 @@ export function DirectorNotesModal({
 					? historyTabRef
 					: activeTabRef.current === 'overview'
 						? overviewTabRef
-						: null;
+						: activeTabRef.current === 'ai-overview'
+							? aiOverviewTabRef
+							: null;
 			if (tabRef?.current?.onEscape?.()) return;
 			onCloseRef.current();
 		},
@@ -291,12 +295,12 @@ export function DirectorNotesModal({
 								onLookbackChange={setLookbackHours}
 							/>
 						</div>
-						<div
-							ref={aiOverviewContentRef}
-							tabIndex={0}
-							className={`h-full outline-none ${activeTab === 'ai-overview' ? '' : 'hidden'}`}
-						>
-							<AIOverviewTab theme={theme} onSynopsisReady={handleSynopsisReady} />
+						<div className={`h-full ${activeTab === 'ai-overview' ? '' : 'hidden'}`}>
+							<AIOverviewTab
+								ref={aiOverviewTabRef}
+								theme={theme}
+								onSynopsisReady={handleSynopsisReady}
+							/>
 						</div>
 					</Suspense>
 				</div>

--- a/src/renderer/components/DirectorNotes/NarrativeSections.tsx
+++ b/src/renderer/components/DirectorNotes/NarrativeSections.tsx
@@ -23,6 +23,7 @@ import type {
 	NarrativeSectionKind,
 } from '../../../shared/directorNotesNarrative';
 import { SectionCard } from '../widgets';
+import { richSectionId } from './directorNotesToc';
 
 interface NarrativeSectionsProps {
 	theme: Theme;
@@ -120,6 +121,8 @@ export const NarrativeSections = memo(function NarrativeSections({
 					<SectionCard
 						key={`${section.kind}-${sectionIndex}`}
 						theme={theme}
+						// Anchor for the table of contents' jump list.
+						id={richSectionId(section.title)}
 						title={section.title}
 						icon={Icon}
 						accent={accent}

--- a/src/renderer/components/DirectorNotes/RichOverview.tsx
+++ b/src/renderer/components/DirectorNotes/RichOverview.tsx
@@ -37,6 +37,7 @@ import { COLORBLIND_STATUS_COLORS } from '../../constants/colorblindPalettes';
 import { logger } from '../../utils/logger';
 import { daysToLookbackHours, bucketCountForLookback } from './lookback';
 import { NarrativeSections } from './NarrativeSections';
+import { richSectionId } from './directorNotesToc';
 import { NarrativeParseError } from './NarrativeParseError';
 import {
 	looksLikeStructuredOutput,
@@ -212,7 +213,12 @@ export function RichOverview({
 			)}
 
 			{/* Activity timeline */}
-			<SectionCard theme={theme} title="Activity Timeline" icon={Activity}>
+			<SectionCard
+				theme={theme}
+				id={richSectionId('Activity Timeline')}
+				title="Activity Timeline"
+				icon={Activity}
+			>
 				<ChartErrorBoundary theme={theme} chartName="Activity Timeline">
 					<ActivityTimeline
 						theme={theme}
@@ -226,7 +232,12 @@ export function RichOverview({
 			    (a split bar and a 132px donut), so stacking them wasted a screen of
 			    vertical space. Collapses to one column on a narrow modal. */}
 			<div className="grid gap-4 grid-cols-1 lg:grid-cols-2">
-				<SectionCard theme={theme} title="Success vs Failure" icon={CheckCircle2}>
+				<SectionCard
+					theme={theme}
+					id={richSectionId('Success vs Failure')}
+					title="Success vs Failure"
+					icon={CheckCircle2}
+				>
 					<ChartErrorBoundary theme={theme} chartName="Success vs Failure">
 						<SuccessFailureWidget
 							theme={theme}
@@ -237,7 +248,12 @@ export function RichOverview({
 					</ChartErrorBoundary>
 				</SectionCard>
 
-				<SectionCard theme={theme} title="Source Breakdown" icon={PieChart}>
+				<SectionCard
+					theme={theme}
+					id={richSectionId('Source Breakdown')}
+					title="Source Breakdown"
+					icon={PieChart}
+				>
 					<ChartErrorBoundary theme={theme} chartName="Source Breakdown">
 						<TypeBreakdown theme={theme} slices={slices} />
 					</ChartErrorBoundary>
@@ -245,7 +261,12 @@ export function RichOverview({
 			</div>
 
 			{/* Per-agent activity */}
-			<SectionCard theme={theme} title="Agent Activity" icon={Users}>
+			<SectionCard
+				theme={theme}
+				id={richSectionId('Agent Activity')}
+				title="Agent Activity"
+				icon={Users}
+			>
 				<ChartErrorBoundary theme={theme} chartName="Agent Activity">
 					<AgentActivityBars theme={theme} data={agentBars} />
 				</ChartErrorBoundary>

--- a/src/renderer/components/DirectorNotes/directorNotesToc.ts
+++ b/src/renderer/components/DirectorNotes/directorNotesToc.ts
@@ -1,0 +1,73 @@
+/**
+ * Table-of-contents entries for the Director's Notes AI Overview.
+ *
+ * Both reading modes present the same jump list, so switching Rich <-> Plain
+ * doesn't change what the TOC offers or how it looks. The two modes derive it
+ * differently:
+ *
+ * - Plain renders `narrativeToMarkdown` output, whose sections are `##`
+ *   headings, so entries come straight from the markdown (and `rehype-slug`
+ *   puts the matching ids in the DOM).
+ * - Rich renders widget and narrative `SectionCard`s, which are not headings at
+ *   all, so entries are derived from the cards that are actually on screen and
+ *   the cards carry matching `id`s as scroll anchors.
+ */
+
+import GithubSlugger from 'github-slugger';
+import { extractHeadings, type TocEntry } from '../Toc';
+import type { DirectorNotesNarrative } from '../../../shared/directorNotesNarrative';
+
+/**
+ * Every entry uses the same level, because every section of the report is a
+ * peer. It matches the `##` depth that `narrativeToMarkdown` emits, so the
+ * panel renders identically in Rich and Plain mode.
+ */
+const SECTION_LEVEL = 2;
+
+/** Prefix for Rich Mode anchor ids, namespaced so they can't collide. */
+const RICH_ID_PREFIX = 'dn-section-';
+
+/** Anchor id for a Rich Mode section card. */
+export function richSectionId(title: string): string {
+	return `${RICH_ID_PREFIX}${new GithubSlugger().slug(title)}`;
+}
+
+/**
+ * Titles of the deterministic widget cards, in render order. Kept here rather
+ * than inferred from the DOM so the TOC can be built during render, and so a
+ * renamed card fails loudly at the call site instead of silently dropping out
+ * of the list.
+ */
+export const RICH_WIDGET_SECTION_TITLES = [
+	'Activity Timeline',
+	'Success vs Failure',
+	'Source Breakdown',
+	'Agent Activity',
+] as const;
+
+/**
+ * Build the Rich Mode jump list: the widget cards, then whichever narrative
+ * sections exist. `narrative` is null when the run produced no parseable
+ * narrative, in which case only the widgets are listed.
+ */
+export function buildRichTocEntries(narrative?: DirectorNotesNarrative | null): TocEntry[] {
+	const titles: string[] = [...RICH_WIDGET_SECTION_TITLES];
+	for (const section of narrative?.sections ?? []) {
+		titles.push(section.title);
+	}
+	return titles.map((text) => ({
+		level: SECTION_LEVEL,
+		text,
+		slug: richSectionId(text),
+	}));
+}
+
+/**
+ * Build the Plain Mode jump list from the rendered markdown. Uses the shared
+ * heading extractor, so the slugs match the ids `rehype-slug` puts on the
+ * rendered headings.
+ */
+export function buildPlainTocEntries(markdown: string): TocEntry[] {
+	if (!markdown) return [];
+	return extractHeadings(markdown);
+}

--- a/src/renderer/components/FilePreview/FilePreview.tsx
+++ b/src/renderer/components/FilePreview/FilePreview.tsx
@@ -82,6 +82,7 @@ import { ImageSaveModal } from './ImageSaveModal';
 import { useImageAnnotatorStore } from '../ImageAnnotator/imageAnnotatorStore';
 import { getParentDir, getBasename } from '../../../shared/formatters';
 import { FilePreviewToc } from './FilePreviewToc';
+import { computeTocWidth } from '../Toc';
 import { MarkdownEditor } from './markdownEditor';
 import type { MarkdownEditorHandle } from './markdownEditor';
 import {
@@ -577,23 +578,9 @@ export const FilePreview = React.memo(
 			return extractHeadings(file.content);
 		}, [isMarkdown, file?.content]);
 
-		// Compute dynamic ToC overlay width based on longest heading text
-		const tocWidth = useMemo(() => {
-			if (tocEntries.length === 0) return 200;
-			const MIN_WIDTH = 200;
-			const MAX_WIDTH = 500;
-			const CHAR_WIDTH = 7.5; // approximate px per character at ~0.8rem
-			const BASE_PADDING = 24; // px padding inside buttons
-			const HEADER_EXTRA = 100; // "CONTENTS" header + headings count badge
-
-			let maxNeeded = HEADER_EXTRA;
-			for (const entry of tocEntries) {
-				const indent = (entry.level - 1) * 12 + 8;
-				const textWidth = entry.text.length * CHAR_WIDTH;
-				maxNeeded = Math.max(maxNeeded, indent + textWidth + BASE_PADDING);
-			}
-			return Math.min(Math.max(Math.ceil(maxNeeded), MIN_WIDTH), MAX_WIDTH);
-		}, [tocEntries]);
+		// Dynamic ToC overlay width - shared with Director's Notes so an equally
+		// long heading yields an equally wide panel on both surfaces.
+		const tocWidth = useMemo(() => computeTocWidth(tocEntries), [tocEntries]);
 
 		const scrollMarkdownToBoundary = useCallback((direction: 'top' | 'bottom') => {
 			// Use contentRef which is the actual scrollable container

--- a/src/renderer/components/FilePreview/FilePreviewToc.tsx
+++ b/src/renderer/components/FilePreview/FilePreviewToc.tsx
@@ -1,5 +1,14 @@
-import React, { RefObject, useCallback, useEffect, useRef, useState } from 'react';
-import { List, ChevronUp, ChevronDown } from 'lucide-react';
+/**
+ * FilePreviewToc - File Preview's adapter over the shared `TocOverlay`.
+ *
+ * The panel, its keyboard navigation, and its styling live in
+ * `components/Toc/TocOverlay` so Director's Notes presents the identical
+ * control. All this file adds is File Preview's own gating: the TOC only makes
+ * sense for markdown, and never while the editor is open.
+ */
+
+import React, { RefObject } from 'react';
+import { TocOverlay } from '../Toc';
 import type { TocEntry } from './types';
 
 interface FilePreviewTocProps {
@@ -37,194 +46,22 @@ export const FilePreviewToc = React.memo(function FilePreviewToc({
 	markdownEditMode,
 	onSelectHeading,
 }: FilePreviewTocProps) {
-	const headingButtonRefs = useRef<Array<HTMLButtonElement | null>>([]);
-	const [activeIndex, setActiveIndex] = useState(0);
-	const prevShowRef = useRef(false);
-
-	// Focus the first heading whenever the overlay opens - supports keyboard-only nav.
-	useEffect(() => {
-		if (showTocOverlay && !prevShowRef.current && tocEntries.length > 0) {
-			setActiveIndex(0);
-			requestAnimationFrame(() => {
-				headingButtonRefs.current[0]?.focus();
-			});
-		}
-		prevShowRef.current = showTocOverlay;
-	}, [showTocOverlay, tocEntries.length]);
-
-	const scrollToHeading = useCallback(
-		(entry: TocEntry, behavior: ScrollBehavior) => {
-			if (onSelectHeading?.(entry.slug)) {
-				return;
-			}
-			const targetElement = markdownContainerRef.current?.querySelector(
-				`#${CSS.escape(entry.slug)}`
-			);
-			if (targetElement) {
-				targetElement.scrollIntoView({ behavior, block: 'start' });
-			}
-		},
-		[markdownContainerRef, onSelectHeading]
-	);
-
-	const handleEntriesKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-		if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp' && e.key !== 'Home' && e.key !== 'End') {
-			return;
-		}
-		// Stop propagation so the FilePreview container's arrow-scroll handler
-		// doesn't also fire and scroll the markdown by 40px on each press.
-		e.preventDefault();
-		e.stopPropagation();
-		const last = tocEntries.length - 1;
-		let next = activeIndex;
-		if (e.key === 'ArrowDown') next = Math.min(activeIndex + 1, last);
-		else if (e.key === 'ArrowUp') next = Math.max(activeIndex - 1, 0);
-		else if (e.key === 'Home') next = 0;
-		else if (e.key === 'End') next = last;
-		if (next === activeIndex) return;
-		setActiveIndex(next);
-		headingButtonRefs.current[next]?.focus();
-		// Instant scroll on keyboard nav so rapid arrow presses stay responsive.
-		scrollToHeading(tocEntries[next], 'auto');
-	};
-
-	if (!isMarkdown || markdownEditMode || tocEntries.length === 0) {
+	if (!isMarkdown || markdownEditMode) {
 		return null;
 	}
 
 	return (
-		<>
-			{/* Floating TOC Button */}
-			<button
-				ref={tocButtonRef}
-				onClick={() => setShowTocOverlay(!showTocOverlay)}
-				className="absolute bottom-4 right-4 p-2.5 rounded-full shadow-lg transition-all duration-200 hover:scale-105 z-10"
-				style={{
-					backgroundColor: showTocOverlay ? theme.colors.accent : theme.colors.bgSidebar,
-					color: showTocOverlay ? theme.colors.accentForeground : theme.colors.textMain,
-					border: `1px solid ${theme.colors.border}`,
-				}}
-				title="Table of Contents"
-			>
-				<List className="w-5 h-5" />
-			</button>
-
-			{/* TOC Overlay - click outside handled by useClickOutside hook */}
-			{showTocOverlay && (
-				<div
-					ref={tocOverlayRef}
-					className="absolute bottom-16 right-4 rounded-lg shadow-xl overflow-hidden z-20 animate-in fade-in slide-in-from-bottom-2 duration-200 flex flex-col"
-					style={{
-						backgroundColor: theme.colors.bgSidebar,
-						border: `1px solid ${theme.colors.border}`,
-						maxHeight: 'calc(70vh - 80px)',
-						width: `${tocWidth}px`,
-					}}
-					onWheel={(e) => e.stopPropagation()}
-				>
-					{/* TOC Header */}
-					<div
-						className="px-3 py-2 border-b flex items-center justify-between flex-shrink-0"
-						style={{ borderColor: theme.colors.border }}
-					>
-						<span
-							className="text-xs font-medium uppercase tracking-wide"
-							style={{ color: theme.colors.textDim }}
-						>
-							Contents
-						</span>
-						<span className="text-[10px]" style={{ color: theme.colors.textDim }}>
-							{tocEntries.length} headings
-						</span>
-					</div>
-					{/* Top Navigation Sash */}
-					<button
-						data-testid="toc-top-button"
-						onClick={() => {
-							scrollMarkdownToBoundary('top');
-						}}
-						className="w-full px-3 py-2 text-left text-xs border-b transition-colors flex items-center gap-2 hover:brightness-110 flex-shrink-0"
-						style={{
-							backgroundColor: `${theme.colors.accent}15`,
-							borderColor: theme.colors.border,
-							color: theme.colors.textMain,
-						}}
-						title="Jump to top"
-					>
-						<ChevronUp className="w-3 h-3" style={{ color: theme.colors.accent }} />
-						<span>Top</span>
-					</button>
-
-					{/* TOC Entries - scrollable middle section */}
-					<div
-						className="overflow-y-auto px-1 py-1 flex-1 min-h-0"
-						style={{ overscrollBehavior: 'contain' }}
-						onWheel={(e) => e.stopPropagation()}
-						onKeyDown={handleEntriesKeyDown}
-					>
-						{tocEntries.map((entry, index) => {
-							// Get color based on heading level (match the prose styles)
-							const levelColors: Record<number, string> = {
-								1: theme.colors.accent,
-								2: theme.colors.success,
-								3: theme.colors.warning,
-								4: theme.colors.textMain,
-								5: theme.colors.textMain,
-								6: theme.colors.textDim,
-							};
-							const headingColor = levelColors[entry.level] || theme.colors.textMain;
-
-							const isActive = index === activeIndex;
-							return (
-								<button
-									key={`${entry.slug}-${index}`}
-									ref={(el) => {
-										headingButtonRefs.current[index] = el;
-									}}
-									onClick={() => {
-										setActiveIndex(index);
-										// Click is deliberate - keep smooth scroll for visual continuity.
-										scrollToHeading(entry, 'smooth');
-										// ToC stays open so user can click multiple items
-										// Dismiss with click outside or Escape key
-									}}
-									className="w-full px-2 py-1.5 text-left text-sm rounded hover:bg-white/10 transition-colors flex items-center gap-1 focus:outline-none"
-									style={{
-										color: headingColor,
-										paddingLeft: `${(entry.level - 1) * 12 + 8}px`,
-										opacity: entry.level > 3 ? 0.85 : 1,
-										fontSize:
-											entry.level === 1 ? '0.875rem' : entry.level === 2 ? '0.8125rem' : '0.75rem',
-										backgroundColor: isActive ? `${theme.colors.accent}25` : undefined,
-										boxShadow: isActive ? `inset 2px 0 0 ${theme.colors.accent}` : undefined,
-									}}
-									title={entry.text}
-								>
-									<span>{entry.text}</span>
-								</button>
-							);
-						})}
-					</div>
-
-					{/* Bottom Navigation Sash */}
-					<button
-						data-testid="toc-bottom-button"
-						onClick={() => {
-							scrollMarkdownToBoundary('bottom');
-						}}
-						className="w-full px-3 py-2 text-left text-xs border-t transition-colors flex items-center gap-2 hover:brightness-110 flex-shrink-0"
-						style={{
-							backgroundColor: `${theme.colors.accent}15`,
-							borderColor: theme.colors.border,
-							color: theme.colors.textMain,
-						}}
-						title="Jump to bottom"
-					>
-						<ChevronDown className="w-3 h-3" style={{ color: theme.colors.accent }} />
-						<span>Bottom</span>
-					</button>
-				</div>
-			)}
-		</>
+		<TocOverlay
+			theme={theme}
+			entries={tocEntries}
+			width={tocWidth}
+			open={showTocOverlay}
+			onOpenChange={setShowTocOverlay}
+			onScrollToBoundary={scrollMarkdownToBoundary}
+			containerRef={markdownContainerRef}
+			buttonRef={tocButtonRef}
+			overlayRef={tocOverlayRef}
+			onSelectEntry={onSelectHeading ? (entry) => onSelectHeading(entry.slug) : undefined}
+		/>
 	);
 });

--- a/src/renderer/components/FilePreview/filePreviewUtils.ts
+++ b/src/renderer/components/FilePreview/filePreviewUtils.ts
@@ -1,5 +1,3 @@
-import GithubSlugger from 'github-slugger';
-import type { TocEntry } from './types';
 import { formatSize } from '../../../shared/formatters';
 
 // ─── Image Cache ──────────────────────────────────────────────────────────────
@@ -357,31 +355,12 @@ export const countMarkdownTasks = (content: string): { open: number; closed: num
 	return { open, closed };
 };
 
-/** Extract headings from markdown content for table of contents */
-export const extractHeadings = (content: string): TocEntry[] => {
-	const headings: TocEntry[] = [];
-	const lines = content.split('\n');
-	let inCodeFence = false;
-	const slugger = new GithubSlugger();
-
-	for (const line of lines) {
-		if (/^ {0,3}(`{3,}|~{3,})/.test(line)) {
-			inCodeFence = !inCodeFence;
-			continue;
-		}
-		if (inCodeFence) continue;
-
-		const match = line.match(/^(#{1,6})\s+(.+)$/);
-		if (match) {
-			const level = match[1].length;
-			const text = match[2].trim();
-			const slug = slugger.slug(text);
-			headings.push({ level, text, slug });
-		}
-	}
-
-	return headings;
-};
+/**
+ * Re-exported from the shared TOC library, which owns heading extraction now
+ * that Director's Notes builds a jump list too. Kept here so existing File
+ * Preview imports keep resolving.
+ */
+export { extractHeadings } from '../Toc';
 
 /**
  * Normalize a POSIX-style path by resolving `.` and `..` segments.

--- a/src/renderer/components/FilePreview/types.ts
+++ b/src/renderer/components/FilePreview/types.ts
@@ -112,8 +112,9 @@ export interface FilePreviewHandle {
 	focus: () => void;
 }
 
-export interface TocEntry {
-	level: number; // 1-6 for h1-h6
-	text: string;
-	slug: string;
-}
+/**
+ * Re-exported from the shared TOC library so existing File Preview imports keep
+ * working. The canonical definition lives in `components/Toc/types` because
+ * Director's Notes builds entries of the same shape.
+ */
+export type { TocEntry } from '../Toc/types';

--- a/src/renderer/components/MarkdownRenderer.tsx
+++ b/src/renderer/components/MarkdownRenderer.tsx
@@ -8,6 +8,7 @@
  */
 
 import { memo } from 'react';
+import type { PluggableList } from 'unified';
 import type { Theme } from '../types';
 import type { FileNode } from '../types/fileTree';
 import { Markdown } from './Markdown/Markdown';
@@ -58,6 +59,12 @@ interface MarkdownRendererProps {
 	 * as a centered block formula (#622).
 	 */
 	chatMath?: boolean;
+	/**
+	 * Extra rehype plugins appended after the standard stack. Used to add
+	 * `rehype-slug` on surfaces that need heading anchors for a table of
+	 * contents (Director's Notes Plain mode).
+	 */
+	extraRehypePlugins?: PluggableList;
 }
 
 /**

--- a/src/renderer/components/Toc/TocOverlay.tsx
+++ b/src/renderer/components/Toc/TocOverlay.tsx
@@ -1,0 +1,257 @@
+/**
+ * TocOverlay
+ *
+ * The floating table-of-contents control: a round button pinned bottom-right
+ * and the panel it opens (Top sash, scrollable entries, Bottom sash).
+ *
+ * This is the SINGLE implementation of the TOC's look and feel. It was lifted
+ * out of `FilePreviewToc` when Director's Notes needed the same control, so the
+ * muscle memory built in File Preview carries over exactly: first entry focused
+ * on open, Arrow/Home/End move focus and scroll instantly, clicking an entry
+ * scrolls smoothly and leaves the panel open, and the panel is dismissed by
+ * Escape or a click outside (both owned by `useTocOverlay`).
+ *
+ * Presentational only: it does not own the open state, the hotkey, or the
+ * dismiss wiring. Pair it with `useTocOverlay` so every surface gets identical
+ * behavior rather than a re-implementation that drifts.
+ */
+
+import React, { RefObject, useCallback, useEffect, useRef, useState } from 'react';
+import { List, ChevronUp, ChevronDown } from 'lucide-react';
+import type { Theme } from '../../types';
+import type { TocEntry } from './types';
+
+interface TocOverlayProps {
+	theme: Theme;
+	/** Entries to list. The overlay renders nothing when this is empty. */
+	entries: TocEntry[];
+	/** Overlay width in px - use `computeTocWidth(entries)`. */
+	width: number;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	/** Jump the scroll container to its top or bottom (the two sashes). */
+	onScrollToBoundary: (direction: 'top' | 'bottom') => void;
+	/**
+	 * Scroll container searched for `#slug` when `onSelectEntry` is absent or
+	 * declines. Optional so a surface can rely solely on `onSelectEntry`.
+	 */
+	containerRef?: RefObject<HTMLElement | null>;
+	/** Ref for the toggle button - `useTocOverlay` needs it for click-outside. */
+	buttonRef: RefObject<HTMLButtonElement>;
+	/** Ref for the panel - `useTocOverlay` needs it for click-outside. */
+	overlayRef: RefObject<HTMLDivElement>;
+	/**
+	 * Custom scroll handler. Return true when handled; false falls back to
+	 * `containerRef.querySelector('#slug')`. Used where the target isn't a
+	 * plain heading in the DOM (the virtualized Fast tier, Rich Mode's cards).
+	 */
+	onSelectEntry?: (entry: TocEntry) => boolean;
+	/** Accessible label / tooltip for the toggle button. */
+	buttonTitle?: string;
+}
+
+export const TocOverlay = React.memo(function TocOverlay({
+	theme,
+	entries,
+	width,
+	open,
+	onOpenChange,
+	onScrollToBoundary,
+	containerRef,
+	buttonRef,
+	overlayRef,
+	onSelectEntry,
+	buttonTitle = 'Table of Contents',
+}: TocOverlayProps) {
+	const entryButtonRefs = useRef<Array<HTMLButtonElement | null>>([]);
+	const [activeIndex, setActiveIndex] = useState(0);
+	const prevOpenRef = useRef(false);
+
+	// Focus the first entry whenever the overlay opens - supports keyboard-only nav.
+	useEffect(() => {
+		if (open && !prevOpenRef.current && entries.length > 0) {
+			setActiveIndex(0);
+			requestAnimationFrame(() => {
+				entryButtonRefs.current[0]?.focus();
+			});
+		}
+		prevOpenRef.current = open;
+	}, [open, entries.length]);
+
+	const scrollToEntry = useCallback(
+		(entry: TocEntry, behavior: ScrollBehavior) => {
+			if (onSelectEntry?.(entry)) {
+				return;
+			}
+			const targetElement = containerRef?.current?.querySelector(`#${CSS.escape(entry.slug)}`);
+			if (targetElement) {
+				targetElement.scrollIntoView({ behavior, block: 'start' });
+			}
+		},
+		[containerRef, onSelectEntry]
+	);
+
+	const handleEntriesKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+		if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp' && e.key !== 'Home' && e.key !== 'End') {
+			return;
+		}
+		// Stop propagation so the host container's arrow-scroll handler doesn't
+		// also fire and nudge the content on each press.
+		e.preventDefault();
+		e.stopPropagation();
+		const last = entries.length - 1;
+		let next = activeIndex;
+		if (e.key === 'ArrowDown') next = Math.min(activeIndex + 1, last);
+		else if (e.key === 'ArrowUp') next = Math.max(activeIndex - 1, 0);
+		else if (e.key === 'Home') next = 0;
+		else if (e.key === 'End') next = last;
+		if (next === activeIndex) return;
+		setActiveIndex(next);
+		entryButtonRefs.current[next]?.focus();
+		// Instant scroll on keyboard nav so rapid arrow presses stay responsive.
+		scrollToEntry(entries[next], 'auto');
+	};
+
+	if (entries.length === 0) {
+		return null;
+	}
+
+	return (
+		<>
+			{/* Floating TOC Button */}
+			<button
+				ref={buttonRef}
+				onClick={() => onOpenChange(!open)}
+				className="absolute bottom-4 right-4 p-2.5 rounded-full shadow-lg transition-all duration-200 hover:scale-105 z-10"
+				style={{
+					backgroundColor: open ? theme.colors.accent : theme.colors.bgSidebar,
+					color: open ? theme.colors.accentForeground : theme.colors.textMain,
+					border: `1px solid ${theme.colors.border}`,
+				}}
+				title={buttonTitle}
+			>
+				<List className="w-5 h-5" />
+			</button>
+
+			{/* TOC Overlay - click outside and Escape handled by useTocOverlay */}
+			{open && (
+				<div
+					ref={overlayRef}
+					className="absolute bottom-16 right-4 rounded-lg shadow-xl overflow-hidden z-20 animate-in fade-in slide-in-from-bottom-2 duration-200 flex flex-col"
+					style={{
+						backgroundColor: theme.colors.bgSidebar,
+						border: `1px solid ${theme.colors.border}`,
+						maxHeight: 'calc(70vh - 80px)',
+						width: `${width}px`,
+					}}
+					onWheel={(e) => e.stopPropagation()}
+				>
+					{/* TOC Header */}
+					<div
+						className="px-3 py-2 border-b flex items-center justify-between flex-shrink-0"
+						style={{ borderColor: theme.colors.border }}
+					>
+						<span
+							className="text-xs font-medium uppercase tracking-wide"
+							style={{ color: theme.colors.textDim }}
+						>
+							Contents
+						</span>
+						<span className="text-[10px]" style={{ color: theme.colors.textDim }}>
+							{entries.length} headings
+						</span>
+					</div>
+
+					{/* Top Navigation Sash */}
+					<button
+						data-testid="toc-top-button"
+						onClick={() => {
+							onScrollToBoundary('top');
+						}}
+						className="w-full px-3 py-2 text-left text-xs border-b transition-colors flex items-center gap-2 hover:brightness-110 flex-shrink-0"
+						style={{
+							backgroundColor: `${theme.colors.accent}15`,
+							borderColor: theme.colors.border,
+							color: theme.colors.textMain,
+						}}
+						title="Jump to top"
+					>
+						<ChevronUp className="w-3 h-3" style={{ color: theme.colors.accent }} />
+						<span>Top</span>
+					</button>
+
+					{/* TOC Entries - scrollable middle section */}
+					<div
+						className="overflow-y-auto px-1 py-1 flex-1 min-h-0"
+						style={{ overscrollBehavior: 'contain' }}
+						onWheel={(e) => e.stopPropagation()}
+						onKeyDown={handleEntriesKeyDown}
+					>
+						{entries.map((entry, index) => {
+							// Color by level (matches the prose styles).
+							const levelColors: Record<number, string> = {
+								1: theme.colors.accent,
+								2: theme.colors.success,
+								3: theme.colors.warning,
+								4: theme.colors.textMain,
+								5: theme.colors.textMain,
+								6: theme.colors.textDim,
+							};
+							const entryColor = levelColors[entry.level] || theme.colors.textMain;
+
+							const isActive = index === activeIndex;
+							return (
+								<button
+									key={`${entry.slug}-${index}`}
+									ref={(el) => {
+										entryButtonRefs.current[index] = el;
+									}}
+									onClick={() => {
+										setActiveIndex(index);
+										// Click is deliberate - keep smooth scroll for visual continuity.
+										scrollToEntry(entry, 'smooth');
+										// Panel stays open so the user can click several entries.
+										// Dismiss with a click outside or Escape.
+									}}
+									className="w-full px-2 py-1.5 text-left text-sm rounded hover:bg-white/10 transition-colors flex items-center gap-1 focus:outline-none"
+									style={{
+										color: entryColor,
+										paddingLeft: `${(entry.level - 1) * 12 + 8}px`,
+										opacity: entry.level > 3 ? 0.85 : 1,
+										fontSize:
+											entry.level === 1 ? '0.875rem' : entry.level === 2 ? '0.8125rem' : '0.75rem',
+										backgroundColor: isActive ? `${theme.colors.accent}25` : undefined,
+										boxShadow: isActive ? `inset 2px 0 0 ${theme.colors.accent}` : undefined,
+									}}
+									title={entry.text}
+								>
+									<span>{entry.text}</span>
+								</button>
+							);
+						})}
+					</div>
+
+					{/* Bottom Navigation Sash */}
+					<button
+						data-testid="toc-bottom-button"
+						onClick={() => {
+							onScrollToBoundary('bottom');
+						}}
+						className="w-full px-3 py-2 text-left text-xs border-t transition-colors flex items-center gap-2 hover:brightness-110 flex-shrink-0"
+						style={{
+							backgroundColor: `${theme.colors.accent}15`,
+							borderColor: theme.colors.border,
+							color: theme.colors.textMain,
+						}}
+						title="Jump to bottom"
+					>
+						<ChevronDown className="w-3 h-3" style={{ color: theme.colors.accent }} />
+						<span>Bottom</span>
+					</button>
+				</div>
+			)}
+		</>
+	);
+});
+
+export default TocOverlay;

--- a/src/renderer/components/Toc/extractHeadings.ts
+++ b/src/renderer/components/Toc/extractHeadings.ts
@@ -1,0 +1,37 @@
+/**
+ * Markdown heading extraction for the table of contents.
+ *
+ * Lives in the shared TOC library because every surface that renders markdown
+ * and offers a jump list needs the same entries: File Preview and Director's
+ * Notes today. Slugs come from `github-slugger`, the same slugger `rehype-slug`
+ * uses, so these slugs match the `id`s on the rendered headings.
+ */
+
+import GithubSlugger from 'github-slugger';
+import type { TocEntry } from './types';
+
+/** Extract headings from markdown content for a table of contents. */
+export const extractHeadings = (content: string): TocEntry[] => {
+	const headings: TocEntry[] = [];
+	const lines = content.split('\n');
+	let inCodeFence = false;
+	const slugger = new GithubSlugger();
+
+	for (const line of lines) {
+		if (/^ {0,3}(`{3,}|~{3,})/.test(line)) {
+			inCodeFence = !inCodeFence;
+			continue;
+		}
+		if (inCodeFence) continue;
+
+		const match = line.match(/^(#{1,6})\s+(.+)$/);
+		if (match) {
+			const level = match[1].length;
+			const text = match[2].trim();
+			const slug = slugger.slug(text);
+			headings.push({ level, text, slug });
+		}
+	}
+
+	return headings;
+};

--- a/src/renderer/components/Toc/index.ts
+++ b/src/renderer/components/Toc/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared table-of-contents control.
+ *
+ * `TocOverlay` renders the floating button + panel; `useTocOverlay`
+ * (`hooks/ui/useTocOverlay`) owns the hotkey, Escape, and click-outside
+ * behavior. Use both together so every surface behaves identically.
+ */
+
+export { TocOverlay } from './TocOverlay';
+export { computeTocWidth } from './tocWidth';
+export { extractHeadings } from './extractHeadings';
+export type { TocEntry } from './types';

--- a/src/renderer/components/Toc/tocWidth.ts
+++ b/src/renderer/components/Toc/tocWidth.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared sizing for the table-of-contents overlay.
+ *
+ * Every TOC surface (File Preview, Director's Notes) measures its width the
+ * same way, so a heading of a given length produces an identically sized
+ * overlay wherever it appears. This lived inline in `FilePreview` before
+ * Director's Notes needed it too.
+ */
+
+import type { TocEntry } from './types';
+
+const MIN_WIDTH = 200;
+const MAX_WIDTH = 500;
+/** Approximate px per character at ~0.8rem. */
+const CHAR_WIDTH = 7.5;
+/** Padding inside the entry buttons. */
+const BASE_PADDING = 24;
+/** Room for the "CONTENTS" header plus the headings-count badge. */
+const HEADER_EXTRA = 100;
+
+/**
+ * Width in px for the overlay: wide enough for the longest indented entry,
+ * clamped so a single long heading can't take over the panel.
+ */
+export function computeTocWidth(entries: TocEntry[]): number {
+	if (entries.length === 0) return MIN_WIDTH;
+
+	let maxNeeded = HEADER_EXTRA;
+	for (const entry of entries) {
+		const indent = (entry.level - 1) * 12 + 8;
+		const textWidth = entry.text.length * CHAR_WIDTH;
+		maxNeeded = Math.max(maxNeeded, indent + textWidth + BASE_PADDING);
+	}
+	return Math.min(Math.max(Math.ceil(maxNeeded), MIN_WIDTH), MAX_WIDTH);
+}

--- a/src/renderer/components/Toc/types.ts
+++ b/src/renderer/components/Toc/types.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared table-of-contents types.
+ *
+ * `TocEntry` is the one shape every TOC surface speaks. File Preview derives
+ * entries from markdown headings; Director's Notes derives them from its
+ * rendered sections. Both feed the same overlay.
+ */
+
+export interface TocEntry {
+	/** Heading depth, 1-6. Drives indentation and color in the overlay. */
+	level: number;
+	/** Visible label. */
+	text: string;
+	/** DOM id of the scroll target. */
+	slug: string;
+}

--- a/src/renderer/components/widgets/output/SectionCard.tsx
+++ b/src/renderer/components/widgets/output/SectionCard.tsx
@@ -15,6 +15,11 @@ import type { WidgetProps } from '../types';
 interface SectionCardProps extends WidgetProps {
 	/** Card title shown in the header row. */
 	title: string;
+	/**
+	 * Optional DOM id on the card element. Used as a scroll anchor so a table
+	 * of contents can jump to this section.
+	 */
+	id?: string;
 	/** Optional lucide icon rendered before the title. */
 	icon?: LucideIcon;
 	/** Optional accent color for the icon. Defaults to the theme accent. */
@@ -30,6 +35,7 @@ interface SectionCardProps extends WidgetProps {
 export const SectionCard = memo(function SectionCard({
 	theme,
 	title,
+	id,
 	icon: Icon,
 	accent,
 	action,
@@ -39,6 +45,7 @@ export const SectionCard = memo(function SectionCard({
 	const accentColor = accent ?? theme.colors.accent;
 	return (
 		<section
+			id={id}
 			className={`rounded-lg border overflow-hidden ${className ?? ''}`}
 			style={{ backgroundColor: theme.colors.bgMain, borderColor: theme.colors.border }}
 		>

--- a/src/renderer/hooks/ui/useTocOverlay.ts
+++ b/src/renderer/hooks/ui/useTocOverlay.ts
@@ -1,0 +1,136 @@
+/**
+ * useTocOverlay - open/close plumbing for the shared `TocOverlay`.
+ *
+ * Owns the parts of the TOC's muscle memory that are NOT visual: the toggle
+ * hotkey, Escape-to-dismiss, click-outside-to-dismiss, and returning focus to
+ * the host container on close (without which the next hotkey press is swallowed
+ * by the entry button that just unmounted).
+ *
+ * Extracted from `FilePreview`, which had all of this open-coded, so Director's
+ * Notes gets identical behavior instead of a second copy that drifts. Pair with
+ * `<TocOverlay>`, which owns the panel itself and its arrow-key navigation.
+ *
+ * The host is still responsible for two things the hook cannot see:
+ * - calling `handleKeyDown` from its own keydown handler, and
+ * - ordering Escape against its other dismissible UI (a surface with a search
+ *   box open may want that closed first). `closeIfOpen()` exists for that: call
+ *   it from an Escape chain and it reports whether it consumed the key.
+ */
+
+import { useCallback, useRef, useState, type RefObject } from 'react';
+import { useClickOutside } from './useClickOutside';
+import { useKeyboardShortcutHelpers } from '../keyboard/useKeyboardShortcutHelpers';
+import type { Shortcut } from '../../types';
+
+const NO_TAB_SHORTCUTS: Record<string, Shortcut> = {};
+
+interface UseTocOverlayOptions {
+	/**
+	 * User-configured shortcuts (from `useSettings`). Matching goes through the
+	 * canonical `useKeyboardShortcutHelpers` matcher so a remapped binding is
+	 * honored on every TOC surface, not just the one that read the setting.
+	 */
+	shortcuts: Record<string, Shortcut>;
+	/**
+	 * Focused when the overlay closes, so subsequent shortcuts keep firing.
+	 * Usually the scrollable content container.
+	 */
+	containerRef?: RefObject<HTMLElement | null>;
+	/**
+	 * Shortcut that toggles the overlay. Defaults to the File Preview binding
+	 * so every surface answers to the same keys unless told otherwise.
+	 */
+	shortcutId?: string;
+	/**
+	 * Gate for the hotkey: when false, the key is ignored and left to the host
+	 * (e.g. no entries to show, or the surface is in edit mode).
+	 */
+	enabled?: boolean;
+	/** Notified when the hotkey fires, for shortcut-usage telemetry. */
+	onShortcutUsed?: (id: string) => void;
+}
+
+export function useTocOverlay({
+	shortcuts,
+	containerRef,
+	shortcutId = 'toggleFilePreviewToc',
+	enabled = true,
+	onShortcutUsed,
+}: UseTocOverlayOptions) {
+	const { isShortcut } = useKeyboardShortcutHelpers({
+		shortcuts,
+		tabShortcuts: NO_TAB_SHORTCUTS,
+	});
+	const [open, setOpen] = useState(false);
+	const buttonRef = useRef<HTMLButtonElement>(null);
+	const overlayRef = useRef<HTMLDivElement>(null);
+
+	const close = useCallback(() => {
+		setOpen(false);
+		containerRef?.current?.focus();
+	}, [containerRef]);
+
+	// Dismiss on a click outside the panel AND the toggle button. The delay
+	// keeps the click that opened it from immediately closing it again.
+	const closeOnClickOutside = useCallback(() => setOpen(false), []);
+	useClickOutside<HTMLElement>([overlayRef, buttonRef], closeOnClickOutside, open, {
+		delay: true,
+	});
+
+	const toggle = useCallback(() => {
+		setOpen((v) => {
+			// Restore focus to the host when closing - the focused entry button is
+			// about to unmount and would otherwise take the keyboard with it.
+			if (v) containerRef?.current?.focus();
+			return !v;
+		});
+	}, [containerRef]);
+
+	/**
+	 * Close the overlay if it's open. Returns true when it consumed the event,
+	 * so hosts can chain it into an Escape handler that has other UI to dismiss.
+	 */
+	const closeIfOpen = useCallback(() => {
+		if (!open) return false;
+		close();
+		return true;
+	}, [open, close]);
+
+	/**
+	 * Handles Escape and the toggle hotkey. Returns true when the event was
+	 * consumed (already prevented and stopped), so the host can return early.
+	 */
+	const handleKeyDown = useCallback(
+		(e: React.KeyboardEvent | KeyboardEvent): boolean => {
+			if (e.key === 'Escape') {
+				if (!open) return false;
+				e.preventDefault();
+				e.stopPropagation();
+				close();
+				return true;
+			}
+			// The canonical matcher reads only fields React's synthetic event also
+			// carries, so a React.KeyboardEvent is safe to hand it.
+			if (enabled && isShortcut(e as unknown as KeyboardEvent, shortcutId)) {
+				e.preventDefault();
+				e.stopPropagation();
+				toggle();
+				onShortcutUsed?.(shortcutId);
+				return true;
+			}
+			return false;
+		},
+		[open, close, toggle, enabled, shortcutId, onShortcutUsed, isShortcut]
+	);
+
+	return {
+		open,
+		setOpen,
+		close,
+		closeIfOpen,
+		toggle,
+		handleKeyDown,
+		buttonRef,
+		overlayRef,
+	};
+}


### PR DESCRIPTION
The AI Overview is long enough to want a jump list, and one already exists in the Markdown file preview. Rather than write a second one, this extracts the existing control into a shared library and reuses it, so the muscle memory carries over exactly.

## What you get

The same round button at the bottom right of Director's Notes, in **both** Rich and Plain mode, with identical behavior to File Preview:

- Toggle with the same hotkey (`Cmd`/`Ctrl` + `\`) or by clicking the button
- First entry focused on open, so arrows work immediately; `Up`/`Down`/`Home`/`End` navigate and scroll as they go
- Click an entry to scroll to it; the panel stays open for repeat jumps
- **Top** / **Bottom** sashes
- `Esc` or a click outside dismisses it, and `Esc` does **not** close Director's Notes when the panel is open

Rich mode lists the widget cards (Activity Timeline, Success vs Failure, Source Breakdown, Agent Activity) followed by the narrative sections. Plain mode lists the narrative headings.

## How the reuse works

Rather than copy `FilePreviewToc`, its parts moved into a shared library:

| Piece | Location | Responsibility |
| --- | --- | --- |
| `<TocOverlay>` | `components/Toc/TocOverlay.tsx` | Button, panel, entry rendering, Arrow/Home/End nav, focus-first-on-open |
| `useTocOverlay()` | `hooks/ui/useTocOverlay.ts` | Open state, toggle hotkey, Escape, click-outside, focus restore |
| `computeTocWidth()` | `components/Toc/tocWidth.ts` | Panel sizing (was inline in `FilePreview`) |
| `extractHeadings()` | `components/Toc/extractHeadings.ts` | Markdown headings to entries (was in `filePreviewUtils`) |

`FilePreviewToc` is now a thin adapter that adds only File Preview's own gating (markdown, not in edit mode). Its behavior is unchanged and its existing tests pass untouched.

The hook matches the hotkey through the canonical `useKeyboardShortcutHelpers`, so a **remapped binding is honored on both surfaces** rather than only the one that happened to read the setting.

## Two non-obvious bits

**The panel can't live inside the scroller.** An absolutely positioned child of an `overflow-y-auto` box scrolls with its content, so the content region moved inside a positioned wrapper and the overlay pins to that.

**The keydown has to reach the hook.** Keys bubble up, never down. The AI Overview tab was focused via a wrapper *outside* the component, so a handler on the inner content region would never have fired. `AIOverviewTab` now forwards a `TabFocusHandle` (the contract the History and Overview tabs already use); the modal focuses the tab's own scroll region and delegates `Escape` to it, which is also what makes `Escape` close the panel instead of the modal.

Anchors: `SectionCard` gained an optional `id` so each Rich card is a scroll target, and Plain mode adds `rehype-slug` so its rendered headings carry ids matching the extracted slugs.

## Testing

- `directorNotesToc.test.ts` (12): anchors match what the cards and headings actually render, code fences ignored, duplicate headings disambiguated the way `rehype-slug` does, widgets-only when there's no narrative.
- `AIOverviewTab.test.tsx` (+9): hotkey toggles open and closed, per-mode entry lists in order, sashes present, `Escape` reported as consumed when open and passed through when closed, focus handle targets the content region.
- Full run over the touched areas: 796 tests across DirectorNotes + FilePreview, plus 5,749 across FilePreview/Markdown/hooks. `npm run lint` and `lint:eslint` clean.

Docs: user-facing section in `docs/director-notes.md`, and a `UI-PATTERNS.md` entry so the next surface that wants a jump list reuses this instead of writing a third one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added table-of-contents navigation to Director’s Notes in Rich and Plain modes.
  * Added keyboard shortcuts, focus management, Escape dismissal, and top/bottom navigation controls.
  * Improved Markdown heading links and navigation in File Preview.
  * Standardized table-of-contents sizing, scrolling, and interaction behavior across supported views.

* **Documentation**
  * Documented table-of-contents controls, navigation, accessibility behavior, and reading-mode differences.

* **Tests**
  * Added comprehensive coverage for navigation, keyboard interactions, heading extraction, ordering, and anchor generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->