### PR TITLE
fix: prevent Electron preload script from being served to web browser clients

### DIFF
--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -244,6 +244,10 @@ export class WebServer {
 			path.join(__dirname, '..', '..', 'web'),
 			// Alternative: relative to __dirname going up to dist
 			path.join(__dirname, '..', 'web'),
+			// Production build may output to web-desktop instead of web
+			path.join(process.cwd(), 'dist', 'web-desktop'),
+			path.join(__dirname, '..', '..', 'web-desktop'),
+			path.join(__dirname, '..', 'web-desktop'),
 		];
 
 		for (const p of possiblePaths) {

--- a/vite.config.web.mts
+++ b/vite.config.web.mts
@@ -80,7 +80,12 @@ export default defineConfig(({ mode }) => ({
 		// Generate source maps for debugging
 		sourcemap: true,
 
+		// Exclude Electron from the web build. The web interface is served
+		// to regular browsers that do not have Electron APIs available.
+		// This prevents Electron-specific code (e.g., getOwnerBrowserWindow)
+		// from being bundled into the web interface and causing runtime errors.
 		rollupOptions: {
+			external: ['electron'],
 			input: {
 				// Single entry point that handles routing to mobile/desktop
 				main: path.join(__dirname, 'src/web/index.html'),


### PR DESCRIPTION
## Description

The remote control web server is serving the Electron renderer build which includes a preload chunk (\preload-*.js\) that contains Electron-specific code. This chunk calls \getOwnerBrowserWindow\ from a WebSocket event handler, which is an Electron API that is not available in regular browser contexts.

When a user (mobile or desktop browser) opens the remote control URL, the browser loads this chunk and crashes with:
\\\
Cannot read properties of undefined (reading 'getOwnerBrowserWindow')
\\\

## Root Cause

1. The web build (\ite.config.web.mts\) was not excluding the \electron\ module, allowing Electron-specific code to be bundled into the web interface build
2. The \esolveWebAssetsPath\ function in \WebServer.ts\ only looked for \dist/web/\ but the production build outputs to \dist/web-desktop/\

## Changes

### \ite.config.web.mts\
- Added \external: ['electron']\ to \ollupOptions\ to prevent the \electron\ module from being bundled into the web build. This ensures Electron-specific APIs (like \getOwnerBrowserWindow\) are not included in the JavaScript served to browser clients.

### \src/main/web-server/WebServer.ts\
- Added \dist/web-desktop/\ paths to \esolveWebAssetsPath\ for compatibility with the production build output directory

## Testing

1. Build the web app: \
pm run build:web\
2. Start Maestro
3. Enable the web interface (OFFLINE → LIVE)
4. Open the remote control URL in a mobile browser
5. Verify the dashboard loads without the \getOwnerBrowserWindow\ error

Fixes #1344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production asset discovery across additional web build locations.
  * Prevented Electron-specific code from being included in browser builds, improving web build compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->