### PR TITLE
fix(process): reclaim stale agent process entries so idle sessions recover

### DIFF
--- a/src/__tests__/main/process-manager.test.ts
+++ b/src/__tests__/main/process-manager.test.ts
@@ -43,6 +43,19 @@ vi.mock('../../shared/platformDetection', () => ({
 	isWindows: () => mockIsWindows(),
 }));
 
+// Mock the PID liveness probe so the stale-entry reconciliation can be driven
+// deterministically on any host (a hardcoded "dead" PID would otherwise be a
+// coin flip). Defaults to "alive" so unrelated tests keep the old semantics.
+const { mockIsPidAlive } = vi.hoisted(() => ({
+	mockIsPidAlive: vi.fn<(pid: number | undefined) => boolean>().mockReturnValue(true),
+}));
+
+vi.mock('../../main/process-manager/utils/childProcessInfo', async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import('../../main/process-manager/utils/childProcessInfo')>();
+	return { ...actual, isPidAlive: (pid?: number) => mockIsPidAlive(pid) };
+});
+
 import * as fs from 'fs';
 import { logger } from '../../main/utils/logger';
 
@@ -700,8 +713,13 @@ describe('process-manager.ts', () => {
 		});
 
 		describe('spawn() existing process guard', () => {
+			beforeEach(() => {
+				mockIsPidAlive.mockReturnValue(true);
+			});
+
 			afterEach(() => {
 				mockIsWindows.mockImplementation(() => process.platform === 'win32');
+				mockIsPidAlive.mockReturnValue(true);
 			});
 
 			it('should kill existing process before spawning with same sessionId', () => {
@@ -777,6 +795,11 @@ describe('process-manager.ts', () => {
 			});
 
 			it('should retain an exited agent until close cleanup drains its output', () => {
+				// The PID is already gone here: node saw the child exit, so `close` is
+				// still draining trailing stdout microseconds later. Reclaiming on
+				// liveness alone would drop that final response (issue #1249), so the
+				// drain window must stay refused even though the process is dead.
+				mockIsPidAlive.mockReturnValue(false);
 				const processes = (processManager as any).processes as Map<string, any>;
 				const exitingChildProcess = {
 					pid: 32829,
@@ -807,6 +830,83 @@ describe('process-manager.ts', () => {
 				).toThrow('Agent process already running for session draining-agent-session');
 				expect(exitingChildProcess.kill).not.toHaveBeenCalled();
 				expect(processManager.get('draining-agent-session')).toBe(exitingProcess);
+			});
+
+			it('should reclaim an agent entry whose OS process no longer exists', () => {
+				// Issue #1339: after a long idle the child died without node ever
+				// seeing `close`, so the entry (still "running" as far as node knows)
+				// owned the session id forever and every later turn threw.
+				mockIsPidAlive.mockReturnValue(false);
+				const processes = (processManager as any).processes as Map<string, any>;
+				const staleChildProcess = {
+					pid: 32830,
+					exitCode: null,
+					signalCode: null,
+					kill: vi.fn(),
+				};
+				const staleProcess = {
+					sessionId: 'stale-agent-session',
+					toolType: 'codex',
+					isTerminal: false,
+					pid: 32830,
+					cwd: '/tmp',
+					startTime: Date.now(),
+					childProcess: staleChildProcess,
+				};
+				processes.set('stale-agent-session', staleProcess);
+
+				let thrown: unknown;
+				try {
+					processManager.spawn({
+						sessionId: 'stale-agent-session',
+						toolType: 'codex',
+						cwd: '/tmp',
+						command: 'codex',
+						args: ['exec', '--json'],
+						prompt: 'turn after idle',
+					});
+				} catch (err) {
+					// The spawn itself may still fail against the mocked child_process;
+					// what matters is that it was no longer blocked by the guard.
+					thrown = err;
+				}
+
+				expect(String((thrown as Error | undefined)?.message ?? '')).not.toContain(
+					'Agent process already running'
+				);
+				// The dead entry is dropped, and never signalled - there is no process
+				// left to kill, and a kill() would emit a spurious exit.
+				expect(processManager.get('stale-agent-session')).not.toBe(staleProcess);
+				expect(staleChildProcess.kill).not.toHaveBeenCalled();
+			});
+
+			it('should refuse to replace an SDK-backed agent turn even when no OS pid is alive', () => {
+				// SDK turns have no OS child of their own, so a liveness probe proves
+				// nothing and could match an unrelated recycled PID.
+				mockIsPidAlive.mockReturnValue(false);
+				const processes = (processManager as any).processes as Map<string, any>;
+				const sdkProcess = {
+					sessionId: 'sdk-agent-session',
+					toolType: 'opencode',
+					isTerminal: false,
+					pid: 32831,
+					cwd: '/tmp',
+					startTime: Date.now(),
+					sdkController: { interrupt: vi.fn(), kill: vi.fn() },
+				};
+				processes.set('sdk-agent-session', sdkProcess);
+
+				expect(() =>
+					processManager.spawn({
+						sessionId: 'sdk-agent-session',
+						toolType: 'opencode',
+						cwd: '/tmp',
+						command: 'opencode',
+						args: ['run'],
+						prompt: 'second turn',
+					})
+				).toThrow('Agent process already running for session sdk-agent-session');
+				expect(processManager.get('sdk-agent-session')).toBe(sdkProcess);
 			});
 		});
 

--- a/src/main/process-manager/ProcessManager.ts
+++ b/src/main/process-manager/ProcessManager.ts
@@ -19,6 +19,7 @@ import { LocalCommandRunner } from './runners/LocalCommandRunner';
 import { SshCommandRunner } from './runners/SshCommandRunner';
 import { opencodeServerManager } from '../opencode-server/OpencodeServerManager';
 import { logger } from '../utils/logger';
+import { isPidAlive } from './utils/childProcessInfo';
 import { isWindows } from '../../shared/platformDetection';
 import { expandTilde } from '../../shared/pathUtils';
 import type { SshRemoteConfig } from '../../shared/types';
@@ -119,16 +120,57 @@ export class ProcessManager extends EventEmitter {
 				existing.sdkController !== undefined;
 
 			if (!existing.isTerminal) {
-				logger.warn('[ProcessManager] Refusing to replace owned agent process', 'ProcessManager', {
-					sessionId: config.sessionId,
-					existingPid: existing.pid,
-					existingToolType: existing.toolType,
-					requestedToolType: config.toolType,
-				});
-				throw new Error(`Agent process already running for session ${config.sessionId}`);
-			}
+				// An agent entry is only ever removed by the exit handler, so an entry
+				// that is still here while its OS process is gone means `close` never
+				// arrived and never will (reported after the machine idled for hours:
+				// the child died without us seeing the event). Left alone, that entry
+				// owns the session id forever and every later turn throws, with no way
+				// back short of restarting the app. See issue #1339.
+				//
+				// The reconciliation is deliberately narrow so it cannot reopen the
+				// lost-response race from #1249. There, node HAD seen the child exit
+				// (`exitCode` is set) while `close` was still draining trailing stdout
+				// microseconds later, so anything node knows has exited stays refused.
+				// We only reclaim the opposite state: node still believes the child is
+				// running, yet the OS says the PID is gone. The two are disjoint, so
+				// the drain window keeps its protection.
+				//
+				// SDK-backed turns have no OS child of their own, so a liveness probe
+				// would be meaningless (and could match an unrelated recycled PID);
+				// they keep the strict refusal.
+				const nodeObservedExit = existing.childProcess !== undefined && !childProcessRunning;
+				const isStaleEntry =
+					!nodeObservedExit && existing.sdkController === undefined && !isPidAlive(existing.pid);
 
-			if (existingProcessRunning) {
+				if (!isStaleEntry) {
+					logger.warn(
+						'[ProcessManager] Refusing to replace owned agent process',
+						'ProcessManager',
+						{
+							sessionId: config.sessionId,
+							existingPid: existing.pid,
+							existingToolType: existing.toolType,
+							requestedToolType: config.toolType,
+						}
+					);
+					throw new Error(`Agent process already running for session ${config.sessionId}`);
+				}
+
+				logger.warn(
+					'[ProcessManager] Reclaiming stale agent process entry (PID no longer exists)',
+					'ProcessManager',
+					{
+						sessionId: config.sessionId,
+						stalePid: existing.pid,
+						existingToolType: existing.toolType,
+						requestedToolType: config.toolType,
+					}
+				);
+				// Drop the dead entry and let the spawn below take the session id. No
+				// kill() here: there is no process left to signal, and kill() would
+				// emit a spurious exit for a turn that ended long ago.
+				this.processes.delete(config.sessionId);
+			} else if (existingProcessRunning) {
 				logger.warn('[ProcessManager] Restarting existing terminal process', 'ProcessManager', {
 					sessionId: config.sessionId,
 					existingPid: existing.pid,

--- a/src/main/process-manager/utils/__tests__/childProcessInfo.test.ts
+++ b/src/main/process-manager/utils/__tests__/childProcessInfo.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getChildProcesses } from '../childProcessInfo';
+import { getChildProcesses, isPidAlive } from '../childProcessInfo';
 
 // Note: this test mocks execFile (not exec) - the implementation uses execFile
 // which is safe from shell injection by design.
@@ -142,5 +142,46 @@ describe('getChildProcesses', () => {
 
 		const result = await getChildProcesses(12345);
 		expect(result).toEqual([]);
+	});
+});
+
+describe('isPidAlive', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('reports the current process as alive', () => {
+		expect(isPidAlive(process.pid)).toBe(true);
+	});
+
+	it('treats a missing process (ESRCH) as dead', () => {
+		vi.spyOn(process, 'kill').mockImplementation(() => {
+			const err = new Error('kill ESRCH') as NodeJS.ErrnoException;
+			err.code = 'ESRCH';
+			throw err;
+		});
+
+		expect(isPidAlive(4242)).toBe(false);
+	});
+
+	it('treats a foreign-owned process (EPERM) as alive', () => {
+		// EPERM means the PID exists but belongs to another user, so the entry
+		// must not be reclaimed as stale.
+		vi.spyOn(process, 'kill').mockImplementation(() => {
+			const err = new Error('kill EPERM') as NodeJS.ErrnoException;
+			err.code = 'EPERM';
+			throw err;
+		});
+
+		expect(isPidAlive(4242)).toBe(true);
+	});
+
+	it('treats absent or non-positive pids as dead without probing', () => {
+		const killSpy = vi.spyOn(process, 'kill');
+
+		expect(isPidAlive(undefined)).toBe(false);
+		expect(isPidAlive(0)).toBe(false);
+		expect(isPidAlive(-1)).toBe(false);
+		expect(killSpy).not.toHaveBeenCalled();
 	});
 });

--- a/src/main/process-manager/utils/childProcessInfo.ts
+++ b/src/main/process-manager/utils/childProcessInfo.ts
@@ -12,6 +12,28 @@ export interface ChildProcessInfo {
 }
 
 /**
+ * Check whether an OS process with the given PID currently exists.
+ *
+ * Signal 0 performs the permission/existence check without delivering a
+ * signal: it throws ESRCH when no such process exists, and EPERM when the
+ * process exists but belongs to another user. EPERM therefore still means
+ * "alive", so only ESRCH is treated as dead.
+ *
+ * Caveat: PIDs are recycled by the OS, so a stale PID can collide with an
+ * unrelated newer process and report alive. Callers must treat a `true`
+ * result as "cannot prove it is dead" rather than proof of liveness.
+ */
+export function isPidAlive(pid: number | undefined): boolean {
+	if (!pid || pid <= 0) return false;
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException)?.code === 'EPERM';
+	}
+}
+
+/**
  * Get the direct child processes of a given PID.
  * Returns an array of { pid, command } for each child process.
  * On failure (process exited, permission denied, etc.), returns an empty array.

--- a/src/main/process-manager/utils/index.ts
+++ b/src/main/process-manager/utils/index.ts
@@ -1,4 +1,5 @@
 export { appendToBuffer } from './bufferUtils';
+export { getChildProcesses, isPidAlive, type ChildProcessInfo } from './childProcessInfo';
 export { parseDataUrl, saveImageToTempFile, cleanupTempFiles } from './imageUtils';
 export { buildStreamJsonMessage } from './streamJsonBuilder';
 export { buildUnixBasePath, buildPtyTerminalEnv, buildChildProcessEnv } from './envBuilder';


### PR DESCRIPTION
Closes #1339

## Problem

After a session sits idle for hours, sending a new message fails with:

```
Error invoking remote method 'process:spawn': Error: Agent process already running for session <id>-ai-<tabId>
```

The session never recovers on its own.

An agent's entry in the process registry is only ever removed by the exit handler, which runs off the child's `close` event. If the child dies without that event ever arriving, the entry stays behind owning its session id. `ProcessManager.spawn()` then refuses every later turn for that session, and the only way out is restarting the app.

The existing guard computed `existingProcessRunning` but never consulted it on the agent path - non-terminal entries threw unconditionally, so a provably dead entry was treated exactly like a live one.

## Fix

Reconcile the entry against real OS state at spawn time. If node still believes the child is running but the PID no longer exists, drop the dead entry and let the spawn proceed.

## Why this does not reopen #1249

#1249 fixed lost agent responses by refusing to replace an agent process during its drain window. The two situations are distinguishable without any timing heuristic:

| | node's view | OS view | behavior |
|---|---|---|---|
| #1249 drain window | `exitCode` set - node saw the exit, `close` imminent | dead | **still refused** |
| #1339 stale entry | `exitCode === null` - node thinks it is running | dead | reclaimed |

These states are disjoint, so anything node knows has exited keeps its protection. The regression test for the drain window now asserts refusal *even when the PID is already gone*, which is the exact case a naive liveness check would have broken.

SDK-backed turns (OpenCode) have no OS child of their own, so they keep the strict refusal rather than probing a PID that could collide with an unrelated recycled process.

No `kill()` is issued on the reclaim path: there is no process left to signal, and killing would emit a spurious exit for a turn that ended long ago.

## Changes

- `ProcessManager.spawn()`: reclaim provably-dead agent entries instead of throwing.
- New `isPidAlive()` in `process-manager/utils/childProcessInfo.ts`, alongside the other child-process inspection helpers. `EPERM` (process exists, other user) counts as alive; only `ESRCH` means dead.

## Tests

- New: a stale entry (node thinks running, PID gone) is reclaimed and not signalled. Verified this test fails on `rc` without the fix.
- Strengthened: the #1249 drain-window test now pins refusal with a dead PID.
- New: SDK-backed turns still refuse.
- New: unit coverage for `isPidAlive` (ESRCH / EPERM / absent pid).
- Full `process-manager` suite green (484 tests), `npm run lint` clean.

The PID probe is mocked in tests so the behavior is deterministic on both CI legs.

## Note on base branch

Targeting `rc`, not `main`. The guard that throws was introduced by #1249 and exists only on `rc` (0.18.5-RC, the reporter's version); `main` (0.17.4) still has the older kill-and-replace behavior and is unaffected.

## Known limitation

PIDs are recycled by the OS, so a stale PID can collide with an unrelated newer process and report alive. That leaves the session stuck exactly as it is today rather than making anything worse. A visible "restart agent" recovery affordance in the session UI, which the reporter also asked for, is worth doing separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved process replacement handling when a previously tracked process has already exited.
  - Prevented unnecessary termination attempts for stale process entries.
  - Preserved protection for active and SDK-backed processes.
  - Added more reliable handling for invalid, missing, or inaccessible process IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->