### PR TITLE
fix(thinking): drop stale thinking chunks that outlive their turn's answer

### DIFF
--- a/src/__tests__/renderer/hooks/agent/internal/useAgentThinkingListener.test.tsx
+++ b/src/__tests__/renderer/hooks/agent/internal/useAgentThinkingListener.test.tsx
@@ -129,12 +129,29 @@ describe('useAgentThinkingListener', () => {
 	// Regression: the fast (rAF) writer must not append a thinking log below the
 	// turn's answer, which the slow (200ms batched) writer flushed in between.
 	describe('stale straggler after the turn answer landed', () => {
-		function makeLog(source: LogEntry['source'], text: string, id: string): LogEntry {
-			return { id, timestamp: 1, source, text };
+		function makeLog(
+			source: LogEntry['source'],
+			text: string,
+			id: string,
+			timestamp = 1
+		): LogEntry {
+			return { id, timestamp, source, text };
 		}
 
-		it('drops the chunk when the last log is the turn stdout answer', () => {
-			const logs = [makeLog('user', 'prompt', 'l1'), makeLog('stdout', 'final answer', 'l2')];
+		/**
+		 * Reproduce the real interleaving: the chunk is buffered FIRST, then the
+		 * 200ms batch flushes the answer, then the rAF fires. The stdout log must
+		 * therefore carry a timestamp LATER than the moment buffering started -
+		 * that ordering is exactly what marks the chunk stale. Placing the answer
+		 * with an earlier timestamp would instead model an intermediate assistant
+		 * message, which must NOT drop the chunk (see the mid-turn cases below).
+		 */
+		function landAnswerAfterBuffering(logs: LogEntry[], answerText: string): LogEntry[] {
+			return [...logs, makeLog('stdout', answerText, 'answer', Date.now() + 1000)];
+		}
+
+		it('drops the chunk when the turn stdout answer landed after buffering', () => {
+			const logs = landAnswerAfterBuffering([makeLog('user', 'prompt', 'l1')], 'final answer');
 			const tab = createMockAITab({ id: 'tab-1', showThinking: 'on', logs });
 			const session = createMockSession({ id: 'sess-1', aiTabs: [tab] });
 			useSessionStore.setState({ sessions: [session] } as any);
@@ -147,6 +164,31 @@ describe('useAgentThinkingListener', () => {
 			expect(tabAfter.logs).toHaveLength(2);
 			expect(tabAfter.logs.some((l) => l.source === 'thinking')).toBe(false);
 			expect(tabAfter.logs).toEqual(logs);
+		});
+
+		// Greptile P1 on PR #1347: claude-code and factory-droid stream at MESSAGE
+		// granularity, so an intermediate assistant message flushes as stdout
+		// mid-turn and more reasoning legitimately follows it. A source-only guard
+		// treated that as the final answer and silenced thinking for the rest of
+		// the turn.
+		it('still appends reasoning that arrives AFTER an intermediate stdout message', () => {
+			const logs = [
+				makeLog('user', 'prompt', 'l1'),
+				makeLog('stdout', 'intermediate assistant message', 'l2'),
+			];
+			const tab = createMockAITab({ id: 'tab-1', showThinking: 'on', logs });
+			const session = createMockSession({ id: 'sess-1', aiTabs: [tab] });
+			useSessionStore.setState({ sessions: [session] } as any);
+
+			renderHook(() => useAgentThinkingListener());
+			// Buffered AFTER that stdout already existed, so it is new content.
+			handler!('sess-1-ai-tab-1', 'more reasoning');
+			flushRaf();
+
+			const tabAfter = useSessionStore.getState().sessions[0].aiTabs[0];
+			expect(tabAfter.logs).toHaveLength(3);
+			expect(tabAfter.logs[2].source).toBe('thinking');
+			expect(tabAfter.logs[2].text).toBe('more reasoning');
 		});
 
 		it('still appends when the last log is the user prompt (normal turn start)', () => {
@@ -188,10 +230,10 @@ describe('useAgentThinkingListener', () => {
 		});
 
 		it('drops the stale chunk in sticky mode but keeps existing thinking logs', () => {
-			const logs = [
-				makeLog('thinking', 'earlier reasoning', 'l1'),
-				makeLog('stdout', 'final answer', 'l2'),
-			];
+			const logs = landAnswerAfterBuffering(
+				[makeLog('thinking', 'earlier reasoning', 'l1')],
+				'final answer'
+			);
 			const tab = createMockAITab({ id: 'tab-1', showThinking: 'sticky', logs });
 			const session = createMockSession({ id: 'sess-1', aiTabs: [tab] });
 			useSessionStore.setState({ sessions: [session] } as any);

--- a/src/__tests__/renderer/hooks/agent/internal/useAgentThinkingListener.test.tsx
+++ b/src/__tests__/renderer/hooks/agent/internal/useAgentThinkingListener.test.tsx
@@ -4,6 +4,7 @@ import { useAgentThinkingListener } from '../../../../../renderer/hooks/agent/in
 import { useSessionStore } from '../../../../../renderer/stores/sessionStore';
 import { createMockSession } from '../../../../helpers/mockSession';
 import { createMockAITab } from '../../../../helpers/mockTab';
+import type { LogEntry } from '../../../../../renderer/types';
 
 let handler: ((sessionId: string, content: string) => void) | undefined;
 const mockUnsubscribe = vi.fn();
@@ -123,6 +124,105 @@ describe('useAgentThinkingListener', () => {
 
 		flushRaf();
 		expect(useSessionStore.getState().sessions[0].aiTabs[0].logs).toHaveLength(0);
+	});
+
+	// Regression: the fast (rAF) writer must not append a thinking log below the
+	// turn's answer, which the slow (200ms batched) writer flushed in between.
+	describe('stale straggler after the turn answer landed', () => {
+		function makeLog(source: LogEntry['source'], text: string, id: string): LogEntry {
+			return { id, timestamp: 1, source, text };
+		}
+
+		it('drops the chunk when the last log is the turn stdout answer', () => {
+			const logs = [makeLog('user', 'prompt', 'l1'), makeLog('stdout', 'final answer', 'l2')];
+			const tab = createMockAITab({ id: 'tab-1', showThinking: 'on', logs });
+			const session = createMockSession({ id: 'sess-1', aiTabs: [tab] });
+			useSessionStore.setState({ sessions: [session] } as any);
+
+			renderHook(() => useAgentThinkingListener());
+			handler!('sess-1-ai-tab-1', 'final ans');
+			flushRaf();
+
+			const tabAfter = useSessionStore.getState().sessions[0].aiTabs[0];
+			expect(tabAfter.logs).toHaveLength(2);
+			expect(tabAfter.logs.some((l) => l.source === 'thinking')).toBe(false);
+			expect(tabAfter.logs).toEqual(logs);
+		});
+
+		it('still appends when the last log is the user prompt (normal turn start)', () => {
+			const tab = createMockAITab({
+				id: 'tab-1',
+				showThinking: 'on',
+				logs: [makeLog('user', 'prompt', 'l1')],
+			});
+			const session = createMockSession({ id: 'sess-1', aiTabs: [tab] });
+			useSessionStore.setState({ sessions: [session] } as any);
+
+			renderHook(() => useAgentThinkingListener());
+			handler!('sess-1-ai-tab-1', 'thinking...');
+			flushRaf();
+
+			const tabAfter = useSessionStore.getState().sessions[0].aiTabs[0];
+			expect(tabAfter.logs).toHaveLength(2);
+			expect(tabAfter.logs[1].source).toBe('thinking');
+			expect(tabAfter.logs[1].text).toBe('thinking...');
+		});
+
+		it('still coalesces into an open thinking log', () => {
+			const tab = createMockAITab({
+				id: 'tab-1',
+				showThinking: 'on',
+				logs: [makeLog('user', 'prompt', 'l1'), makeLog('thinking', 'hello ', 'l2')],
+			});
+			const session = createMockSession({ id: 'sess-1', aiTabs: [tab] });
+			useSessionStore.setState({ sessions: [session] } as any);
+
+			renderHook(() => useAgentThinkingListener());
+			handler!('sess-1-ai-tab-1', 'world');
+			flushRaf();
+
+			const tabAfter = useSessionStore.getState().sessions[0].aiTabs[0];
+			expect(tabAfter.logs).toHaveLength(2);
+			expect(tabAfter.logs[1].source).toBe('thinking');
+			expect(tabAfter.logs[1].text).toBe('hello world');
+		});
+
+		it('drops the stale chunk in sticky mode but keeps existing thinking logs', () => {
+			const logs = [
+				makeLog('thinking', 'earlier reasoning', 'l1'),
+				makeLog('stdout', 'final answer', 'l2'),
+			];
+			const tab = createMockAITab({ id: 'tab-1', showThinking: 'sticky', logs });
+			const session = createMockSession({ id: 'sess-1', aiTabs: [tab] });
+			useSessionStore.setState({ sessions: [session] } as any);
+
+			renderHook(() => useAgentThinkingListener());
+			handler!('sess-1-ai-tab-1', 'final ans');
+			flushRaf();
+
+			const tabAfter = useSessionStore.getState().sessions[0].aiTabs[0];
+			expect(tabAfter.logs).toEqual(logs);
+			expect(tabAfter.logs.filter((l) => l.source === 'thinking')).toHaveLength(1);
+		});
+
+		it('still appends when the last log is tool activity (thinking resumes mid-turn)', () => {
+			const tab = createMockAITab({
+				id: 'tab-1',
+				showThinking: 'on',
+				logs: [makeLog('user', 'prompt', 'l1'), makeLog('tool', 'Read(file.ts)', 'l2')],
+			});
+			const session = createMockSession({ id: 'sess-1', aiTabs: [tab] });
+			useSessionStore.setState({ sessions: [session] } as any);
+
+			renderHook(() => useAgentThinkingListener());
+			handler!('sess-1-ai-tab-1', 'back to thinking');
+			flushRaf();
+
+			const tabAfter = useSessionStore.getState().sessions[0].aiTabs[0];
+			expect(tabAfter.logs).toHaveLength(3);
+			expect(tabAfter.logs[2].source).toBe('thinking');
+			expect(tabAfter.logs[2].text).toBe('back to thinking');
+		});
 	});
 
 	it('ignores non-AI session ids', () => {

--- a/src/renderer/hooks/agent/internal/useAgentThinkingListener.ts
+++ b/src/renderer/hooks/agent/internal/useAgentThinkingListener.ts
@@ -10,6 +10,14 @@
  * - 'off':  the chunk is dropped.
  * - 'on'/'sticky': the chunk is appended to the last `source: 'thinking'` log
  *   if present, otherwise a new thinking log is created.
+ * - Stale-straggler drop: if the tab's last log is already the turn's
+ *   `source: 'stdout'` answer, the chunk is dropped instead of creating a new
+ *   thinking log below that answer. This hook writes on a ~16ms rAF while the
+ *   answer arrives via the 200ms batched flush in useBatchedSessionUpdates,
+ *   whose inline clear point owns the mid-turn removal of thinking logs; a
+ *   chunk buffered just before that flush would otherwise land just after it.
+ *   Applies in 'sticky' mode too - sticky preserves thinking logs already on
+ *   screen, it does not entitle a stale buffer to materialize a new one.
  *
  * Concatenated-tool-name guard: malformed chunks containing a stream of
  * back-to-back tool names get dropped (or *replace* an existing log) rather
@@ -105,6 +113,15 @@ export function useAgentThinkingListener(): void {
 									//      tool names → replace last log with this chunk only
 									//      (drop the prior text rather than worsen the noise).
 									const lastLog = targetTab.logs[targetTab.logs.length - 1];
+
+									// A chunk that outlives its turn's answer is stale: the inline clear
+									// point in useBatchedSessionUpdates already removed the thinking block
+									// this chunk belonged to and appended the answer below it. Appending
+									// now would resurrect a stale prefix of that same answer underneath
+									// it. Tested explicitly (not as !isContinuation) because a
+									// self-contained thinking card is a non-continuation too.
+									if (lastLog?.source === 'stdout') continue;
+
 									// Same rule as every other coalescing site: same source AND not a
 									// self-contained card. See utils/logEntries.ts.
 									const isContinuation = canAppendToLogEntry(lastLog, 'thinking');

--- a/src/renderer/hooks/agent/internal/useAgentThinkingListener.ts
+++ b/src/renderer/hooks/agent/internal/useAgentThinkingListener.ts
@@ -36,7 +36,13 @@ import { canAppendToLogEntry } from '../../../utils/logEntries';
 import type { LogEntry } from '../../../types';
 
 export function useAgentThinkingListener(): void {
-	const thinkingChunkBufferRef = useRef<Map<string, string>>(new Map());
+	// Buffered text plus the moment buffering STARTED for that tab. The timestamp
+	// is what separates a chunk that outlived its turn's answer (stale) from
+	// reasoning that legitimately follows an intermediate assistant message: only
+	// the former was already in hand before the stdout log appeared.
+	const thinkingChunkBufferRef = useRef<Map<string, { text: string; bufferedAt: number }>>(
+		new Map()
+	);
 	const thinkingChunkRafIdRef = useRef<number | null>(null);
 	const ownedGate = useOwnedSessionGate();
 
@@ -55,8 +61,12 @@ export function useAgentThinkingListener(): void {
 				const tabId = aiTabMatch[2];
 				const bufferKey = `${actualSessionId}:${tabId}`;
 
-				const existingContent = thinkingChunkBufferRef.current.get(bufferKey) || '';
-				thinkingChunkBufferRef.current.set(bufferKey, existingContent + content);
+				const existing = thinkingChunkBufferRef.current.get(bufferKey);
+				thinkingChunkBufferRef.current.set(bufferKey, {
+					text: (existing?.text ?? '') + content,
+					// Keep the FIRST chunk's timestamp for the whole coalesced batch.
+					bufferedAt: existing?.bufferedAt ?? Date.now(),
+				});
 
 				if (thinkingChunkRafIdRef.current === null) {
 					thinkingChunkRafIdRef.current = requestAnimationFrame(() => {
@@ -87,7 +97,8 @@ export function useAgentThinkingListener(): void {
 								const isInteractive = s.claudeInteractive?.mode === 'interactive';
 
 								let updatedTabs = s.aiTabs;
-								for (const [key, bufferedContent] of chunksToProcess) {
+								for (const [key, buffered] of chunksToProcess) {
+									const bufferedContent = buffered.text;
 									const [chunkSessionId, chunkTabId] = key.split(':');
 									if (chunkSessionId !== s.id) continue;
 
@@ -120,7 +131,17 @@ export function useAgentThinkingListener(): void {
 									// now would resurrect a stale prefix of that same answer underneath
 									// it. Tested explicitly (not as !isContinuation) because a
 									// self-contained thinking card is a non-continuation too.
-									if (lastLog?.source === 'stdout') continue;
+									//
+									// The timestamp comparison is what keeps this narrow. Claude Code and
+									// Factory Droid stream at MESSAGE granularity, so an intermediate
+									// assistant message flushes as stdout mid-turn and more reasoning can
+									// legitimately follow it. Dropping on `source === 'stdout'` alone
+									// silenced that reasoning for the rest of the turn. Only a chunk that
+									// was ALREADY buffered when the stdout landed is stale; one that
+									// arrived afterwards is new content and must be appended.
+									const outlivedItsAnswer =
+										lastLog?.source === 'stdout' && lastLog.timestamp >= buffered.bufferedAt;
+									if (outlivedItsAnswer) continue;
 
 									// Same rule as every other coalescing site: same source AND not a
 									// self-contained card. See utils/logEntries.ts.


### PR DESCRIPTION
Closes finding T1.

## Problem

A thinking log could survive **below** the final answer, duplicating it. Two writers hit the same `tab.logs` array on different schedules:

| Writer | Path | Schedule |
| --- | --- | --- |
| thinking chunks | `useAgentThinkingListener` | `requestAnimationFrame`, ~16ms |
| final answer | `useBatchedSessionUpdates` | batched flush, 200ms |

The mid-turn clear point lives only in the slow writer. The fast writer's non-continuation branch appended unconditionally, so a chunk buffered just before a flush was applied *after* it, landing below the answer it duplicated.

## Fix

Refuse to append a thinking log when the tab's last log is already the turn's `stdout` answer - a late chunk for an answered turn is stale by definition.

Deliberately NOT changed: the 200ms flush interval (documented as load-bearing for input latency), and claude-code's forward-all-partials behavior in `StdoutHandler` (its comment records that gating on `isReasoning` was already tried and silenced the thinking display for ordinary turns).

## Testing

Scoped tests only, per repo convention. Adds 100 lines to `useAgentThinkingListener.test.tsx` covering the race directly: buffered chunk, stdout flush first, then the rAF fires - asserts no thinking log is appended after the answer. Also asserts the normal path and continuation coalescing still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated thinking messages from reappearing after an answer is displayed.
  * Preserved new thinking updates received after intermediate answers.
  * Ensured correct thinking behavior in standard and sticky modes, including after prompts or tool activity.
  * Improved handling of batched thinking and answer updates.

* **Tests**
  * Added regression coverage for stale thinking messages, intermediate responses, and message coalescing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->