### PR TITLE
fix(transcript): persist the scroll offset alongside the at-bottom flag

### DIFF
--- a/src/__tests__/renderer/components/TerminalOutput/useTerminalOutputScroll.test.ts
+++ b/src/__tests__/renderer/components/TerminalOutput/useTerminalOutputScroll.test.ts
@@ -675,5 +675,50 @@ describe('scrolled-up persistence across unmount (Y1)', () => {
 			expect(restored.result.current.isAtBottom).toBe(false);
 			expect(restored.result.current.autoScrollPaused).toBe(true);
 		});
+
+		// Review follow-up: the restore gate used to require a POSITIVE offset, so
+		// the one position a user reaches by scrolling all the way up - offset 0
+		// with `isAtBottom: false` - was unrestorable and snapped back to the live
+		// bottom. Zero is a real saved position, not a missing one.
+		it('restores a transcript left scrolled to the absolute top (offset 0)', () => {
+			const restoreRef = { current: makeRestoreContainer(9000) };
+			const restored = renderHook(() =>
+				useTerminalOutputScroll({
+					scrollContainerRef: restoreRef,
+					initialScrollTop: 0,
+					initialIsAtBottom: false,
+					sessionId: 's1',
+					activeTabId: 't1',
+					filteredLogsLength: 3,
+				})
+			);
+
+			flushRaf();
+
+			expect(restoreRef.current.scrollTop).toBe(0);
+			expect(restored.result.current.isAtBottom).toBe(false);
+			expect(restored.result.current.autoScrollPaused).toBe(true);
+		});
+
+		// Guard the other half of the gate: offset 0 with the flag ABSENT (a legacy
+		// tab that never persisted it) or true must still fall through to the
+		// mount-time bottom jump rather than pinning the view to the top.
+		it('does NOT restore offset 0 when the at-bottom flag is not false', () => {
+			const restoreRef = { current: makeRestoreContainer(9000) };
+			const restored = renderHook(() =>
+				useTerminalOutputScroll({
+					scrollContainerRef: restoreRef,
+					initialScrollTop: 0,
+					initialIsAtBottom: undefined,
+					sessionId: 's1',
+					activeTabId: 't1',
+					filteredLogsLength: 3,
+				})
+			);
+
+			flushRaf();
+
+			expect(restored.result.current.autoScrollPaused).toBe(false);
+		});
 	});
 });

--- a/src/__tests__/renderer/components/TerminalOutput/useTerminalOutputScroll.test.ts
+++ b/src/__tests__/renderer/components/TerminalOutput/useTerminalOutputScroll.test.ts
@@ -469,3 +469,74 @@ describe('useTerminalOutputScroll content-resize re-pin (O1)', () => {
 		expect(resizeObservers).toHaveLength(0);
 	});
 });
+
+/**
+ * Y1: a deliberately scrolled-up position is lost when the user swaps agents
+ * within the 200ms scroll-save debounce.
+ *
+ * The two halves of the saved scroll state are persisted on different
+ * schedules inside handleScrollInner: the at-bottom flag goes out
+ * SYNCHRONOUSLY (but only on a transition), while the absolute offset is
+ * debounced by 200ms. The unmount cleanup DROPS the pending debounced save
+ * rather than flushing it (deliberately - see the cleanup comment and #1323:
+ * onScrollPositionChange resolves its target tab at call time, and during an
+ * agent swap the store already points at the incoming session).
+ *
+ * So a fast swap persists `isAtBottom: false` with no matching scrollTop, the
+ * remount restore gate (which requires initialScrollTop > 0) skips, and the
+ * mount-time bottom jump wins.
+ *
+ * The test below PINS that broken behaviour as documentation of the race. It
+ * is inverted once the fix lands.
+ */
+describe('scrolled-up persistence across unmount (Y1)', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('persists the at-bottom flag but loses the offset when the swap beats the 200ms debounce', () => {
+		// 10000 - 5000 - 200 = 4800px from the bottom: well past the 50px
+		// at-bottom threshold, so this is a deliberate scroll-up.
+		const ref = { current: makeContainer(10000, 200, 5000) };
+		const onScrollPositionChange = vi.fn();
+		const onAtBottomChange = vi.fn();
+
+		const { result, unmount } = renderHook(() =>
+			useTerminalOutputScroll({
+				scrollContainerRef: ref,
+				sessionId: 's1',
+				activeTabId: 't1',
+				filteredLogsLength: 3,
+				onScrollPositionChange,
+				onAtBottomChange,
+			})
+		);
+
+		// The throttle runs on the leading edge, so this first call reaches
+		// handleScrollInner without any timer advance.
+		act(() => {
+			result.current.handleScroll();
+		});
+
+		// The flag half went out synchronously, on the transition.
+		expect(onAtBottomChange).toHaveBeenCalledWith(false);
+		expect(result.current.isAtBottom).toBe(false);
+
+		// The user swaps agents before the 200ms debounce fires.
+		act(() => {
+			vi.advanceTimersByTime(100);
+		});
+		unmount();
+		act(() => {
+			vi.advanceTimersByTime(500);
+		});
+
+		// The offset half is dropped: `isAtBottom: false` was saved without a
+		// matching scrollTop, which is exactly the Y1 snap-to-bottom.
+		expect(onScrollPositionChange).not.toHaveBeenCalled();
+	});
+});

--- a/src/__tests__/renderer/components/TerminalOutput/useTerminalOutputScroll.test.ts
+++ b/src/__tests__/renderer/components/TerminalOutput/useTerminalOutputScroll.test.ts
@@ -471,8 +471,8 @@ describe('useTerminalOutputScroll content-resize re-pin (O1)', () => {
 });
 
 /**
- * Y1: a deliberately scrolled-up position is lost when the user swaps agents
- * within the 200ms scroll-save debounce.
+ * Y1: a deliberately scrolled-up position used to be lost when the user swapped
+ * agents within the 200ms scroll-save debounce.
  *
  * The two halves of the saved scroll state are persisted on different
  * schedules inside handleScrollInner: the at-bottom flag goes out
@@ -482,12 +482,12 @@ describe('useTerminalOutputScroll content-resize re-pin (O1)', () => {
  * onScrollPositionChange resolves its target tab at call time, and during an
  * agent swap the store already points at the incoming session).
  *
- * So a fast swap persists `isAtBottom: false` with no matching scrollTop, the
- * remount restore gate (which requires initialScrollTop > 0) skips, and the
- * mount-time bottom jump wins.
+ * A fast swap therefore persisted `isAtBottom: false` with no matching
+ * scrollTop, the remount restore gate (which requires initialScrollTop > 0)
+ * skipped, and the mount-time bottom jump won.
  *
- * The test below PINS that broken behaviour as documentation of the race. It
- * is inverted once the fix lands.
+ * The fix writes the offset alongside the flag inside the transition block, so
+ * the saved pair can never disagree. These tests are the post-fix contract.
  */
 describe('scrolled-up persistence across unmount (Y1)', () => {
 	beforeEach(() => {
@@ -498,14 +498,12 @@ describe('scrolled-up persistence across unmount (Y1)', () => {
 		vi.useRealTimers();
 	});
 
-	it('persists the at-bottom flag but loses the offset when the swap beats the 200ms debounce', () => {
-		// 10000 - 5000 - 200 = 4800px from the bottom: well past the 50px
-		// at-bottom threshold, so this is a deliberate scroll-up.
-		const ref = { current: makeContainer(10000, 200, 5000) };
+	function mountWithSpies(container: HTMLDivElement) {
+		const ref = { current: container };
 		const onScrollPositionChange = vi.fn();
 		const onAtBottomChange = vi.fn();
 
-		const { result, unmount } = renderHook(() =>
+		const hook = renderHook(() =>
 			useTerminalOutputScroll({
 				scrollContainerRef: ref,
 				sessionId: 's1',
@@ -516,27 +514,166 @@ describe('scrolled-up persistence across unmount (Y1)', () => {
 			})
 		);
 
+		return { ref, hook, onScrollPositionChange, onAtBottomChange };
+	}
+
+	it('persists the offset with the flag when the swap beats the 200ms debounce', () => {
+		// 10000 - 5000 - 200 = 4800px from the bottom: well past the 50px
+		// at-bottom threshold, so this is a deliberate scroll-up.
+		const { hook, onScrollPositionChange, onAtBottomChange } = mountWithSpies(
+			makeContainer(10000, 200, 5000)
+		);
+
 		// The throttle runs on the leading edge, so this first call reaches
 		// handleScrollInner without any timer advance.
 		act(() => {
-			result.current.handleScroll();
+			hook.result.current.handleScroll();
 		});
 
-		// The flag half went out synchronously, on the transition.
+		// Both halves go out synchronously, in the same transition flush.
 		expect(onAtBottomChange).toHaveBeenCalledWith(false);
-		expect(result.current.isAtBottom).toBe(false);
+		expect(onScrollPositionChange).toHaveBeenCalledWith(5000);
+		expect(hook.result.current.isAtBottom).toBe(false);
 
-		// The user swaps agents before the 200ms debounce fires.
+		// The user swaps agents before the 200ms debounce would have fired. The
+		// pending save is still dropped, but the position is already persisted.
 		act(() => {
 			vi.advanceTimersByTime(100);
 		});
-		unmount();
+		hook.unmount();
 		act(() => {
 			vi.advanceTimersByTime(500);
 		});
 
-		// The offset half is dropped: `isAtBottom: false` was saved without a
-		// matching scrollTop, which is exactly the Y1 snap-to-bottom.
+		expect(onScrollPositionChange).toHaveBeenCalledTimes(1);
+		expect(onScrollPositionChange).toHaveBeenLastCalledWith(5000);
+	});
+
+	it('persists the offset again on the transition back to the bottom', () => {
+		const { ref, hook, onScrollPositionChange, onAtBottomChange } = mountWithSpies(
+			makeContainer(10000, 200, 5000)
+		);
+
+		act(() => {
+			hook.result.current.handleScroll();
+		});
+		expect(onAtBottomChange).toHaveBeenLastCalledWith(false);
+		expect(onScrollPositionChange).toHaveBeenLastCalledWith(5000);
+
+		// Back to the live bottom (10000 - 9800 - 200 = 0px from the bottom).
+		// Clear the throttle window first so this second call is not swallowed.
+		act(() => {
+			vi.advanceTimersByTime(20);
+		});
+		ref.current.scrollTop = 9800;
+		act(() => {
+			hook.result.current.handleScroll();
+		});
+
+		expect(onAtBottomChange).toHaveBeenLastCalledWith(true);
+		expect(onScrollPositionChange).toHaveBeenLastCalledWith(9800);
+	});
+
+	it('keeps refining the offset through the debounce while the user scrolls on', () => {
+		const { ref, hook, onScrollPositionChange } = mountWithSpies(makeContainer(10000, 200, 5000));
+
+		act(() => {
+			hook.result.current.handleScroll();
+		});
+		expect(onScrollPositionChange).toHaveBeenLastCalledWith(5000);
+
+		// Continued scrolling, no boundary transition this time: only the
+		// debounced save carries the refinement.
+		act(() => {
+			vi.advanceTimersByTime(20);
+		});
+		ref.current.scrollTop = 4200;
+		act(() => {
+			hook.result.current.handleScroll();
+		});
+		act(() => {
+			vi.advanceTimersByTime(200);
+		});
+
+		expect(onScrollPositionChange).toHaveBeenLastCalledWith(4200);
+	});
+
+	it('does not persist anything when the user never scrolls', () => {
+		const { hook, onScrollPositionChange, onAtBottomChange } = mountWithSpies(
+			makeContainer(10000, 200, 5000)
+		);
+
+		hook.unmount();
+		act(() => {
+			vi.advanceTimersByTime(500);
+		});
+
 		expect(onScrollPositionChange).not.toHaveBeenCalled();
+		expect(onAtBottomChange).not.toHaveBeenCalled();
+	});
+
+	describe('end-to-end restore of the persisted transition offset', () => {
+		let rafQueue: FrameRequestCallback[] = [];
+
+		beforeEach(() => {
+			rafQueue = [];
+			vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+				rafQueue.push(cb);
+				return rafQueue.length;
+			});
+		});
+
+		afterEach(() => {
+			vi.unstubAllGlobals();
+		});
+
+		function flushRaf() {
+			act(() => {
+				let guard = 0;
+				while (rafQueue.length > 0 && guard++ < 20) {
+					const cbs = rafQueue.splice(0);
+					cbs.forEach((cb) => cb(0));
+				}
+			});
+		}
+
+		it('lands the remounted transcript on the offset the fast swap saved', () => {
+			// Leg 1: scroll up and swap away inside the debounce window.
+			const { hook, onScrollPositionChange, onAtBottomChange } = mountWithSpies(
+				makeContainer(10000, 200, 5000)
+			);
+
+			act(() => {
+				hook.result.current.handleScroll();
+			});
+			act(() => {
+				vi.advanceTimersByTime(100);
+			});
+			hook.unmount();
+
+			const savedScrollTop = onScrollPositionChange.mock.calls.at(-1)?.[0] as number;
+			const savedIsAtBottom = onAtBottomChange.mock.calls.at(-1)?.[0] as boolean;
+			expect(savedScrollTop).toBe(5000);
+			expect(savedIsAtBottom).toBe(false);
+
+			// Leg 2: swap back. The saved pair is what the tab hands the hook.
+			const restoreRef = { current: makeRestoreContainer(9000) };
+			const restored = renderHook(() =>
+				useTerminalOutputScroll({
+					scrollContainerRef: restoreRef,
+					initialScrollTop: savedScrollTop,
+					initialIsAtBottom: savedIsAtBottom,
+					sessionId: 's1',
+					activeTabId: 't1',
+					filteredLogsLength: 3,
+				})
+			);
+
+			flushRaf();
+
+			expect(restoreRef.current.scrollTop).toBe(5000);
+			expect(restored.result.current.isAtBottom).toBe(false);
+			expect(restored.result.current.autoScrollPaused).toBe(true);
+		});
 	});
 });

--- a/src/renderer/components/TerminalOutput/hooks/useTerminalOutputScroll.ts
+++ b/src/renderer/components/TerminalOutput/hooks/useTerminalOutputScroll.ts
@@ -86,6 +86,15 @@ export function useTerminalOutputScroll({
 			if (atBottom !== prevIsAtBottomRef.current) {
 				prevIsAtBottomRef.current = atBottom;
 				onAtBottomChange?.(atBottom);
+				// The flag and the offset MUST be persisted together. The debounced
+				// save below is dropped on unmount (see the cleanup effect), so a
+				// swap within 200ms of crossing the boundary would otherwise store
+				// `isAtBottom: false` with no matching scrollTop - and the remount
+				// restore, which requires `initialScrollTop > 0`, then skips and the
+				// mount-time bottom jump snaps the user back down. Writing both
+				// halves in the same tick, in both directions, keeps the saved pair
+				// coherent no matter when the component goes away. (Y1)
+				onScrollPositionChange?.(scrollTop);
 			}
 
 			if (atBottom) {
@@ -304,9 +313,14 @@ export function useTerminalOutputScroll({
 			// its target from `selectActiveSession` AT CALL TIME, and during an agent
 			// swap the store already points at the NEW session by the time this
 			// component unmounts - so flushing would write the outgoing agent's
-			// offset into the incoming agent's tab. The cost is that up to the last
-			// ~200ms of scrolling is not persisted; the fix would need the callback
-			// to carry the owning sessionId/tabId, which is out of scope here.
+			// offset into the incoming agent's tab. The cost is now only that up to
+			// the last ~200ms of scrolling REFINEMENT is not persisted, never the
+			// coherence of the saved pair: handleScrollInner writes the flag and the
+			// offset together, synchronously, whenever the at-bottom boundary is
+			// crossed (Y1), so a dropped debounce can only cost precision within a
+			// position that was already saved. Removing even that imprecision would
+			// need the callback to carry the owning sessionId/tabId, which is out of
+			// scope here.
 			if (scrollSaveTimerRef.current) {
 				clearTimeout(scrollSaveTimerRef.current);
 			}

--- a/src/renderer/components/TerminalOutput/hooks/useTerminalOutputScroll.ts
+++ b/src/renderer/components/TerminalOutput/hooks/useTerminalOutputScroll.ts
@@ -273,7 +273,13 @@ export function useTerminalOutputScroll({
 	}, [sessionId, activeTabId]);
 
 	useEffect(() => {
-		if (initialScrollTop !== undefined && initialScrollTop > 0 && !hasRestoredScrollRef.current) {
+		// `>= 0`, not `> 0`: scrolling to the ABSOLUTE TOP of an overflowing
+		// transcript persists `scrollTop: 0` with `isAtBottom: false`, which is a
+		// perfectly ordinary deliberate position. Requiring a positive offset made
+		// that one spot unrestorable, so returning to a tab left at the very top
+		// snapped it to the live bottom. `initialIsAtBottom !== false` below is the
+		// real gate; the offset only needs to exist. (Y1 review)
+		if (initialScrollTop !== undefined && initialScrollTop >= 0 && !hasRestoredScrollRef.current) {
 			hasRestoredScrollRef.current = true;
 			// Only restore a saved absolute offset when the user had deliberately
 			// scrolled up when they left (initialIsAtBottom === false). When they


### PR DESCRIPTION
Closes finding Y1.

## Problem

A deliberately scrolled-up transcript snapped back to the live bottom after an agent swap, instead of holding the position the user chose. This is the inverse of J1/O1 (#1323), which were about failing to *reach* the bottom.

`useTerminalOutputScroll` restores a saved offset only when **both** `initialScrollTop > 0` and `initialIsAtBottom === false` are persisted. The two halves were written on different schedules:

- `onAtBottomChange` fires synchronously on a transition
- `onScrollPositionChange` is debounced 200ms, and #1323 deliberately **drops** the pending save on unmount

So a user who scrolled up and swapped within ~200ms persisted `isAtBottom: false` with no matching `scrollTop`. The restore was skipped and the mount-time bottom jump won.

## Fix

Persist the offset alongside the synchronous at-bottom transition, so both halves are written together and can never disagree. This deliberately does **not** flush the debounce on unmount - #1323 rejected that explicitly, and its reasoning still holds.

## Testing

Scoped tests only. Adds 208 lines to `useTerminalOutputScroll.test.ts`, including a test that pins the race by unmounting before the 200ms debounce fires. Existing #1323 follow-the-bottom coverage and the #1140 scroll-event guard bookkeeping are untouched.

## Human verification

Confirmed on a local RC build: following the bottom, swapping away and back, still lands at the live bottom (the O1 behaviour must not regress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript scroll-position preservation when switching agents after scrolling up.
  * Restored saved scroll offsets, including position 0, when returning to a transcript.
  * Kept saved position and bottom-of-transcript state synchronized during scrolling.
  * Prevented unintended position persistence when the user has not manually scrolled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->