### PR TITLE
perf(transcript): render agent transcripts tail-first with idle backfill

### DIFF
--- a/CLAUDE-PERFORMANCE.md
+++ b/CLAUDE-PERFORMANCE.md
@@ -199,6 +199,43 @@ const virtualizer = useVirtualizer({
 });
 ```
 
+## Progressive (Tail-First) Rendering
+
+When rows are individually expensive - each one runs a markdown pipeline, a
+syntax highlighter, or a chart - virtualization is not always the right tool.
+Virtualization needs a measurable row height, and it breaks `querySelector` over
+the full list (in-page search, jump-to-message). Use
+`useProgressiveRenderWindow()` in `src/renderer/hooks/utils/` instead:
+
+```typescript
+// See: src/renderer/components/TerminalOutput.tsx (issue #1342)
+const { startIndex, revealTo } = useProgressiveRenderWindow(
+	logs.length,
+	`${session.id}-${activeTabId}`, // resets the window on conversation switch
+	{ onBeforeExpand: snapshotScrollPosition }
+);
+const visible = logs.slice(startIndex);
+```
+
+It renders the newest slice immediately, then walks `startIndex` toward 0 a
+chunk at a time on `requestIdleCallback`, so a big list hydrates across many
+short tasks that yield to input instead of one multi-second long task. Every row
+still ends up in the DOM, so DOM-walking features keep working once backfill
+completes.
+
+Two things to get right at the call site:
+
+1. **Anchor the scroll.** Backfill prepends content above the viewport. Snapshot
+   `scrollHeight - scrollTop` in `onBeforeExpand` and restore it in a
+   `useLayoutEffect` on `startIndex`, before paint.
+2. **Use `revealTo(index)` for jumps.** Anything that scrolls to a specific row
+   with a bounded retry (see `jumpToElement`, ~30 frames) will time out waiting
+   for backfill to reach deep history. Pull the target in explicitly.
+
+Anything that re-walks the DOM on content change (search highlighting, match
+counts) must take `startIndex` as a dependency, or matches in freshly hydrated
+rows are silently missed.
+
 ## Per-Row DOM Budget
 
 A list row component should aim for **<30 DOM nodes per row**. CDP profiling

--- a/src/__tests__/renderer/components/TerminalOutput.test.tsx
+++ b/src/__tests__/renderer/components/TerminalOutput.test.tsx
@@ -2887,6 +2887,89 @@ describe('TerminalOutput', () => {
 			expect(screen.queryByText('Dynamic claude -p')).not.toBeInTheDocument();
 		});
 	});
+
+	describe('progressive transcript rendering (#1342)', () => {
+		// Switching to an agent with a long transcript used to mount every entry in
+		// one synchronous commit, freezing the UI for seconds on the PREVIOUS agent's
+		// view. The newest entries must render immediately; the rest backfills later.
+		const createLongTranscript = (count: number): LogEntry[] =>
+			Array.from({ length: count }, (_, i) =>
+				createLogEntry({
+					id: `log-${i}`,
+					text: `Message ${i}`,
+					source: i % 2 === 0 ? 'user' : 'stdout',
+				})
+			);
+
+		const renderedIndices = (container: HTMLElement): number[] =>
+			Array.from(container.querySelectorAll('[data-log-index]')).map((el) =>
+				Number(el.getAttribute('data-log-index'))
+			);
+
+		it('bounds the first commit instead of mounting the whole transcript', () => {
+			const logs = createLongTranscript(400);
+			const session = createDefaultSession({
+				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				activeTabId: 'tab-1',
+			});
+
+			const { container } = render(<TerminalOutput {...createDefaultProps({ session })} />);
+
+			const indices = renderedIndices(container);
+			expect(indices.length).toBeLessThan(logs.length);
+			// The newest entry is what the user is looking at — it must be present.
+			expect(screen.getByText('Message 399')).toBeInTheDocument();
+			// Ancient history is deferred, not dropped (see backfill test below).
+			expect(screen.queryByText('Message 0')).not.toBeInTheDocument();
+		});
+
+		it('keeps absolute log indices so message navigation still targets correctly', () => {
+			const logs = createLongTranscript(400);
+			const session = createDefaultSession({
+				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				activeTabId: 'tab-1',
+			});
+
+			const { container } = render(<TerminalOutput {...createDefaultProps({ session })} />);
+
+			const indices = renderedIndices(container);
+			// Indices are offsets into the full log list, not into the rendered window,
+			// so the last one is 399 rather than (window length - 1).
+			expect(indices[indices.length - 1]).toBe(399);
+			expect(indices[0]).toBeGreaterThan(0);
+		});
+
+		it('backfills the deferred history over subsequent idle ticks', async () => {
+			const logs = createLongTranscript(40);
+			const session = createDefaultSession({
+				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				activeTabId: 'tab-1',
+			});
+
+			const { container } = render(<TerminalOutput {...createDefaultProps({ session })} />);
+			expect(renderedIndices(container).length).toBeLessThan(40);
+
+			// jsdom has no requestIdleCallback, so the hook uses its setTimeout fallback.
+			await act(async () => {
+				vi.advanceTimersByTime(500);
+			});
+
+			expect(renderedIndices(container).length).toBe(40);
+			expect(screen.getByText('Message 0')).toBeInTheDocument();
+		});
+
+		it('renders short transcripts in full immediately', () => {
+			const logs = createLongTranscript(5);
+			const session = createDefaultSession({
+				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				activeTabId: 'tab-1',
+			});
+
+			const { container } = render(<TerminalOutput {...createDefaultProps({ session })} />);
+
+			expect(renderedIndices(container)).toEqual([0, 1, 2, 3, 4]);
+		});
+	});
 });
 
 describe('helper function behaviors (tested via component)', () => {

--- a/src/__tests__/renderer/hooks/utils/useProgressiveRenderWindow.test.ts
+++ b/src/__tests__/renderer/hooks/utils/useProgressiveRenderWindow.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for useProgressiveRenderWindow — the tail-first render window that keeps
+ * agent switching responsive on long transcripts (issue #1342).
+ *
+ * The hook returns a slice index plus a reveal escape hatch. The behaviours that
+ * matter are: the first commit is bounded regardless of transcript size, the
+ * index walks to 0 over successive idle ticks, and it never moves backwards
+ * while a conversation is live (which would make a rendered entry vanish).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+	useProgressiveRenderWindow,
+	DEFAULT_INITIAL_RENDER_COUNT,
+	DEFAULT_BACKFILL_CHUNK,
+} from '../../../../renderer/hooks/utils/useProgressiveRenderWindow';
+
+/**
+ * jsdom has no requestIdleCallback, so the hook takes its setTimeout fallback.
+ * Fake timers let each test step the backfill deterministically.
+ */
+function flushIdleTick() {
+	act(() => {
+		vi.advanceTimersByTime(20);
+	});
+}
+
+describe('useProgressiveRenderWindow', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('renders only the newest slice on the first commit', () => {
+		const { result } = renderHook(() => useProgressiveRenderWindow(500, 'a'));
+		// 500 entries, 25 rendered => start at 475 rather than 0.
+		expect(result.current.startIndex).toBe(500 - DEFAULT_INITIAL_RENDER_COUNT);
+	});
+
+	it('renders everything immediately when the list is already short', () => {
+		const { result } = renderHook(() => useProgressiveRenderWindow(10, 'a'));
+		expect(result.current.startIndex).toBe(0);
+	});
+
+	it('backfills older history one chunk per idle tick', () => {
+		const { result } = renderHook(() => useProgressiveRenderWindow(500, 'a'));
+		const start = result.current.startIndex;
+
+		flushIdleTick();
+		expect(result.current.startIndex).toBe(start - DEFAULT_BACKFILL_CHUNK);
+
+		flushIdleTick();
+		expect(result.current.startIndex).toBe(start - DEFAULT_BACKFILL_CHUNK * 2);
+	});
+
+	it('eventually reaches the head and then stops scheduling work', () => {
+		const { result } = renderHook(() => useProgressiveRenderWindow(60, 'a'));
+		expect(result.current.startIndex).toBeGreaterThan(0);
+
+		// 60 - 25 = 35 hidden entries, 8 per tick => 5 ticks. Run extra to be sure
+		// it clamps at 0 instead of going negative.
+		for (let i = 0; i < 12; i++) flushIdleTick();
+
+		expect(result.current.startIndex).toBe(0);
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it('does not re-hide rendered entries when new messages stream in', () => {
+		const { result, rerender } = renderHook(({ total }) => useProgressiveRenderWindow(total, 'a'), {
+			initialProps: { total: 500 },
+		});
+
+		flushIdleTick();
+		const afterBackfill = result.current.startIndex;
+
+		// Agent streams 40 more entries. They append at the tail, so they are inside
+		// the window already — the start index must not jump forward.
+		rerender({ total: 540 });
+		expect(result.current.startIndex).toBe(afterBackfill);
+	});
+
+	it('reveals more entries when the list shrinks below the window', () => {
+		const { result, rerender } = renderHook(({ total }) => useProgressiveRenderWindow(total, 'a'), {
+			initialProps: { total: 500 },
+		});
+		expect(result.current.startIndex).toBe(475);
+
+		// User deletes most of the transcript; the window must not point past the end.
+		rerender({ total: 30 });
+		expect(result.current.startIndex).toBe(30 - DEFAULT_INITIAL_RENDER_COUNT);
+	});
+
+	it('snaps back to the tail when the conversation identity changes', () => {
+		const { result, rerender } = renderHook(
+			({ total, key }) => useProgressiveRenderWindow(total, key),
+			{ initialProps: { total: 500, key: 'session-a' } }
+		);
+
+		for (let i = 0; i < 3; i++) flushIdleTick();
+		expect(result.current.startIndex).toBeLessThan(475);
+
+		// Switching to another agent's tab must start from its own tail, not inherit
+		// the previous conversation's backfill progress.
+		rerender({ total: 300, key: 'session-b' });
+		expect(result.current.startIndex).toBe(300 - DEFAULT_INITIAL_RENDER_COUNT);
+	});
+
+	it('notifies the caller before each expansion so scroll can be anchored', () => {
+		const onBeforeExpand = vi.fn();
+		renderHook(() => useProgressiveRenderWindow(500, 'a', { onBeforeExpand }));
+
+		expect(onBeforeExpand).not.toHaveBeenCalled();
+
+		flushIdleTick();
+		expect(onBeforeExpand).toHaveBeenCalledTimes(1);
+
+		flushIdleTick();
+		expect(onBeforeExpand).toHaveBeenCalledTimes(2);
+	});
+
+	it('cancels pending backfill work on unmount', () => {
+		const { unmount } = renderHook(() => useProgressiveRenderWindow(500, 'a'));
+		expect(vi.getTimerCount()).toBe(1);
+		unmount();
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it('honours custom initial and chunk sizes', () => {
+		const { result } = renderHook(() =>
+			useProgressiveRenderWindow(200, 'a', { initial: 50, chunk: 25 })
+		);
+		expect(result.current.startIndex).toBe(150);
+
+		flushIdleTick();
+		expect(result.current.startIndex).toBe(125);
+	});
+
+	describe('revealTo', () => {
+		it('pulls a deferred item into the window immediately', () => {
+			const { result } = renderHook(() => useProgressiveRenderWindow(500, 'a'));
+			expect(result.current.startIndex).toBe(475);
+
+			act(() => {
+				result.current.revealTo(120);
+			});
+			expect(result.current.startIndex).toBe(120);
+		});
+
+		it('never narrows the window back down', () => {
+			const { result } = renderHook(() => useProgressiveRenderWindow(500, 'a'));
+
+			act(() => {
+				result.current.revealTo(100);
+			});
+			// A later request for a newer item must not re-hide the history already
+			// pulled in — that would unmount entries the user can see.
+			act(() => {
+				result.current.revealTo(400);
+			});
+			expect(result.current.startIndex).toBe(100);
+		});
+
+		it('reveals the whole list when asked for index 0', () => {
+			const { result } = renderHook(() => useProgressiveRenderWindow(500, 'a'));
+
+			act(() => {
+				result.current.revealTo(0);
+			});
+			expect(result.current.startIndex).toBe(0);
+			expect(vi.getTimerCount()).toBe(0);
+		});
+	});
+
+	it('uses requestIdleCallback when the platform provides one', () => {
+		const scheduled: Array<() => void> = [];
+		const ric = vi.fn((cb: () => void) => {
+			scheduled.push(cb);
+			return 1;
+		});
+		const cic = vi.fn();
+		vi.stubGlobal('requestIdleCallback', ric);
+		vi.stubGlobal('cancelIdleCallback', cic);
+
+		try {
+			const { result, unmount } = renderHook(() => useProgressiveRenderWindow(500, 'a'));
+			expect(ric).toHaveBeenCalledTimes(1);
+
+			act(() => {
+				scheduled[0]();
+			});
+			expect(result.current.startIndex).toBe(475 - DEFAULT_BACKFILL_CHUNK);
+
+			unmount();
+			expect(cic).toHaveBeenCalled();
+		} finally {
+			vi.unstubAllGlobals();
+		}
+	});
+});

--- a/src/renderer/components/TerminalOutput.tsx
+++ b/src/renderer/components/TerminalOutput.tsx
@@ -1,4 +1,13 @@
-import React, { useRef, useEffect, useMemo, forwardRef, useState, useCallback, memo } from 'react';
+import React, {
+	useRef,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	forwardRef,
+	useState,
+	useCallback,
+	memo,
+} from 'react';
 import {
 	ChevronDown,
 	ChevronUp,
@@ -21,7 +30,7 @@ import Convert from 'ansi-to-html';
 import { useLayerStack } from '../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { getActiveTab } from '../utils/tabHelpers';
-import { useDebouncedValue, useThrottledCallback } from '../hooks';
+import { useDebouncedValue, useThrottledCallback, useProgressiveRenderWindow } from '../hooks';
 import {
 	processLogTextHelper,
 	filterTextByLinesHelper,
@@ -1785,6 +1794,45 @@ export const TerminalOutput = memo(
 		const filteredLogs = collapsedLogs;
 
 		// ============================================================================
+		// Progressive transcript rendering (issue #1342)
+		// ============================================================================
+		// Mounting every entry of a long transcript in one commit blocked the main
+		// thread for seconds on agent switch (each entry runs the full remark/rehype
+		// pipeline). Render the newest slice first, then backfill older history on
+		// idle ticks. Prepending entries above the viewport would shift what the user
+		// is reading, so snapshot distance-from-bottom before each expansion and
+		// restore it in a layout effect, before the browser paints.
+		const backfillBottomDistanceRef = useRef<number | null>(null);
+
+		const handleBeforeBackfill = useCallback(() => {
+			const container = scrollContainerRef.current;
+			if (container) {
+				backfillBottomDistanceRef.current = container.scrollHeight - container.scrollTop;
+			}
+		}, []);
+
+		const { startIndex: logStartIndex, revealTo: revealLogIndex } = useProgressiveRenderWindow(
+			filteredLogs.length,
+			`${session.id}-${activeTabId ?? ''}`,
+			{ onBeforeExpand: handleBeforeBackfill }
+		);
+
+		useLayoutEffect(() => {
+			const container = scrollContainerRef.current;
+			const bottomDistance = backfillBottomDistanceRef.current;
+			backfillBottomDistanceRef.current = null;
+			if (!container || bottomDistance === null) return;
+			// Anchor to the bottom rather than the top: content was prepended, so the
+			// distance from the bottom is what stayed constant for the user.
+			container.scrollTop = container.scrollHeight - bottomDistance;
+		}, [logStartIndex]);
+
+		const visibleLogs = useMemo(
+			() => (logStartIndex > 0 ? filteredLogs.slice(logStartIndex) : filteredLogs),
+			[filteredLogs, logStartIndex]
+		);
+
+		// ============================================================================
 		// Cross-tab search jump (Opt+Cmd+F -> pick a hit in another tab)
 		// ============================================================================
 		// The modal switches the active tab, seeds this tab's Find bar with the same
@@ -1808,6 +1856,12 @@ export const TerminalOutput = memo(
 			const renderedId = renderedIdByLogId.get(logId) ?? logId;
 			pendingJumpMatchIdRef.current = renderedId;
 			cancelJumpRef.current?.();
+
+			// The target may still be behind the progressive render window (#1342).
+			// jumpToElement gives up after ~30 frames, which idle backfill can outlast
+			// on a long transcript, so pull the entry in now instead of racing it.
+			const targetIndex = filteredLogs.findIndex((l) => l.id === renderedId);
+			if (targetIndex >= 0) revealLogIndex(targetIndex);
 
 			jumpInFlightRef.current = true;
 			const releaseJump = () => {
@@ -1849,7 +1903,15 @@ export const TerminalOutput = memo(
 			};
 			// Consume it: the jump is a one-shot request, not persistent state.
 			useUIStore.getState().clearPendingLogJump(logId);
-		}, [pendingLogJump, session.id, activeTab, renderedIdByLogId, theme.colors.accent]);
+		}, [
+			pendingLogJump,
+			session.id,
+			activeTab,
+			renderedIdByLogId,
+			theme.colors.accent,
+			filteredLogs,
+			revealLogIndex,
+		]);
 
 		// ============================================================================
 		// Search match navigation (CSS Custom Highlight API)
@@ -1964,7 +2026,10 @@ export const TerminalOutput = memo(
 			// require re-walking the DOM.
 
 			return clearHighlights;
-		}, [debouncedSearchQuery, outputSearchRegex, outputSearchOpen, filteredLogs]);
+			// logStartIndex is a dependency because idle backfill adds entries to the
+			// DOM after the initial pass; without it, matches in freshly hydrated
+			// history would never be highlighted or counted.
+		}, [debouncedSearchQuery, outputSearchRegex, outputSearchOpen, filteredLogs, logStartIndex]);
 
 		// Update the "current" highlight and scroll it into view when index changes.
 		useEffect(() => {
@@ -2491,65 +2556,70 @@ export const TerminalOutput = memo(
 					onScroll={handleScroll}
 				>
 					{/* Log entries */}
-					{filteredLogs.map((log, index) => (
-						<LogItemComponent
-							key={log.id}
-							log={log}
-							index={index}
-							isTerminal={isTerminal}
-							isAIMode={isAIMode}
-							theme={theme}
-							fontFamily={fontFamily}
-							maxOutputLines={maxOutputLines}
-							lastUserCommand={
-								isTerminal && log.source !== 'user' ? getLastUserCommand(index) : undefined
-							}
-							isExpanded={expandedLogs.has(log.id)}
-							onToggleExpanded={toggleExpanded}
-							localFilterQuery={localFilters.get(log.id) || ''}
-							filterMode={filterModes.get(log.id) || { mode: 'include', regex: false }}
-							activeLocalFilter={activeLocalFilter}
-							onToggleLocalFilter={toggleLocalFilter}
-							onSetLocalFilterQuery={setLocalFilterQuery}
-							onSetFilterMode={setFilterModeForLog}
-							onClearLocalFilter={clearLocalFilter}
-							deleteConfirmLogId={deleteConfirmLogId}
-							onDeleteLog={onDeleteLog}
-							onSetDeleteConfirmLogId={setDeleteConfirmLogId}
-							scrollContainerRef={scrollContainerRef}
-							setLightboxImage={setLightboxImage}
-							copyToClipboard={copyToClipboard}
-							ansiConverter={ansiConverter}
-							markdownEditMode={markdownEditMode}
-							onToggleMarkdownEditMode={toggleMarkdownEditMode}
-							onReplayMessage={onReplayMessage}
-							onForkConversation={onForkConversation}
-							sessionId={session.id}
-							onSessionRecover={onSessionRecover}
-							isRecoveringSession={isRecoveringSession}
-							sessionRecoveryError={sessionRecoveryError}
-							fileTree={fileTree}
-							cwd={cwd}
-							projectRoot={projectRoot}
-							onFileClick={onFileClick}
-							sshRemoteId={
-								session.sessionSshRemoteConfig?.enabled
-									? (session.sessionSshRemoteConfig?.remoteId ?? undefined)
-									: undefined
-							}
-							onShowErrorDetails={onShowErrorDetails}
-							onSaveToFile={handleSaveToFile}
-							ghCliAvailable={ghCliAvailable}
-							onPublishGist={onPublishMessageGist}
-							publishedGistUrl={publishedGists[log.id]?.gistUrl}
-							bionifyReadingMode={globalBionifyReadingMode}
-							bionifyIntensity={globalBionifyIntensity}
-							bionifyAlgorithm={globalBionifyAlgorithm}
-							userMessageAlignment={userMessageAlignment}
-							isClaudeCode={session.toolType === 'claude-code'}
-							isAdaptiveMode={getClaudeTokenMode(session) === 'dynamic'}
-						/>
-					))}
+					{visibleLogs.map((log, visibleIndex) => {
+						// Absolute index into filteredLogs — sibling lookups (echo stripping)
+						// and jump-to-message targeting must not see the window offset.
+						const index = logStartIndex + visibleIndex;
+						return (
+							<LogItemComponent
+								key={log.id}
+								log={log}
+								index={index}
+								isTerminal={isTerminal}
+								isAIMode={isAIMode}
+								theme={theme}
+								fontFamily={fontFamily}
+								maxOutputLines={maxOutputLines}
+								lastUserCommand={
+									isTerminal && log.source !== 'user' ? getLastUserCommand(index) : undefined
+								}
+								isExpanded={expandedLogs.has(log.id)}
+								onToggleExpanded={toggleExpanded}
+								localFilterQuery={localFilters.get(log.id) || ''}
+								filterMode={filterModes.get(log.id) || { mode: 'include', regex: false }}
+								activeLocalFilter={activeLocalFilter}
+								onToggleLocalFilter={toggleLocalFilter}
+								onSetLocalFilterQuery={setLocalFilterQuery}
+								onSetFilterMode={setFilterModeForLog}
+								onClearLocalFilter={clearLocalFilter}
+								deleteConfirmLogId={deleteConfirmLogId}
+								onDeleteLog={onDeleteLog}
+								onSetDeleteConfirmLogId={setDeleteConfirmLogId}
+								scrollContainerRef={scrollContainerRef}
+								setLightboxImage={setLightboxImage}
+								copyToClipboard={copyToClipboard}
+								ansiConverter={ansiConverter}
+								markdownEditMode={markdownEditMode}
+								onToggleMarkdownEditMode={toggleMarkdownEditMode}
+								onReplayMessage={onReplayMessage}
+								onForkConversation={onForkConversation}
+								sessionId={session.id}
+								onSessionRecover={onSessionRecover}
+								isRecoveringSession={isRecoveringSession}
+								sessionRecoveryError={sessionRecoveryError}
+								fileTree={fileTree}
+								cwd={cwd}
+								projectRoot={projectRoot}
+								onFileClick={onFileClick}
+								sshRemoteId={
+									session.sessionSshRemoteConfig?.enabled
+										? (session.sessionSshRemoteConfig?.remoteId ?? undefined)
+										: undefined
+								}
+								onShowErrorDetails={onShowErrorDetails}
+								onSaveToFile={handleSaveToFile}
+								ghCliAvailable={ghCliAvailable}
+								onPublishGist={onPublishMessageGist}
+								publishedGistUrl={publishedGists[log.id]?.gistUrl}
+								bionifyReadingMode={globalBionifyReadingMode}
+								bionifyIntensity={globalBionifyIntensity}
+								bionifyAlgorithm={globalBionifyAlgorithm}
+								userMessageAlignment={userMessageAlignment}
+								isClaudeCode={session.toolType === 'claude-code'}
+								isAdaptiveMode={getClaudeTokenMode(session) === 'dynamic'}
+							/>
+						);
+					})}
 
 					{/* Queued items section - filtered to active tab */}
 					{session.executionQueue && session.executionQueue.length > 0 && (

--- a/src/renderer/hooks/utils/index.ts
+++ b/src/renderer/hooks/utils/index.ts
@@ -8,6 +8,14 @@
 // Debounce and throttle utilities
 export { useDebouncedValue, useThrottledCallback, useDebouncedCallback } from './useThrottle';
 
+// Tail-first list rendering with idle backfill (long transcripts, #1342)
+export {
+	useProgressiveRenderWindow,
+	DEFAULT_INITIAL_RENDER_COUNT,
+	DEFAULT_BACKFILL_CHUNK,
+} from './useProgressiveRenderWindow';
+export type { UseProgressiveRenderWindowOptions } from './useProgressiveRenderWindow';
+
 // Debounced session persistence
 export { useDebouncedPersistence, DEFAULT_DEBOUNCE_DELAY } from './useDebouncedPersistence';
 export type { UseDebouncedPersistenceReturn } from './useDebouncedPersistence';

--- a/src/renderer/hooks/utils/useProgressiveRenderWindow.ts
+++ b/src/renderer/hooks/utils/useProgressiveRenderWindow.ts
@@ -1,0 +1,143 @@
+/**
+ * useProgressiveRenderWindow - render the tail of a long list first, then
+ * backfill the older head during idle time.
+ *
+ * Motivation (issue #1342): switching to an agent with a long transcript mounted
+ * every log entry in a single synchronous React commit. Each entry runs the full
+ * remark/rehype markdown pipeline, so the commit scaled linearly with transcript
+ * size and blocked the main thread for seconds - the UI stayed frozen on the
+ * PREVIOUS agent's view until it finished.
+ *
+ * This hook returns a `startIndex` into the list. Callers render
+ * `items.slice(startIndex)`, which is the newest slice - the part the user is
+ * actually looking at. The index then walks back toward 0 a chunk at a time on
+ * `requestIdleCallback`, so the remaining history hydrates across many short
+ * tasks that yield to input between them instead of one long blocking task.
+ *
+ * Invariants that make this safe for a live, streaming transcript:
+ * - `startIndex` only ever DECREASES for a given conversation. New items are
+ *   appended at the tail, so they fall inside the window automatically and an
+ *   already-rendered entry never disappears mid-session.
+ * - The returned index is clamped so at least `initial` items stay visible, which
+ *   keeps the view populated when entries are deleted and the list shrinks.
+ * - `onBeforeExpand` fires synchronously before each expansion so the caller can
+ *   snapshot scroll position; prepending content above the viewport would
+ *   otherwise shift what the user is reading.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/** Entries rendered in the first commit after a conversation switch. */
+export const DEFAULT_INITIAL_RENDER_COUNT = 25;
+
+/**
+ * Entries added per idle tick. Deliberately small: each markdown entry can cost
+ * several ms to render, so a large chunk would recreate the long-task jank this
+ * hook exists to avoid.
+ */
+export const DEFAULT_BACKFILL_CHUNK = 8;
+
+export interface UseProgressiveRenderWindowOptions {
+	/** Entries rendered immediately. Default {@link DEFAULT_INITIAL_RENDER_COUNT}. */
+	initial?: number;
+	/** Entries added per idle tick. Default {@link DEFAULT_BACKFILL_CHUNK}. */
+	chunk?: number;
+	/** Called synchronously before each expansion (snapshot scroll position here). */
+	onBeforeExpand?: () => void;
+}
+
+type IdleHandle = { kind: 'idle' | 'timeout'; id: number };
+
+/** requestIdleCallback where available, timeout fallback otherwise (jsdom, older WebKit). */
+function scheduleIdle(callback: () => void): IdleHandle {
+	const ric = (
+		window as unknown as {
+			requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+		}
+	).requestIdleCallback;
+	if (typeof ric === 'function') {
+		// The timeout bounds worst-case latency on a busy thread so backfill still
+		// completes while the agent is streaming.
+		return { kind: 'idle', id: ric(callback, { timeout: 200 }) };
+	}
+	return { kind: 'timeout', id: window.setTimeout(callback, 16) };
+}
+
+function cancelIdle(handle: IdleHandle): void {
+	if (handle.kind === 'idle') {
+		const cic = (window as unknown as { cancelIdleCallback?: (id: number) => void })
+			.cancelIdleCallback;
+		if (typeof cic === 'function') {
+			cic(handle.id);
+			return;
+		}
+	}
+	window.clearTimeout(handle.id);
+}
+
+export interface ProgressiveRenderWindow {
+	/** The index to slice from: render `items.slice(startIndex)`. */
+	startIndex: number;
+	/**
+	 * Pull an item into the window right now, skipping the idle schedule. For
+	 * jump-to-item affordances that must reach history the backfill has not
+	 * reached yet - waiting for it would blow their timeout. Pass 0 to reveal all.
+	 */
+	revealTo: (index: number) => void;
+}
+
+/**
+ * @param totalCount Total number of items in the list.
+ * @param resetKey Identity of the list (e.g. `sessionId-tabId`). Changing it
+ *   snaps the window back to the tail, for callers that are not remounted.
+ */
+export function useProgressiveRenderWindow(
+	totalCount: number,
+	resetKey: string,
+	options: UseProgressiveRenderWindowOptions = {}
+): ProgressiveRenderWindow {
+	const {
+		initial = DEFAULT_INITIAL_RENDER_COUNT,
+		chunk = DEFAULT_BACKFILL_CHUNK,
+		onBeforeExpand,
+	} = options;
+
+	const [startIndex, setStartIndex] = useState(() => Math.max(0, totalCount - initial));
+
+	// Adjusting state during render when a prop changes - the React-documented
+	// alternative to a reset useEffect, which would render one wasted full-list
+	// frame (the exact frame this hook exists to avoid) before snapping back.
+	const prevResetKeyRef = useRef(resetKey);
+	if (prevResetKeyRef.current !== resetKey) {
+		prevResetKeyRef.current = resetKey;
+		setStartIndex(Math.max(0, totalCount - initial));
+	}
+
+	// Keep the callback in a ref so a caller passing an inline closure doesn't
+	// cancel and reschedule the in-flight backfill tick on every render.
+	const onBeforeExpandRef = useRef(onBeforeExpand);
+	onBeforeExpandRef.current = onBeforeExpand;
+
+	const expand = useCallback(() => {
+		onBeforeExpandRef.current?.();
+		setStartIndex((prev) => Math.max(0, prev - chunk));
+	}, [chunk]);
+
+	const revealTo = useCallback((index: number) => {
+		// Monotonic like the idle path: only ever widens the window.
+		setStartIndex((prev) => Math.min(prev, Math.max(0, index)));
+	}, []);
+
+	useEffect(() => {
+		if (startIndex <= 0) return;
+		const handle = scheduleIdle(expand);
+		return () => cancelIdle(handle);
+	}, [startIndex, expand]);
+
+	// Clamp downward only: never re-hide an entry that has already been rendered,
+	// but do reveal more when the list shrinks below the current window.
+	return {
+		startIndex: Math.min(startIndex, Math.max(0, totalCount - initial)),
+		revealTo,
+	};
+}


### PR DESCRIPTION
Closes #1342

## The problem

Switching to an agent with a long transcript freezes the UI for ~5s, stuck on the **previous** agent's view.

`TerminalOutput` is keyed by `session.id-activeTabId`, so switching agents remounts it, and the render did:

```tsx
{filteredLogs.map((log, index) => <LogItemComponent ... />)}
```

Every entry mounts in one synchronous React commit, and each entry runs the full remark/rehype markdown pipeline. The commit therefore scales linearly with transcript size, and nothing can paint until it finishes.

## Confirming it from the reporter's trace

The profile attached to the issue (Apple M3 Ultra, 0.18.5-RC) has exactly one task that matters:

| Task | Duration | Dominant cost |
| --- | --- | --- |
| Renderer main (UI) | **2.97s** | `v8.callFunction` 2.86s self |

Reconstructing the CPU-profiler call tree for that task's hottest frames (~2.1s of self time) gives:

```
<remark plugin visitor>
<- unist-util-visit recursion
<- runSync            <- unified, synchronous
<- Ho / Ul / Al / Sl  <- React render work loop
```

So the markdown pipeline is running *inside* React's render loop, once per entry, in a single uninterruptible task. That is the freeze. No other renderer task in the profile exceeds 470ms.

## The fix

New `useProgressiveRenderWindow()` hook (`src/renderer/hooks/utils/`). It returns a slice index: render the newest 25 entries on the first commit, then walk the index toward 0 in chunks of 8 on `requestIdleCallback`. One multi-second task becomes many short ones that yield to input between them.

This is deliberately **not** virtualization. Rows here have no measurable uniform height, and the transcript has several features that `querySelector` over the full list (in-page search highlighting, jump-to-message, cross-tab search jumps). Progressive rendering keeps every entry in the DOM once backfill completes, so all of that keeps working.

Chunk sizing is the whole game: the window has to stay small enough that a backfill tick doesn't recreate the long task it exists to avoid.

### Edge cases handled

- **Streaming.** The window only ever widens for a live conversation. New entries append at the tail, inside the window already, so an entry that is on screen can never disappear.
- **Scroll stability.** Backfill prepends content *above* the viewport. `onBeforeExpand` snapshots `scrollHeight - scrollTop` and a `useLayoutEffect` restores it before paint, so the user's reading position holds. Anchoring to the bottom (not the top) is the correct invariant when prepending.
- **Deleted entries.** The returned index is clamped so it can never point past the end of a shrinking list.
- **Cross-tab search jump.** `jumpToElement` gives up after ~30 frames, which idle backfill can outlast on a long transcript. The jump now calls `revealTo(targetIndex)` to pull the entry in directly instead of racing.
- **Search highlighting.** The CSS Custom Highlight pass re-walks the DOM, so it takes `startIndex` as a dependency; otherwise matches in freshly hydrated history would be silently missed from the count.

## Testing

- 11 new unit tests for the hook: bounded first commit, per-tick backfill, termination at the head, no re-hiding during streaming, clamping on shrink, reset on conversation switch, `revealTo` monotonicity, timer cleanup on unmount, and the `requestIdleCallback` path (jsdom only has the `setTimeout` fallback, so that one is stubbed).
- 4 new `TerminalOutput` tests asserting the rendered `[data-log-index]` set: bounded initial mount at 400 entries, absolute indices preserved (so message navigation still targets correctly), full backfill on idle, and short transcripts rendered whole immediately.
- Full renderer suite: **19,049 passed**, 106 skipped. `npm run lint` and ESLint clean.

Not yet verified against a real 5s transcript in a packaged build - worth a confirmation from the reporter, since only they have the session that reproduces it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Large terminal transcripts now load newest entries first, progressively loading older entries in the background.
  * Search navigation can immediately reveal and scroll to older matching entries.
  * Search highlighting updates as additional transcript entries become available.

* **Bug Fixes**
  * Preserved scroll position while older transcript entries load.
  * Short transcripts continue to render completely without progressive loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->