### PR TITLE
refactor(main): decompose src/main/index.ts into focused modules

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1058,7 +1058,8 @@ type UnifiedTabRef = { type: 'ai' | 'file'; id: string };
 
 // Discriminated union for rendering
 type UnifiedTab =
-	{ type: 'ai'; id: string; data: AITab } | { type: 'file'; id: string; data: FilePreviewTab };
+	| { type: 'ai'; id: string; data: AITab }
+	| { type: 'file'; id: string; data: FilePreviewTab };
 ```
 
 ### Session Fields

--- a/docs/agent-guides/MAIN-LIFECYCLE.md
+++ b/docs/agent-guides/MAIN-LIFECYCLE.md
@@ -385,7 +385,13 @@ autoUpdater.allowPrerelease = false; // Stable channel only
 ```typescript
 type UpdateStatus = {
 	status:
-		'idle' | 'checking' | 'available' | 'not-available' | 'downloading' | 'downloaded' | 'error';
+		| 'idle'
+		| 'checking'
+		| 'available'
+		| 'not-available'
+		| 'downloading'
+		| 'downloaded'
+		| 'error';
 	info?: UpdateInfo;
 	progress?: ProgressInfo;
 	error?: string;
@@ -511,7 +517,7 @@ const historyManager = getHistoryManager();
 
 ## IPC Handler Registration
 
-All IPC handlers are registered in `setupIpcHandlers()` within `src/main/index.ts`. Each handler module is a self-contained file in `src/main/ipc/handlers/`:
+All IPC handlers are registered in `setupIpcHandlers()` within `src/main/ipc/bootstrap/index.ts`, called once from `src/main/index.ts`'s `app.whenReady()` with a deps object of getter closures over its module-level state. Each handler module is a self-contained file in `src/main/ipc/handlers/`:
 
 | Registration Call                 | Handler Module      | Dependencies                                                         |
 | --------------------------------- | ------------------- | -------------------------------------------------------------------- |
@@ -560,7 +566,7 @@ Logger event forwarding is also set up to stream logs to the renderer.
 
 ## Process Listeners
 
-Set up in `setupProcessListeners()`, delegating to `src/main/process-listeners/index.ts`:
+Set up in `wireProcessListeners()` (`src/main/process-listeners-wiring/index.ts`), called once from `src/main/index.ts`'s `app.whenReady()`, delegating to `src/main/process-listeners/index.ts`:
 
 The process manager emits events for:
 
@@ -604,31 +610,37 @@ The `performCleanup()` function runs synchronously from `before-quit` (async ope
 
 ## Key Source Files
 
-| File                                         | Purpose                                                     |
-| -------------------------------------------- | ----------------------------------------------------------- |
-| `src/main/index.ts`                          | Entry point, startup sequence, IPC wiring                   |
-| `src/main/app-lifecycle/index.ts`            | Lifecycle module barrel                                     |
-| `src/main/app-lifecycle/window-manager.ts`   | BrowserWindow creation, crash detection, auto-updater init  |
-| `src/main/app-lifecycle/quit-handler.ts`     | Quit confirmation flow and cleanup                          |
-| `src/main/app-lifecycle/error-handlers.ts`   | Global uncaught exception handlers                          |
-| `src/main/app-lifecycle/cli-watcher.ts`      | CLI activity file watcher                                   |
-| `src/main/app-lifecycle/settings-watcher.ts` | External settings-file change detection                     |
-| `src/main/stores/write-tracker.ts`           | Stamps the app's own store writes so the watcher skips them |
-| `src/main/stores/index.ts`                   | Store module barrel                                         |
-| `src/main/stores/types.ts`                   | Store type definitions                                      |
-| `src/main/stores/instances.ts`               | Store initialization                                        |
-| `src/main/stores/getters.ts`                 | Store getter functions                                      |
-| `src/main/stores/defaults.ts`                | Store default values                                        |
-| `src/main/stores/utils.ts`                   | Store utilities (early settings, custom sync path)          |
-| `src/main/auto-updater.ts`                   | electron-updater integration                                |
-| `src/main/power-manager.ts`                  | System sleep prevention                                     |
-| `src/main/wakatime-manager.ts`               | WakaTime heartbeat integration                              |
-| `src/main/history-manager.ts`                | Per-session history storage and migration                   |
-| `src/main/process-manager/`                  | Process spawning (PTY + child_process)                      |
-| `src/main/process-listeners/`                | Process event routing                                       |
-| `src/main/ipc/handlers/`                     | All IPC handler modules                                     |
-| `src/main/utils/sentry.ts`                   | Sentry utilities and memory monitoring                      |
-| `src/main/utils/logger.ts`                   | Structured logging                                          |
+| File                                         | Purpose                                                                                                                            |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `src/main/index.ts`                          | Entry point, startup sequence, IPC wiring                                                                                          |
+| `src/main/app-lifecycle/index.ts`            | Lifecycle module barrel                                                                                                            |
+| `src/main/app-lifecycle/window-manager.ts`   | BrowserWindow creation, crash detection, auto-updater init                                                                         |
+| `src/main/app-lifecycle/quit-handler.ts`     | Quit confirmation flow and cleanup                                                                                                 |
+| `src/main/app-lifecycle/error-handlers.ts`   | Global uncaught exception handlers                                                                                                 |
+| `src/main/app-lifecycle/cli-watcher.ts`      | CLI activity file watcher                                                                                                          |
+| `src/main/app-lifecycle/settings-watcher.ts` | External settings-file change detection                                                                                            |
+| `src/main/stores/write-tracker.ts`           | Stamps the app's own store writes so the watcher skips them                                                                        |
+| `src/main/stores/index.ts`                   | Store module barrel                                                                                                                |
+| `src/main/stores/types.ts`                   | Store type definitions                                                                                                             |
+| `src/main/stores/instances.ts`               | Store initialization                                                                                                               |
+| `src/main/stores/getters.ts`                 | Store getter functions                                                                                                             |
+| `src/main/stores/defaults.ts`                | Store default values                                                                                                               |
+| `src/main/stores/utils.ts`                   | Store utilities (early settings, custom sync path)                                                                                 |
+| `src/main/auto-updater.ts`                   | electron-updater integration                                                                                                       |
+| `src/main/power-manager.ts`                  | System sleep prevention                                                                                                            |
+| `src/main/wakatime-manager.ts`               | WakaTime heartbeat integration                                                                                                     |
+| `src/main/history-manager.ts`                | Per-session history storage and migration                                                                                          |
+| `src/main/pianola/pianola-lifecycle.ts`      | Constructs the Pianola supervisor + relearn scheduler; owns the CLI-mining and existing-rules-read pure helpers                    |
+| `src/main/process-manager/`                  | Process spawning (PTY + child_process)                                                                                             |
+| `src/main/process-listeners/`                | Process event routing                                                                                                              |
+| `src/main/process-listeners-wiring/index.ts` | Builds the process-listener deps object from index.ts module state and wires WakaTime's listener                                   |
+| `src/main/ipc/handlers/`                     | All IPC handler modules                                                                                                            |
+| `src/main/ipc/bootstrap/index.ts`            | Single-entry orchestrator for all ~45 IPC handler registrations + inline group-chat/coworking/window-registry wiring               |
+| `src/main/agents/agent-config-lookup.ts`     | Per-agent config/custom-env-var lookup, shared by IPC bootstrap and Cue construction                                               |
+| `src/main/cadenza-bridge/index.ts`           | Routes cadenza payloads to the HUD window; registers the two module-eval-time `cadenza-hud:decision`/`cadenza:flash` IPC listeners |
+| `src/main/plugin-host-view-bridge/index.ts`  | Concerto/plugin host-view forwarding gate + `PluginHostViewRegistry` construction                                                  |
+| `src/main/utils/sentry.ts`                   | Sentry utilities and memory monitoring                                                                                             |
+| `src/main/utils/logger.ts`                   | Structured logging                                                                                                                 |
 
 ## Electron Major-Bump Smoke Test
 

--- a/docs/agent-guides/PLUGIN-DEVELOPMENT.md
+++ b/docs/agent-guides/PLUGIN-DEVELOPMENT.md
@@ -567,7 +567,9 @@ parent.postMessage(
 	{
 		type: 'maestro:invokeCommand',
 		commandId: 'say-hello',
-		args: {/* optional */},
+		args: {
+			/* optional */
+		},
 	},
 	'*'
 );

--- a/docs/agent-guides/UI-PATTERNS.md
+++ b/docs/agent-guides/UI-PATTERNS.md
@@ -1366,7 +1366,9 @@ Zustand stores are singletons. Reset between tests:
 
 ```typescript
 beforeEach(() => {
-	useSettingsStore.setState({/* initial state */});
+	useSettingsStore.setState({
+		/* initial state */
+	});
 });
 ```
 

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -558,7 +558,13 @@ export const PLUGIN_TIERS: readonly PluginTier[] = [0, 1, 2];
 
 /** Coarse marketplace category used to group/filter extensions. Absent => 'other'. */
 export type PluginCategory =
-	'automation' | 'agents' | 'insights' | 'ui' | 'data' | 'devtools' | 'other';
+	| 'automation'
+	| 'agents'
+	| 'insights'
+	| 'ui'
+	| 'data'
+	| 'devtools'
+	| 'other';
 
 export const PLUGIN_CATEGORIES: readonly PluginCategory[] = [
 	'automation',

--- a/src/__tests__/integration/RemoteControlSync.test.ts
+++ b/src/__tests__/integration/RemoteControlSync.test.ts
@@ -52,7 +52,8 @@ class MockWebServer {
 		| ((sessionId: string, command: string, inputMode?: 'ai' | 'terminal') => Promise<boolean>)
 		| null = null;
 	private switchModeCallback:
-		((sessionId: string, mode: 'ai' | 'terminal') => Promise<boolean>) | null = null;
+		| ((sessionId: string, mode: 'ai' | 'terminal') => Promise<boolean>)
+		| null = null;
 	private getThemeCallback: (() => Theme | null) | null = null;
 
 	constructor() {

--- a/src/__tests__/plugins/agent-flow-main.test.ts
+++ b/src/__tests__/plugins/agent-flow-main.test.ts
@@ -67,7 +67,8 @@ function makeStub(): Stub {
 		focus,
 		snapshot: () => {
 			const call = panelPost.mock.calls[panelPost.mock.calls.length - 1] as
-				[string, Record<string, unknown>] | undefined;
+				| [string, Record<string, unknown>]
+				| undefined;
 			return call?.[1];
 		},
 	};

--- a/src/__tests__/renderer/components/Markdown/plugins.test.ts
+++ b/src/__tests__/renderer/components/Markdown/plugins.test.ts
@@ -61,7 +61,8 @@ describe('buildMarkdownPlugins', () => {
 		expect(fns).toContain(remarkPromoteDisplayMath);
 		// remark-math configured with singleDollarTextMath: false
 		const mathEntry = remark.find((e) => Array.isArray(e) && e[0] === remarkMath) as
-			[unknown, Record<string, unknown>] | undefined;
+			| [unknown, Record<string, unknown>]
+			| undefined;
 		expect(mathEntry?.[1]).toEqual({ singleDollarTextMath: false });
 		// promote runs AFTER remark-math (order matters)
 		expect(fns.indexOf(remarkPromoteDisplayMath)).toBeGreaterThan(fns.indexOf(remarkMath));

--- a/src/__tests__/renderer/components/MermaidRenderer.test.tsx
+++ b/src/__tests__/renderer/components/MermaidRenderer.test.tsx
@@ -45,7 +45,8 @@ async function captureThemeVariables(
 
 	const calls = initializeMock.mock.calls;
 	const config = calls[calls.length - 1]?.[0] as
-		{ themeVariables?: Record<string, string> } | undefined;
+		| { themeVariables?: Record<string, string> }
+		| undefined;
 	expect(config?.themeVariables).toBeDefined();
 	return config!.themeVariables!;
 }

--- a/src/__tests__/renderer/components/Settings/Extensions/extensionModel.test.ts
+++ b/src/__tests__/renderer/components/Settings/Extensions/extensionModel.test.ts
@@ -136,10 +136,7 @@ describe('extensionModel first-party projection (all Encore features)', () => {
 
 	it('surfaces the plan-table identities on the details pane fields', () => {
 		const byFlag = (flag: keyof EncoreFeatureFlags) =>
-			builtinExtension(
-				BUILTIN_FEATURES.find((d) => d.flag === flag)!,
-				flags()
-			);
+			builtinExtension(BUILTIN_FEATURES.find((d) => d.flag === flag)!, flags());
 		expect(byFlag('directorNotes')).toMatchObject({
 			pluginId: 'com.maestro.director-notes',
 			category: 'insights',

--- a/src/__tests__/renderer/components/TerminalView.test.tsx
+++ b/src/__tests__/renderer/components/TerminalView.test.tsx
@@ -842,7 +842,8 @@ describe('TerminalView - touch key bar (coarse pointer)', () => {
 		// The bridge object is stable across renders; isActive() reads the latest
 		// armed state, so a reference captured now stays valid after re-renders.
 		const bridge = xtermPropsBySessionId.get('session-1-terminal-tab-1')?.stickyCtrl as
-			{ isActive: () => boolean; onConsume: () => void } | undefined;
+			| { isActive: () => boolean; onConsume: () => void }
+			| undefined;
 		expect(bridge).toBeDefined();
 		expect(bridge?.isActive()).toBe(false);
 

--- a/src/__tests__/renderer/components/Wizard/services/phaseGenerator_ssh.test.ts
+++ b/src/__tests__/renderer/components/Wizard/services/phaseGenerator_ssh.test.ts
@@ -11,7 +11,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 let capturedDataCallback: ((sessionId: string, data: string) => void) | null = null;
 let capturedExitCallback: ((sessionId: string, code: number) => void) | null = null;
 let capturedFileChangedCallback:
-	((data: { filename: string; eventType: string; folderPath: string }) => void) | null = null;
+	| ((data: { filename: string; eventType: string; folderPath: string }) => void)
+	| null = null;
 
 // Mock window.maestro
 const mockMaestro = {

--- a/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
@@ -56,14 +56,18 @@ describe('useRemoteIntegration', () => {
 	let onRemoteNewTabHandler: ((sessionId: string, responseChannel: string) => void) | undefined;
 	let onRemoteCloseTabHandler: ((sessionId: string, tabId: string) => void) | undefined;
 	let onRemoteRenameTabHandler:
-		((sessionId: string, tabId: string, newName: string) => void) | undefined;
+		| ((sessionId: string, tabId: string, newName: string) => void)
+		| undefined;
 	let onRemoteStarTabHandler:
-		((sessionId: string, tabId: string, starred: boolean) => void) | undefined;
+		| ((sessionId: string, tabId: string, starred: boolean) => void)
+		| undefined;
 	let onRemoteReorderTabHandler:
-		((sessionId: string, fromIndex: number, toIndex: number) => void) | undefined;
+		| ((sessionId: string, fromIndex: number, toIndex: number) => void)
+		| undefined;
 	let onRemoteToggleBookmarkHandler: ((sessionId: string) => void) | undefined;
 	let onRequestMovementDesignerInspectionHandler:
-		((id: string, expectedRevision: number, responseChannel: string) => void) | undefined;
+		| ((id: string, expectedRevision: number, responseChannel: string) => void)
+		| undefined;
 	let onRemoteNewAITabWithPromptHandler:
 		| ((sessionId: string, prompt: string, responseChannel: string, background?: boolean) => void)
 		| undefined;
@@ -79,9 +83,11 @@ describe('useRemoteIntegration', () => {
 		  ) => void)
 		| undefined;
 	let onRemoteListQueueHandler:
-		((sessionId: string | undefined, responseChannel: string) => void) | undefined;
+		| ((sessionId: string | undefined, responseChannel: string) => void)
+		| undefined;
 	let onRemoteRemoveQueueItemHandler:
-		((sessionId: string, itemId: string, responseChannel: string) => void) | undefined;
+		| ((sessionId: string, itemId: string, responseChannel: string) => void)
+		| undefined;
 	let onRemoteNotifyToastHandler:
 		| ((params: {
 				title: string;
@@ -100,7 +106,8 @@ describe('useRemoteIntegration', () => {
 		  }) => void)
 		| undefined;
 	let onRemoteMovementHandler:
-		((params: MovementPayload, responseChannel?: string) => void) | undefined;
+		| ((params: MovementPayload, responseChannel?: string) => void)
+		| undefined;
 
 	const mockProcess = {
 		...window.maestro.process,

--- a/src/__tests__/renderer/services/inlineWizardDocumentGeneration_ssh.test.ts
+++ b/src/__tests__/renderer/services/inlineWizardDocumentGeneration_ssh.test.ts
@@ -15,7 +15,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 let capturedDataCallback: ((sessionId: string, data: string) => void) | null = null;
 let capturedExitCallback: ((sessionId: string, code: number) => void) | null = null;
 let capturedFileChangedCallback:
-	((data: { filename: string; eventType: string; folderPath: string }) => void) | null = null;
+	| ((data: { filename: string; eventType: string; folderPath: string }) => void)
+	| null = null;
 
 // Mock window.maestro
 const mockMaestro = {

--- a/src/cli/commands/pianola-orchestrate.ts
+++ b/src/cli/commands/pianola-orchestrate.ts
@@ -530,13 +530,15 @@ export async function pianolaOrchestrate(
 			{ type: 'get_session_history', tabId, tail: HISTORY_TAIL },
 			'session_history_result'
 		);
-		const messages = (result.messages ?? []).map((m): PianolaMessage => ({
-			id: m.id,
-			role: m.role,
-			source: m.source ?? '',
-			content: m.content,
-			timestamp: m.timestamp,
-		}));
+		const messages = (result.messages ?? []).map(
+			(m): PianolaMessage => ({
+				id: m.id,
+				role: m.role,
+				source: m.source ?? '',
+				content: m.content,
+				timestamp: m.timestamp,
+			})
+		);
 		historyCache.set(tabId, { at: now, messages });
 		return messages;
 	};

--- a/src/maestro-p/tui-driver.ts
+++ b/src/maestro-p/tui-driver.ts
@@ -151,7 +151,13 @@ export const READY_MAX_TAPS = 3;
 export const READY_TIMEOUT_MS = 8000;
 
 export type TuiDriverEvent =
-	'ready' | 'ready-timeout' | 'limit-hit' | 'line' | 'exit' | 'trust-accepted' | 'bypass-accepted';
+	| 'ready'
+	| 'ready-timeout'
+	| 'limit-hit'
+	| 'line'
+	| 'exit'
+	| 'trust-accepted'
+	| 'bypass-accepted';
 
 export class TuiDriver extends EventEmitter {
 	private readonly options: TuiDriverOptions;

--- a/src/main/agents/agent-config-lookup.ts
+++ b/src/main/agents/agent-config-lookup.ts
@@ -1,0 +1,29 @@
+/**
+ * Per-agent config/env-var lookup, read from the agent configs store.
+ *
+ * Extracted out of main/index.ts (Phase 5 refactoring) rather than into the
+ * IPC bootstrap module specifically, because it's read from both
+ * setupIpcHandlers() AND unscoped Cue-construction code inside
+ * app.whenReady() - it isn't exclusively an IPC-bootstrap concern.
+ */
+
+import type { getAgentConfigsStore } from '../stores';
+
+export interface AgentConfigLookup {
+	getAgentConfigForAgent: (agentId: string) => Record<string, any>;
+	getCustomEnvVarsForAgent: (agentId: string) => Record<string, string> | undefined;
+}
+
+export function createAgentConfigLookup(
+	agentConfigsStore: ReturnType<typeof getAgentConfigsStore>
+): AgentConfigLookup {
+	const getAgentConfigForAgent = (agentId: string): Record<string, any> => {
+		const allConfigs = agentConfigsStore.get('configs', {});
+		return allConfigs[agentId] || {};
+	};
+
+	const getCustomEnvVarsForAgent = (agentId: string): Record<string, string> | undefined =>
+		getAgentConfigForAgent(agentId).customEnvVars as Record<string, string> | undefined;
+
+	return { getAgentConfigForAgent, getCustomEnvVarsForAgent };
+}

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -77,7 +77,10 @@ interface SelectConfigOption extends BaseConfigOption {
  * Uses discriminated union for full type safety.
  */
 export type AgentConfigOption =
-	CheckboxConfigOption | TextConfigOption | NumberConfigOption | SelectConfigOption;
+	| CheckboxConfigOption
+	| TextConfigOption
+	| NumberConfigOption
+	| SelectConfigOption;
 
 /**
  * Full agent configuration including runtime detection state.

--- a/src/main/agents/detector.ts
+++ b/src/main/agents/detector.ts
@@ -68,7 +68,8 @@ async function fetchCopilotModelsFromApi(): Promise<string[] | null> {
 		}
 		const data = (await response.json()) as Record<string, unknown>;
 		const copilotProvider = data?.['github-copilot'] as
-			{ models?: Record<string, unknown> } | undefined;
+			| { models?: Record<string, unknown> }
+			| undefined;
 		const models = copilotProvider?.models;
 		if (models && typeof models === 'object') {
 			return Object.keys(models).sort();

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -16,7 +16,13 @@ import { getReleaseDownloadFeedUrl } from './update-checker';
 
 export interface UpdateStatus {
 	status:
-		'idle' | 'checking' | 'available' | 'not-available' | 'downloading' | 'downloaded' | 'error';
+		| 'idle'
+		| 'checking'
+		| 'available'
+		| 'not-available'
+		| 'downloading'
+		| 'downloaded'
+		| 'error';
 	info?: UpdateInfo;
 	progress?: ProgressInfo;
 	error?: string;

--- a/src/main/cadenza-bridge/delivery.ts
+++ b/src/main/cadenza-bridge/delivery.ts
@@ -1,0 +1,31 @@
+import { deliverCadenzaToHud } from '../app-lifecycle';
+import type { CadenzaBridgeDependencies } from './types';
+
+/**
+ * Route a cadenza payload to the HUD window (creating it lazily). Returns
+ * false when there's no main window to parent it, so the caller can fall back
+ * to the in-app renderer.
+ */
+export function createCadenzaDelivery(deps: CadenzaBridgeDependencies) {
+	const deliverCadenza = (payload: Parameters<typeof deliverCadenzaToHud>[2]): boolean => {
+		const mainWindow = deps.getMainWindow();
+		if (!mainWindow) return false;
+		// Concerto is an opt-in Encore feature: don't spawn the HUD window (or
+		// route anything) unless the user enabled it in Extensions.
+		if (deps.settingsStore.get('encoreFeatures')?.concerto !== true) return false;
+		// The HUD window has no session store, so resolve the owning agent's display
+		// name here (for the "opened by X" attribution chip) and stamp it on.
+		let stamped = payload;
+		if (payload.sessionId && !payload.sourceAgent) {
+			const sessions = deps.sessionsStore.get('sessions', []) as Array<{
+				id?: string;
+				name?: string;
+			}>;
+			const sourceAgent = sessions.find((s) => s.id === payload.sessionId)?.name;
+			if (sourceAgent) stamped = { ...payload, sourceAgent };
+		}
+		return deliverCadenzaToHud(mainWindow, deps.cadenzaHudDeps, stamped);
+	};
+
+	return { deliverCadenza };
+}

--- a/src/main/cadenza-bridge/index.ts
+++ b/src/main/cadenza-bridge/index.ts
@@ -1,0 +1,3 @@
+export { createCadenzaDelivery } from './delivery';
+export { registerCadenzaIpcHandlers } from './ipc';
+export type { CadenzaBridgeDependencies, CadenzaIpcDependencies } from './types';

--- a/src/main/cadenza-bridge/ipc.ts
+++ b/src/main/cadenza-bridge/ipc.ts
@@ -1,0 +1,44 @@
+import { ipcMain } from 'electron';
+import { getCadenzaHudWindow } from '../app-lifecycle';
+import type { CadenzaIpcDependencies } from './types';
+
+/**
+ * Registers the two cadenza IPC listeners at module-eval time (not inside
+ * setupIpcHandlers()) - matching the exact registration timing this code had
+ * inline in main/index.ts. Do not fold these into the IPC bootstrap module,
+ * that would change when they start listening.
+ */
+export function registerCadenzaIpcHandlers(deps: CadenzaIpcDependencies): void {
+	// A `decision` cadenza's chosen option replies to the owning agent: inject the
+	// value as a live prompt into that agent's session via the main renderer's
+	// existing remote-command path (the same one `maestro-cli dispatch` uses). The
+	// agent process is already spawned (with SSH if configured), so feeding its live
+	// session inherits that transport - no new spawn, no separate SSH handling.
+	ipcMain.on('cadenza-hud:decision', (_event, sessionId: string, message: string) => {
+		// Same Concerto gate as the other cadenza entry points: with the flag off no
+		// decision card can exist, so a decision arriving anyway must not inject a
+		// prompt into a live agent session.
+		if (deps.settingsStore.get('encoreFeatures')?.concerto !== true) return;
+		const mainWindow = deps.getMainWindow();
+		if (!mainWindow || mainWindow.isDestroyed()) return;
+		if (!sessionId || !message) return;
+		// force=true (5th arg): a decision card is answered mid-turn, so the owning
+		// agent is busy by definition; without the force flag the renderer's busy
+		// guard would silently drop the choice while the UI reports it was sent.
+		mainWindow.webContents.send('remote:executeCommand', sessionId, message, 'ai', undefined, true);
+	});
+
+	// A chat "point" chip that targets a cadenza asks main to pulse it. Cadenzas live
+	// in the HUD renderer (a separate window with its own store), so the flash must be
+	// routed to whichever renderer actually holds the card: the HUD window when it's
+	// up, otherwise the main window (the in-app fallback layer). Gated by Concerto so
+	// it's inert when off (no cadenzas exist then anyway).
+	ipcMain.on('cadenza:flash', (_event, id: string) => {
+		if (!id) return;
+		if (deps.settingsStore.get('encoreFeatures')?.concerto !== true) return;
+		const hud = getCadenzaHudWindow();
+		const mainWindow = deps.getMainWindow();
+		const target = hud && !hud.isDestroyed() ? hud : mainWindow;
+		if (target && !target.isDestroyed()) target.webContents.send('remote:cadenzaFlash', id);
+	});
+}

--- a/src/main/cadenza-bridge/types.ts
+++ b/src/main/cadenza-bridge/types.ts
@@ -1,0 +1,15 @@
+import type { BrowserWindow } from 'electron';
+import type { CadenzaHudWindowDeps } from '../app-lifecycle';
+import type { getSettingsStore, getSessionsStore } from '../stores';
+
+export interface CadenzaBridgeDependencies {
+	getMainWindow: () => BrowserWindow | null;
+	sessionsStore: ReturnType<typeof getSessionsStore>;
+	settingsStore: ReturnType<typeof getSettingsStore>;
+	cadenzaHudDeps: CadenzaHudWindowDeps;
+}
+
+export interface CadenzaIpcDependencies {
+	getMainWindow: () => BrowserWindow | null;
+	settingsStore: ReturnType<typeof getSettingsStore>;
+}

--- a/src/main/cue/cue-db.ts
+++ b/src/main/cue/cue-db.ts
@@ -623,7 +623,8 @@ export function updateHeartbeat(): void {
  */
 export function getLastHeartbeat(): number | null {
 	const row = getDb().prepare(`SELECT last_seen FROM cue_heartbeat WHERE id = 1`).get() as
-		{ last_seen: number } | undefined;
+		| { last_seen: number }
+		| undefined;
 	return row?.last_seen ?? null;
 }
 
@@ -706,7 +707,8 @@ export function getGitHubItemState(
 			`SELECT last_revision, fire_count FROM cue_github_seen WHERE subscription_id = ? AND item_key = ?`
 		)
 		.get(subscriptionId, itemKey) as
-		{ last_revision: string | null; fire_count: number } | undefined;
+		| { last_revision: string | null; fire_count: number }
+		| undefined;
 	if (!row) return null;
 	return {
 		lastRevision: row.last_revision,
@@ -982,7 +984,8 @@ export function deleteTelemetryEvents(ids: string[]): void {
 export function countTelemetryEvents(): number {
 	if (!db) return 0;
 	const row = db.prepare(`SELECT COUNT(*) AS c FROM cue_telemetry_outbox`).get() as
-		{ c: number } | undefined;
+		| { c: number }
+		| undefined;
 	return row?.c ?? 0;
 }
 

--- a/src/main/cue/cue-engine.ts
+++ b/src/main/cue/cue-engine.ts
@@ -335,7 +335,8 @@ export class CueEngine {
 				// completion notification so downstream agents can access them via
 				// per-source template variables ({{CUE_FORWARDED_<NAME>}}).
 				const forwarded = result.event.payload.forwardedOutputs as
-					Record<string, string> | undefined;
+					| Record<string, string>
+					| undefined;
 				this.notifyAgentCompleted(sessionId, {
 					sessionName: result.sessionName,
 					status: result.status,

--- a/src/main/dispatch-callbacks/types.ts
+++ b/src/main/dispatch-callbacks/types.ts
@@ -27,7 +27,12 @@ export type DispatchCallbackStatus = 'completed' | 'failed' | 'timeout' | 'cance
  * - `fired` / `cancelled` - terminal.
  */
 export type DispatchCallbackState =
-	'pending' | 'armed' | 'grace' | 'awaiting-autorun' | 'fired' | 'cancelled';
+	| 'pending'
+	| 'armed'
+	| 'grace'
+	| 'awaiting-autorun'
+	| 'fired'
+	| 'cancelled';
 
 /** What the dispatch site knows when it arms a callback. */
 export interface DispatchCallbackRegistration {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,10 +23,8 @@ import { readFile } from 'fs/promises';
 import { ProcessManager } from './process-manager';
 import { WebServer } from './web-server';
 import { AgentDetector } from './agents';
-import { getAgentDefinition } from './agents/definitions';
-import { DEFAULT_CONTEXT_WINDOWS, FALLBACK_CONTEXT_WINDOW } from '../shared/agentConstants';
+import { createAgentConfigLookup } from './agents/agent-config-lookup';
 import { shouldDropSentryEvent } from '../shared/sentryFilters';
-import type { AgentId } from '../shared/agentIds';
 import {
 	initGlobalHotkey,
 	setGlobalShowHotkey,
@@ -36,11 +34,8 @@ import { CueEngine } from './cue/cue-engine';
 import { createCueSupervisorHooks } from './cue/cue-first-party';
 import { PianolaSupervisor } from './pianola/pianola-supervisor';
 import { PianolaRelearnScheduler } from './pianola/pianola-relearn-scheduler';
-import { runRelearnJob } from './pianola/pianola-relearn';
-import { readRules, writeSuggestions, getProfile } from './pianola/pianola-store-main';
-import type { DecisionPair } from '../shared/pianola/transcript-mining';
-import type { PianolaRule } from '../shared/pianola/types';
-import { spawn, execFile, type ChildProcess } from 'child_process';
+import { createPianolaLifecycle } from './pianola/pianola-lifecycle';
+import { execFile } from 'child_process';
 import { PluginManager } from './plugins/plugin-manager';
 import { resolveTrustedKeys } from '../shared/plugins/publisher-keys';
 import { seedBundledPlugins } from './plugins/bundled-plugins';
@@ -59,8 +54,8 @@ import {
 	type PluginSessionMetadata,
 	type PluginTabMetadata,
 } from './plugins/plugin-host-handlers';
-import { PluginHostViewRegistry, type HostViewMutation } from './plugins/plugin-host-view-registry';
-import { forwardPluginHostViewToRenderer } from './plugins/plugin-host-view-forwarder';
+import { createCadenzaDelivery, registerCadenzaIpcHandlers } from './cadenza-bridge';
+import { createPluginHostViewBridge } from './plugin-host-view-bridge';
 import { ActionGuard } from './plugins/action-guard';
 import { PluginKvStore } from './plugins/plugin-kv-store';
 import { PluginEventBusImpl } from './plugins/plugin-event-bus';
@@ -100,14 +95,9 @@ import {
 	type OpenedConsentWindow,
 } from './plugins/consent-window';
 import { configureCueTelemetry } from './cue/cue-telemetry';
-import {
-	executeCuePrompt,
-	recordCueHistoryEntry,
-	stopCueRun,
-	getCueProcessList,
-} from './cue/cue-executor';
+import { executeCuePrompt, recordCueHistoryEntry, stopCueRun } from './cue/cue-executor';
 import { executeCueShell, stopCueShellRun } from './cue/cue-shell-executor';
-import { executeCueCli, stopCueCliRun, resolveMaestroCliScriptPath } from './cue/cue-cli-executor';
+import { executeCueCli, stopCueCliRun } from './cue/cue-cli-executor';
 import { executeCueNotify } from './cue/cue-notify-executor';
 import { getAgentDisplayName } from '../shared/agentMetadata';
 import { logger } from './utils/logger';
@@ -126,120 +116,33 @@ import {
 	getWindowStateStore,
 	getClaudeSessionOriginsStore,
 	getAgentSessionOriginsStore,
-	getSshRemoteById,
 } from './stores';
 import { runSettingsMigrations } from './stores/migrations';
 import {
-	registerGitHandlers,
-	registerAutorunHandlers,
-	registerPlaybooksHandlers,
-	registerHistoryHandlers,
-	registerAgentsHandlers,
-	registerProcessHandlers,
-	registerPersistenceHandlers,
-	registerSystemHandlers,
-	registerClaudeHandlers,
-	registerAgentSessionsHandlers,
-	registerGroupChatHandlers,
-	registerDebugHandlers,
-	registerSpeckitHandlers,
-	registerOpenSpecHandlers,
-	registerBmadHandlers,
-	registerContextHandlers,
-	registerMarketplaceHandlers,
-	registerStatsHandlers,
-	registerCueStatsHandlers,
-	registerDocumentGraphHandlers,
-	registerSshRemoteHandlers,
-	registerFilesystemHandlers,
-	registerAttachmentsHandlers,
-	registerWebHandlers,
 	ensureCliServer,
 	startCliDiscoveryWatchdog,
 	stopCliDiscoveryWatchdog,
-	registerLeaderboardHandlers,
-	registerNotificationsHandlers,
-	registerSymphonyHandlers,
-	registerTabNamingHandlers,
-	registerAgentErrorHandlers,
-	registerDirectorNotesHandlers,
-	registerCrossAgentHandlers,
-	registerCueHandlers,
-	registerCueBackupHandlers,
-	registerWakatimeHandlers,
-	registerFeedbackHandlers,
-	registerMaestroCliHandlers,
-	registerPromptsHandlers,
-	registerMemoryHandlers,
-	registerPianolaHandlers,
-	registerPluginsHandlers,
-	registerAgentRunHandlers,
-	registerCoworkingHandlers,
-	registerBrowserSessionHandlers,
-	registerWindowsHandlers,
-	wireWindowRegistryBroadcast,
-	wireEmptySecondaryWindowAutoClose,
-	setupLoggerEventForwarding,
 	cleanupAllGroomingSessions,
 	getActiveGroomingSessionCount,
 } from './ipc/handlers';
-import { startCoworkingBridge, stopCoworkingBridge } from './coworking/coworking-bridge';
-import { ensureCoworkingServerScript } from './coworking/coworking-server-paths';
-import { resolveSessionFromPidWalk } from './coworking/pid-resolution';
-import { initializeStatsDB, closeStatsDB, getStatsDB, wireMultiWindowTelemetry } from './stats';
-import { groupChatEmitters } from './ipc/handlers/groupChat';
-import {
-	routeModeratorResponse,
-	routeAgentResponse,
-	setGetSessionsCallback,
-	setGetCustomEnvVarsCallback,
-	setGetAgentConfigCallback,
-	setGetModeratorSettingsCallback,
-	setSshStore,
-	setGetCustomShellPathCallback,
-	markParticipantResponded,
-	spawnModeratorSynthesis,
-	getGroupChatReadOnlyState,
-	respawnParticipantWithRecovery,
-	clearActiveParticipantTaskSession,
-	clearModeratorResponseTimeout,
-} from './group-chat/group-chat-router';
+import { setupIpcHandlers } from './ipc/bootstrap';
+import { stopCoworkingBridge } from './coworking/coworking-bridge';
+import { initializeStatsDB, closeStatsDB } from './stats';
 import { createSshRemoteStoreAdapter } from './utils/ssh-remote-resolver';
-import { updateParticipant, loadGroupChat, updateGroupChat } from './group-chat/group-chat-storage';
 import { stopSessionCleanup } from './group-chat/group-chat-moderator';
-import { needsSessionRecovery, initiateSessionRecovery } from './group-chat/session-recovery';
 import { initializePrompts, getPrompt, savePrompt } from './prompt-manager';
 import { captureException } from './utils/sentry';
-import { initializeSessionStorages } from './storage';
 import { resolveToFilePath, configureImageStore } from './storage/session-image-store';
 import { CONCERTO_HTML_SCHEME } from '../shared/concerto-html';
 import { createConcertoHtmlResponse } from './concerto-html';
 import { MEDIA_SCHEME } from '../shared/mediaTypes';
 import { handleMediaStreamRequest } from './media/media-stream';
-import { initializeOutputParsers } from './parsers';
-import { calculateContextTokens } from './parsers/usage-aggregator';
-import {
-	DEMO_MODE,
-	DEMO_DATA_PATH,
-	REGEX_MODERATOR_SESSION,
-	REGEX_MODERATOR_SESSION_TIMESTAMP,
-	REGEX_AI_SUFFIX,
-	REGEX_AI_TAB_ID,
-	REGEX_BATCH_SESSION,
-	REGEX_SYNOPSIS_SESSION,
-	debugLog,
-} from './constants';
+import { DEMO_MODE, DEMO_DATA_PATH } from './constants';
 // initAutoUpdater is now used by window-manager.ts (Phase 4 refactoring)
 import { checkWslEnvironment } from './utils/wslDetector';
 import { setupDeepLinkHandling, flushPendingDeepLink } from './deep-links';
 // Extracted modules (Phase 1 refactoring)
-import { parseParticipantSessionId } from './group-chat/session-parser';
-import { extractTextFromStreamJson } from './group-chat/output-parser';
-import {
-	appendToGroupChatBuffer,
-	getGroupChatBufferedOutput,
-	clearGroupChatBuffer,
-} from './group-chat/output-buffer';
+import { wireProcessListeners } from './process-listeners-wiring';
 // Phase 2 refactoring - dependency injection
 import { createSafeSend, isWebContentsAvailable } from './utils/safe-send';
 import { capabilitySnapshots, createSnapshotBroadcaster } from './agents/capability-snapshot';
@@ -251,29 +154,19 @@ import {
 	createSettingsWatcher,
 	createWindowManager,
 	createQuitHandler,
-	deliverCadenzaToHud,
-	deliverCadenzaToExistingHud,
 	closeCadenzaHudWindow,
-	getCadenzaHudWindow,
 	type QuitHandler,
 } from './app-lifecycle';
 // Multi-window registry (single source of truth for window<->session ownership)
 import { WindowRegistry } from './window-registry';
 // Multi-window startup restore: turn the persisted MultiWindowState back into
 // window-creation specs (pruning agents that no longer exist).
-import {
-	planWindowRestore,
-	pickFocusWindowSpec,
-	saveWindowState,
-} from './window-state-persistence';
+import { planWindowRestore, pickFocusWindowSpec } from './window-state-persistence';
 import type { WindowState as SharedWindowState } from '../shared/window-types';
-// Phase 3 refactoring - process listeners
-import { setupProcessListeners as setupProcessListenersModule } from './process-listeners';
 import { setupAgentRunCapture } from './agent-run/setup-capture-listener';
 import { setAgentRunSink } from './agent-run/broadcast';
 import { startAgentRunStoreWatcher } from './agent-run/store-watcher';
 import { setupAgentRunRecovery } from './agent-run/setup-recovery';
-import { setupWakaTimeListener } from './process-listeners/wakatime-listener';
 import { WakaTimeManager } from './wakatime-manager';
 import { MaestroCliManager } from './maestro-cli-manager';
 import {
@@ -497,14 +390,8 @@ const windowStateStore = getWindowStateStore();
 const claudeSessionOriginsStore = getClaudeSessionOriginsStore();
 const agentSessionOriginsStore = getAgentSessionOriginsStore();
 
-function getAgentConfigForAgent(agentId: string): Record<string, any> {
-	const allConfigs = agentConfigsStore.get('configs', {});
-	return allConfigs[agentId] || {};
-}
-
-function getCustomEnvVarsForAgent(agentId: string): Record<string, string> | undefined {
-	return getAgentConfigForAgent(agentId).customEnvVars as Record<string, string> | undefined;
-}
+const { getAgentConfigForAgent, getCustomEnvVarsForAgent } =
+	createAgentConfigLookup(agentConfigsStore);
 
 // Note: History storage is now handled by HistoryManager which uses per-session files
 // in the history/ directory. The legacy maestro-history.json file is migrated automatically.
@@ -530,74 +417,6 @@ let pluginEventBus: PluginEventBusImpl | null = null;
 let noteSessionActivatedInPersistence: ((sessionId: string) => void) | null = null;
 let usageRefreshScheduler: UsageRefreshScheduler | null = null;
 let interactiveReplayController: InteractiveReplayController<ProcessSpawnConfig> | null = null;
-
-/** Cap on decision pairs the scheduled re-learn pulls from the CLI per run. */
-const RELEARN_MAX_PAIRS = 100_000;
-
-/**
- * Mine the installed CLIs' native transcripts into a decision corpus by spawning
- * the existing `pianola learn --json` crawler (the single source of transcript
- * discovery + parsing) and parsing its `pairs`. Rejects on spawn/exit/parse
- * failure so a failed mine leaves the previously staged suggestions untouched.
- */
-function mineDecisionPairsViaCli(): Promise<DecisionPair[]> {
-	const cliScriptPath = resolveMaestroCliScriptPath();
-	return new Promise<DecisionPair[]>((resolve, reject) => {
-		let child: ChildProcess;
-		try {
-			child = spawn(
-				process.execPath,
-				[cliScriptPath, 'pianola', 'learn', '--json', '--max-pairs', String(RELEARN_MAX_PAIRS)],
-				{
-					env: {
-						...process.env,
-						// In packaged Electron, process.execPath is the app binary, not
-						// Node; without this it would launch the app instead of the CLI.
-						ELECTRON_RUN_AS_NODE: '1',
-						MAESTRO_CLI_JS: cliScriptPath,
-					},
-					stdio: ['ignore', 'pipe', 'pipe'],
-				}
-			);
-		} catch (err) {
-			reject(err instanceof Error ? err : new Error(String(err)));
-			return;
-		}
-		let stdout = '';
-		let stderr = '';
-		child.stdout?.setEncoding('utf8');
-		child.stdout?.on('data', (d: string) => {
-			stdout += d;
-		});
-		child.stderr?.setEncoding('utf8');
-		child.stderr?.on('data', (d: string) => {
-			stderr += d;
-		});
-		child.on('error', (err) => reject(err));
-		child.on('exit', (code) => {
-			if (code !== 0) {
-				reject(new Error(`pianola learn exited ${code ?? 'null'}: ${stderr.trim().slice(0, 200)}`));
-				return;
-			}
-			try {
-				const parsed = JSON.parse(stdout) as { pairs?: unknown };
-				resolve(Array.isArray(parsed.pairs) ? (parsed.pairs as DecisionPair[]) : []);
-			} catch (err) {
-				reject(err instanceof Error ? err : new Error(String(err)));
-			}
-		});
-	});
-}
-
-/**
- * Read the user's live rules and global decision-profile markdown for the
- * re-learn baseline. A missing or malformed profiles file degrades to an empty
- * baseline (getProfile already returns a well-formed empty result), so the job
- * stages a fresh draft rather than crashing.
- */
-function readExistingForRelearn(): { rules: PianolaRule[]; profile: string } {
-	return { rules: readRules(), profile: getProfile().entry?.profile ?? '' };
-}
 
 // Create safeSend with dependency injection (Phase 2 refactoring).
 // Broadcasts to EVERY open window, not just the primary one - see the
@@ -678,59 +497,21 @@ const cadenzaHudDeps = {
 	windowRegistry,
 };
 
-/**
- * Route a cadenza payload to the HUD window (creating it lazily). Returns
- * false when there's no main window to parent it, so the caller can fall back
- * to the in-app renderer.
- */
-function deliverCadenza(payload: Parameters<typeof deliverCadenzaToHud>[2]): boolean {
-	if (!mainWindow) return false;
-	// Concerto is an opt-in Encore feature: don't spawn the HUD window (or
-	// route anything) unless the user enabled it in Extensions.
-	if (store.get('encoreFeatures')?.concerto !== true) return false;
-	// The HUD window has no session store, so resolve the owning agent's display
-	// name here (for the "opened by X" attribution chip) and stamp it on.
-	let stamped = payload;
-	if (payload.sessionId && !payload.sourceAgent) {
-		const sessions = sessionsStore.get('sessions', []) as Array<{ id?: string; name?: string }>;
-		const sourceAgent = sessions.find((s) => s.id === payload.sessionId)?.name;
-		if (sourceAgent) stamped = { ...payload, sourceAgent };
-	}
-	return deliverCadenzaToHud(mainWindow, cadenzaHudDeps, stamped);
-}
-
-/** Host views are a bridge between two opt-in Encore features. Re-read both
- * flags on every mutation: a disabled feature must never retain a pending view. */
-function arePluginHostViewsEnabled(): boolean {
-	const features = store.get('encoreFeatures', {}) as Record<string, boolean>;
-	return features.plugins === true && features.concerto === true;
-}
-
-/** Forward one host-owned mutation over the exact Concerto renderer channels
- * used by the CLI bridge. No renderer handles or plugin code cross this seam. */
-function forwardPluginHostView(mutation: HostViewMutation): boolean {
-	if (!(mutation.kind === 'remove' && mutation.force) && !arePluginHostViewsEnabled()) return false;
-	if (!mainWindow || mainWindow.isDestroyed() || !isWebContentsAvailable(mainWindow)) return false;
-	const targetWindow = mainWindow;
-	const sourcePlugin =
-		pluginManager?.getRegistry().records.find((record) => record.id === mutation.view.pluginId)
-			?.manifest?.name ?? mutation.view.pluginId;
-	return forwardPluginHostViewToRenderer(mutation, {
-		sourcePlugin,
-		isCadenzaEnabled: store.get('encoreFeatures', {})?.concerto === true,
-		sendToMain: (channel, payload) => targetWindow.webContents.send(channel, payload),
-		deliverCadenza,
-		deliverCadenzaToExistingHud,
-	});
-}
-
-const pluginHostViews = new PluginHostViewRegistry({
-	isEnabled: arePluginHostViewsEnabled,
-	getHostViews: () => pluginManager?.getContributions().hostViews ?? [],
-	isPluginRecordPresent: (pluginId) =>
-		pluginManager?.getRegistry().records.some((record) => record.id === pluginId) ?? false,
-	forward: forwardPluginHostView,
+// See src/main/cadenza-bridge/ and src/main/plugin-host-view-bridge/ for what
+// each of these does (Phase 5 refactoring).
+const { deliverCadenza } = createCadenzaDelivery({
+	getMainWindow: () => mainWindow,
+	sessionsStore,
+	settingsStore: store,
+	cadenzaHudDeps,
 });
+const { arePluginHostViewsEnabled, pluginHostViews } = createPluginHostViewBridge({
+	getMainWindow: () => mainWindow,
+	getPluginManager: () => pluginManager,
+	settingsStore: store,
+	deliverCadenza,
+});
+registerCadenzaIpcHandlers({ getMainWindow: () => mainWindow, settingsStore: store });
 
 // Disabling either side of the bridge purges any live views immediately. If both
 // are enabled after a flag change, re-sync static data without asking a renderer
@@ -746,37 +527,6 @@ store.onDidChange('encoreFeatures', (encoreFeatures) => {
 		return;
 	}
 	pluginHostViews.sync();
-});
-
-// A `decision` cadenza's chosen option replies to the owning agent: inject the
-// value as a live prompt into that agent's session via the main renderer's
-// existing remote-command path (the same one `maestro-cli dispatch` uses). The
-// agent process is already spawned (with SSH if configured), so feeding its live
-// session inherits that transport - no new spawn, no separate SSH handling.
-ipcMain.on('cadenza-hud:decision', (_event, sessionId: string, message: string) => {
-	// Same Concerto gate as the other cadenza entry points: with the flag off no
-	// decision card can exist, so a decision arriving anyway must not inject a
-	// prompt into a live agent session.
-	if (store.get('encoreFeatures')?.concerto !== true) return;
-	if (!mainWindow || mainWindow.isDestroyed()) return;
-	if (!sessionId || !message) return;
-	// force=true (5th arg): a decision card is answered mid-turn, so the owning
-	// agent is busy by definition; without the force flag the renderer's busy
-	// guard would silently drop the choice while the UI reports it was sent.
-	mainWindow.webContents.send('remote:executeCommand', sessionId, message, 'ai', undefined, true);
-});
-
-// A chat "point" chip that targets a cadenza asks main to pulse it. Cadenzas live
-// in the HUD renderer (a separate window with its own store), so the flash must be
-// routed to whichever renderer actually holds the card: the HUD window when it's
-// up, otherwise the main window (the in-app fallback layer). Gated by Concerto so
-// it's inert when off (no cadenzas exist then anyway).
-ipcMain.on('cadenza:flash', (_event, id: string) => {
-	if (!id) return;
-	if (store.get('encoreFeatures')?.concerto !== true) return;
-	const hud = getCadenzaHudWindow();
-	const target = hud && !hud.isDestroyed() ? hud : mainWindow;
-	if (target && !target.isDestroyed()) target.webContents.send('remote:cadenzaFlash', id);
 });
 
 // Create web server factory with dependency injection (Phase 2 refactoring)
@@ -1575,50 +1325,15 @@ app
 			},
 		});
 
-		// Initialize the Pianola supervised daemon. It owns Pianola's background
-		// watchers and orchestrations as supervised child processes (restart on
-		// crash, relaunch on app start, visible health), replacing the unmanaged
-		// nohup model. It self-gates on encoreFeatures.pianola and reconciles from a
-		// shared store file that both the CLI and renderer write.
-		pianolaSupervisor = new PianolaSupervisor({
-			isEnabled: () => {
-				const ef = store.get('encoreFeatures', {}) as Record<string, boolean>;
-				return ef.pianola === true;
-			},
-			getPianolaAgentId: () => {
-				const sessions = sessionsStore.get('sessions', []) as Array<{
-					id?: string;
-					isPianola?: boolean;
-				}>;
-				return sessions.find((s) => s?.isPianola === true)?.id;
-			},
+		// Initialize the Pianola supervised daemon and its scheduled re-learn job.
+		// See src/main/pianola/pianola-lifecycle.ts for what each one does.
+		const pianolaLifecycle = createPianolaLifecycle({
+			settingsStore: store,
+			sessionsStore,
+			logger,
 		});
-
-		// Pianola scheduled re-learn: keeps the learned profile fresh as a PROPOSAL
-		// (stages suggestions; never overwrites the live profile/rules) and
-		// relaunches stale supervised targets, on a fixed cadence. Self-gates per
-		// tick on encoreFeatures.pianola. Mining reuses the existing `pianola learn`
-		// crawler via the bundled CLI; the composition is pure with injected deps.
-		pianolaRelearnScheduler = new PianolaRelearnScheduler({
-			isEnabled: () => {
-				const ef = store.get('encoreFeatures', {}) as Record<string, boolean>;
-				return ef.pianola === true;
-			},
-			runJob: async () => {
-				await runRelearnJob({
-					isEnabled: () => {
-						const ef = store.get('encoreFeatures', {}) as Record<string, boolean>;
-						return ef.pianola === true;
-					},
-					mine: mineDecisionPairsViaCli,
-					readExisting: readExistingForRelearn,
-					writeSuggestions,
-					relaunchStale: () => pianolaSupervisor?.relaunchStale() ?? 0,
-					now: Date.now,
-					log: (line) => logger.info(line, '[PianolaRelearn]'),
-				});
-			},
-		});
+		pianolaSupervisor = pianolaLifecycle.supervisor;
+		pianolaRelearnScheduler = pianolaLifecycle.relearnScheduler;
 
 		// Plugin manager: discovers installed community plugins, tracks their
 		// enable state, verifies signatures, and (tier 1) runs their sandboxed
@@ -2935,11 +2650,56 @@ app
 
 		// Set up IPC handlers
 		logger.debug('Setting up IPC handlers', 'Startup');
-		setupIpcHandlers();
+		setupIpcHandlers({
+			getMainWindow: () => mainWindow,
+			getProcessManager: () => processManager,
+			getWebServer: () => webServer,
+			setWebServer: (server) => {
+				webServer = server;
+			},
+			getAgentDetector: () => agentDetector,
+			getCueEngine: () => cueEngine,
+			getPianolaSupervisor: () => pianolaSupervisor,
+			getPluginManager: () => pluginManager,
+			getPluginSandboxHost: () => pluginSandboxHost,
+			getPluginGroupingRegistry: () => pluginGroupingRegistry,
+			getPluginAuthStore: () => pluginAuthStore,
+			getPluginEventBus: () => pluginEventBus,
+			getInteractiveReplayController: () => interactiveReplayController,
+			setNoteSessionActivated: (fn) => {
+				noteSessionActivatedInPersistence = fn;
+			},
+			app,
+			settingsStore: store,
+			sessionsStore,
+			groupsStore,
+			agentConfigsStore,
+			windowStateStore,
+			claudeSessionOriginsStore,
+			agentSessionOriginsStore,
+			bootstrapStore,
+			safeSend,
+			windowRegistry,
+			windowManager,
+			createWebServer,
+			wakatimeManager,
+			maestroCliManager,
+			getAgentConfigForAgent,
+			getCustomEnvVarsForAgent,
+		});
 
 		// Set up process event listeners
 		logger.debug('Setting up process event listeners', 'Startup');
-		setupProcessListeners();
+		wireProcessListeners({
+			getProcessManager: () => processManager,
+			getWebServer: () => webServer,
+			getAgentDetector: () => agentDetector,
+			getCueEngine: () => cueEngine,
+			getPluginEventBus: () => pluginEventBus,
+			safeSend,
+			settingsStore: store,
+			wakatimeManager,
+		});
 
 		// Wire agent-run lifecycle capture to the ProcessManager (F1). Always-on
 		// per D1: minimal metadata capture is observability, not an opt-in feature.
@@ -3273,531 +3033,3 @@ quitHandler = createQuitHandler({
 	getWindowRegistry: () => windowRegistry,
 });
 quitHandler.setup();
-
-// startCliActivityWatcher is now handled by cliWatcher (Phase 4 refactoring)
-
-function setupIpcHandlers() {
-	// Settings, sessions, and groups persistence - extracted to src/main/ipc/handlers/persistence.ts
-
-	// Web/Live handlers - extracted to src/main/ipc/handlers/web.ts
-	registerWebHandlers({
-		getWebServer: () => webServer,
-		setWebServer: (server) => {
-			webServer = server;
-		},
-		createWebServer,
-		settingsStore: store,
-	});
-
-	// Git operations - extracted to src/main/ipc/handlers/git.ts
-	registerGitHandlers({
-		settingsStore: store,
-		getMainWindow: () => mainWindow,
-	});
-
-	// Auto Run operations - extracted to src/main/ipc/handlers/autorun.ts
-	registerAutorunHandlers({
-		mainWindow,
-		getMainWindow: () => mainWindow,
-		app,
-		settingsStore: store,
-	});
-
-	// Playbook operations - extracted to src/main/ipc/handlers/playbooks.ts
-	registerPlaybooksHandlers({
-		mainWindow,
-		getMainWindow: () => mainWindow,
-		app,
-	});
-
-	// History operations - extracted to src/main/ipc/handlers/history.ts
-	// Uses HistoryManager singleton for per-session storage
-	registerHistoryHandlers({
-		safeSend,
-		emitPluginEvent: (event) => pluginEventBus?.emit(event),
-		getMaxEntries: () => store.get('maxLogBuffer', 5000) as number,
-		getSshRemoteById,
-		getSessionById: (id: string) => {
-			const sessions = (sessionsStore.get('sessions', []) as Array<Record<string, unknown>>).filter(
-				(s) => typeof s === 'object' && s !== null
-			);
-			return sessions.find((s) => s.id === id);
-		},
-	});
-
-	// Director's Notes - unified history + synopsis generation
-	registerDirectorNotesHandlers({
-		getProcessManager: () => processManager,
-		getAgentDetector: () => agentDetector,
-		agentConfigsStore,
-		getMainWindow: () => mainWindow,
-	});
-
-	// Cross-agent @mention dispatch - streams a target agent's response back
-	// into the source agent's transcript (Phase 03).
-	registerCrossAgentHandlers({
-		getProcessManager: () => processManager,
-		getAgentDetector: () => agentDetector,
-		sessionsStore,
-		agentConfigsStore,
-		settingsStore: store,
-		sshStore: createSshRemoteStoreAdapter(store),
-		getCustomEnvVars: getCustomEnvVarsForAgent,
-		safeSend,
-	});
-
-	// Cue - event-driven automation engine
-	registerCueHandlers({
-		getCueEngine: () => cueEngine,
-	});
-
-	// Cue Backup - snapshot / restore .maestro/cue.yaml + prompts (Cue modal Backup tab)
-	registerCueBackupHandlers({
-		sessionsStore,
-	});
-
-	// Agent management operations - extracted to src/main/ipc/handlers/agents.ts
-	registerAgentsHandlers({
-		getAgentDetector: () => agentDetector,
-		agentConfigsStore,
-		settingsStore: store,
-		sessionsStore,
-	});
-
-	// Process management operations - extracted to src/main/ipc/handlers/process.ts
-	registerProcessHandlers({
-		getProcessManager: () => processManager,
-		getAgentDetector: () => agentDetector,
-		agentConfigsStore,
-		settingsStore: store,
-		getMainWindow: () => mainWindow,
-		safeSend,
-		sessionsStore,
-		interactiveReplayController: interactiveReplayController ?? undefined,
-		getCueProcesses: () => {
-			// Always query the executor's active process map - processes may still be
-			// running even if the engine has been disabled (in-flight runs complete
-			// independently of engine state).
-			const processList = getCueProcessList();
-			if (processList.length === 0) return [];
-			const activeRuns = cueEngine?.getActiveRuns() ?? [];
-			// Merge PID/command data from executor with metadata from run manager
-			return processList.map((proc) => {
-				const run = activeRuns.find((r) => r.runId === proc.runId);
-				return {
-					...proc,
-					sessionName: run?.sessionName ?? '',
-					subscriptionName: run?.subscriptionName ?? '',
-					eventType: run?.event.type ?? '',
-				};
-			});
-		},
-	});
-
-	// Persistence operations - extracted to src/main/ipc/handlers/persistence.ts
-	const persistenceHandlers = registerPersistenceHandlers({
-		settingsStore: store,
-		sessionsStore,
-		groupsStore,
-		getWebServer: () => webServer,
-		// Metadata-only session/agent lifecycle -> subscribed plugins. Null-safe:
-		// the bus is created during plugin init and re-authorizes every delivery
-		// against live grants, so this is a no-op when plugins are disabled.
-		emitPluginEvent: (event) => pluginEventBus?.emit(event),
-	});
-	// Wire the plugin focus verbs into the persistence layer's session.activated
-	// dedupe so the two emit paths share one last-emitted id.
-	noteSessionActivatedInPersistence = persistenceHandlers.noteSessionActivated;
-
-	// System operations - extracted to src/main/ipc/handlers/system.ts
-	registerSystemHandlers({
-		getMainWindow: () => mainWindow,
-		app,
-		settingsStore: store,
-		tunnelManager,
-		getWebServer: () => webServer,
-		bootstrapStore, // For iCloud/sync settings
-	});
-
-	// Claude Code sessions - extracted to src/main/ipc/handlers/claude.ts
-	registerClaudeHandlers({
-		claudeSessionOriginsStore,
-		getMainWindow: () => mainWindow,
-	});
-
-	// Initialize output parsers for all agents (Codex, OpenCode, Claude Code)
-	// This must be called before any agent output is processed
-	initializeOutputParsers();
-
-	// Initialize session storages and register generic agent sessions handlers
-	// This provides the new window.maestro.agentSessions.* API
-	// Pass the shared claudeSessionOriginsStore so session names/stars are consistent
-	initializeSessionStorages({ claudeSessionOriginsStore });
-	registerAgentSessionsHandlers({ getMainWindow: () => mainWindow, agentSessionOriginsStore });
-
-	// Register Group Chat handlers
-	registerGroupChatHandlers({
-		getMainWindow: () => mainWindow,
-		getProcessManager: () => processManager,
-		getAgentDetector: () => agentDetector,
-		getCustomEnvVars: getCustomEnvVarsForAgent,
-		getAgentConfig: getAgentConfigForAgent,
-	});
-
-	// Register Debug Package handlers
-	registerDebugHandlers({
-		getMainWindow: () => mainWindow,
-		getAgentDetector: () => agentDetector,
-		getProcessManager: () => processManager,
-		getWebServer: () => webServer,
-		settingsStore: store,
-		sessionsStore,
-		groupsStore,
-		bootstrapStore,
-	});
-
-	// Register Spec Kit handlers (no dependencies needed)
-	registerSpeckitHandlers();
-
-	// Register OpenSpec handlers (no dependencies needed)
-	registerOpenSpecHandlers();
-
-	// Register BMAD handlers (no dependencies needed)
-	registerBmadHandlers();
-
-	// Register Core Prompts handlers (no dependencies needed)
-	registerPromptsHandlers();
-
-	// Register project Memory handlers (Claude Code per-project memory viewer)
-	registerMemoryHandlers();
-
-	// Register Pianola handlers (autonomous manager: rules, decisions, and the
-	// supervised daemon). The supervisor is constructed during core-service init
-	// above, so it is available here; guard anyway to keep types honest.
-	if (pianolaSupervisor) {
-		registerPianolaHandlers({
-			settingsStore: store,
-			supervisor: pianolaSupervisor,
-		});
-	}
-
-	// Register Plugins handlers (community plugin subsystem, list-only in Phase 0).
-	// The manager is constructed during core-service init above; guard for types.
-	if (pluginManager && pluginAuthStore) {
-		registerPluginsHandlers({
-			settingsStore: store,
-			manager: pluginManager,
-			sandboxHost: pluginSandboxHost ?? undefined,
-			authStore: pluginAuthStore,
-			groupingRegistry: pluginGroupingRegistry ?? undefined,
-		});
-	}
-
-	// Register AgentRun control-plane handlers (neutral run/campaign ledger).
-	registerAgentRunHandlers({
-		getProcessManager: () => processManager,
-		settingsStore: store,
-	});
-
-	// Register Browser Session handlers (clear per-partition browsing data)
-	registerBrowserSessionHandlers();
-
-	// Register Coworking handlers + start the IPC bridge socket and refresh the bundled
-	// MCP-server script. The bridge runs whenever Maestro is up; per-agent activation
-	// is opt-in via Settings → Encore Features → Coworking Setup. Bridge startup is
-	// non-fatal - feature degrades to "not available" until next launch.
-	registerCoworkingHandlers({ getMainWindow: () => mainWindow });
-	void (async () => {
-		try {
-			await ensureCoworkingServerScript();
-			await startCoworkingBridge({
-				resolveSessionFromPid: (pid) =>
-					resolveSessionFromPidWalk(
-						pid,
-						(candidate) => processManager?.getSessionIdByPid(candidate) ?? null
-					),
-			});
-		} catch (err) {
-			// EADDRINUSE means another Maestro process already owns the bridge
-			// socket/pipe for this userData slug. Bridge startup is deliberately
-			// non-fatal (the feature degrades to "not available" until the next
-			// launch), so a second instance losing the race is an expected
-			// outcome rather than a defect worth reporting (MAESTRO-WH).
-			const code = (err as NodeJS.ErrnoException | null)?.code;
-			if (code !== 'EADDRINUSE') {
-				void captureException(err instanceof Error ? err : new Error(String(err)), {
-					operation: 'startup:coworkingBridge',
-				});
-			}
-			logger.warn(`Failed to start coworking bridge: ${String(err)}`, 'Startup');
-		}
-	})();
-	// Register multi-window handlers (windows:* channel surface). Registered here
-	// because the running app wires handlers through setupIpcHandlers(), not
-	// registerAllHandlers(). The registry and window manager are module-scope
-	// instances; lazy getters resolve the live instance at call time.
-	registerWindowsHandlers({
-		getWindowRegistry: () => windowRegistry,
-		getWindowManager: () => windowManager,
-	});
-	// Push registry ownership moves out to every window so each renderer's
-	// WindowContext can refresh which agents it surfaces (and the Left Bar's
-	// cross-window badges). The registry is a module-scope instance, so pass it
-	// directly rather than through the handlers' lazy getter.
-	wireWindowRegistryBroadcast(windowRegistry);
-	// Close a secondary window as soon as its last agent moves out - an empty
-	// secondary shell can surface nothing (every agent is owned by some window),
-	// so the agent-level move flow tidies it up automatically.
-	wireEmptySecondaryWindowAutoClose(windowRegistry);
-	// Persist a window rename or a panel-collapse toggle as soon as it happens
-	// (rather than only on quit), so both survive even an abrupt exit. A panel
-	// toggle fires no window move/resize, so without this its saved value would go
-	// stale. saveWindowState snapshots the whole live registry, so passing the
-	// affected window's id is enough.
-	windowRegistry.onChange((change) => {
-		if ((change.type === 'name-changed' || change.type === 'panel-changed') && change.windowId) {
-			saveWindowState(windowStateStore, windowRegistry, change.windowId);
-		}
-	});
-
-	// Record aggregate multi-window usage telemetry (secondary windows opened +
-	// peak concurrent windows) as windows open. Gated on the user's
-	// `statsCollectionEnabled` analytics setting; records nothing when off, and a
-	// stats failure can never break window creation (see wireMultiWindowTelemetry).
-	wireMultiWindowTelemetry(windowRegistry, { settingsStore: store });
-	// Register Context Merge handlers for session context transfer and grooming
-	registerContextHandlers({
-		getMainWindow: () => mainWindow,
-		getProcessManager: () => processManager,
-		getAgentDetector: () => agentDetector,
-		agentConfigsStore,
-	});
-
-	// Register Marketplace handlers for fetching and importing playbooks
-	registerMarketplaceHandlers({
-		app,
-		settingsStore: store,
-		getMainWindow: () => mainWindow,
-	});
-
-	// Register Stats handlers for usage tracking
-	registerStatsHandlers({
-		getMainWindow: () => mainWindow,
-		settingsStore: store,
-	});
-
-	// Register Cue Stats handlers for the Cue Dashboard aggregation query.
-	// Pass `getCueEngine` so the handler can fall back to the live cue config
-	// when persisted `pipeline_id` is null (legacy events / events recorded
-	// before lineage tracking was enabled).
-	registerCueStatsHandlers({
-		settingsStore: store,
-		getCueEngine: () => cueEngine,
-	});
-
-	// Register Document Graph handlers for file watching
-	registerDocumentGraphHandlers({
-		getMainWindow: () => mainWindow,
-		app,
-	});
-
-	// Register SSH Remote handlers for managing SSH configurations
-	registerSshRemoteHandlers({
-		settingsStore: store,
-	});
-
-	// Set up callback for group chat router to lookup sessions for auto-add @mentions
-	setGetSessionsCallback(() => {
-		const sessions = sessionsStore.get('sessions', []);
-		return sessions.map((s: any) => {
-			// Resolve SSH remote name if session has SSH config
-			let sshRemoteName: string | undefined;
-			if (s.sessionSshRemoteConfig?.enabled && s.sessionSshRemoteConfig.remoteId) {
-				const sshConfig = getSshRemoteById(s.sessionSshRemoteConfig.remoteId);
-				sshRemoteName = sshConfig?.name;
-			}
-			return {
-				id: s.id,
-				name: s.name,
-				toolType: s.toolType,
-				cwd: s.cwd || s.fullPath || os.homedir(),
-				customArgs: s.customArgs,
-				customEnvVars: s.customEnvVars,
-				customModel: s.customModel,
-				// Claude token-source selection, so group chat participants honor
-				// the same maestro-p TUI / API / dynamic choice as their agent.
-				enableMaestroP: s.enableMaestroP,
-				maestroPMode: s.maestroPMode,
-				maestroPPath: s.maestroPPath,
-				sshRemoteName,
-				// Pass full SSH config for remote execution support
-				sshRemoteConfig: s.sessionSshRemoteConfig,
-				autoRunFolderPath: s.autoRunFolderPath,
-				worktreeBasePath: s.worktreeConfig?.basePath,
-			};
-		});
-	});
-
-	// Set up callback for group chat router to lookup custom env vars for agents
-	setGetCustomEnvVarsCallback(getCustomEnvVarsForAgent);
-	setGetAgentConfigCallback(getAgentConfigForAgent);
-
-	// Set up callback for group chat router to get moderator conductor profile
-	setGetModeratorSettingsCallback(() => ({
-		conductorProfile: (store.get('conductorProfile', '') as string) || '',
-	}));
-
-	// Set up SSH store for group chat SSH remote execution support
-	setSshStore(createSshRemoteStoreAdapter(store));
-
-	// Set up callback for group chat to get custom shell path (for Windows PowerShell preference)
-	// This is used by both group-chat-router.ts and group-chat-agent.ts via the shared config module
-	const getCustomShellPathFn = () => store.get('customShellPath', '') as string | undefined;
-	setGetCustomShellPathCallback(getCustomShellPathFn);
-
-	// Setup logger event forwarding to renderer
-	setupLoggerEventForwarding(() => mainWindow);
-
-	// Register filesystem handlers (extracted to handlers/filesystem.ts)
-	registerFilesystemHandlers();
-
-	// System operations (dialog, fonts, shells, tunnel, devtools, updates, logger)
-	// extracted to src/main/ipc/handlers/system.ts
-
-	// Claude Code sessions - extracted to src/main/ipc/handlers/claude.ts
-
-	// Agent Error Handling API - extracted to src/main/ipc/handlers/agent-error.ts
-	registerAgentErrorHandlers();
-
-	// Register notification handlers (extracted to handlers/notifications.ts)
-	registerNotificationsHandlers({ getMainWindow: () => mainWindow });
-
-	// Register attachments handlers (extracted to handlers/attachments.ts)
-	registerAttachmentsHandlers({ app });
-
-	// Register leaderboard handlers (extracted to handlers/leaderboard.ts)
-	registerLeaderboardHandlers({
-		app,
-		settingsStore: store,
-	});
-
-	// Register Symphony handlers for token donation / open source contributions
-	registerSymphonyHandlers({
-		app,
-		getMainWindow: () => mainWindow,
-		sessionsStore,
-		settingsStore: store,
-	});
-
-	// Register tab naming handlers for automatic tab naming
-	registerTabNamingHandlers({
-		getProcessManager: () => processManager,
-		getAgentDetector: () => agentDetector,
-		agentConfigsStore,
-		settingsStore: store,
-	});
-
-	// Register WakaTime handlers (CLI check, API key validation)
-	registerWakatimeHandlers(wakatimeManager);
-
-	// Register Maestro CLI handlers (status check + install/update)
-	registerMaestroCliHandlers(maestroCliManager);
-
-	// Register feedback handlers (gh auth + feedback submission)
-	registerFeedbackHandlers({
-		getProcessManager: () => processManager,
-		debugPackageDeps: {
-			getAgentDetector: () => agentDetector,
-			getProcessManager: () => processManager,
-			getWebServer: () => webServer,
-			settingsStore: store,
-			sessionsStore,
-			groupsStore,
-			bootstrapStore,
-		},
-	});
-}
-
-// Handle process output streaming (set up after initialization)
-// Phase 3 refactoring - delegates to extracted process-listeners module
-function setupProcessListeners() {
-	if (processManager) {
-		setupProcessListenersModule(processManager, {
-			getProcessManager: () => processManager,
-			getWebServer: () => webServer,
-			getAgentDetector: () => agentDetector,
-			safeSend,
-			powerManager,
-			groupChatEmitters,
-			emitPluginEvent: (event) => pluginEventBus?.emit(event),
-			groupChatRouter: {
-				routeModeratorResponse,
-				routeAgentResponse,
-				markParticipantResponded,
-				spawnModeratorSynthesis,
-				getGroupChatReadOnlyState,
-				respawnParticipantWithRecovery,
-				clearActiveParticipantTaskSession,
-				clearModeratorResponseTimeout,
-			},
-			groupChatStorage: {
-				loadGroupChat,
-				updateGroupChat,
-				updateParticipant,
-			},
-			sessionRecovery: {
-				needsSessionRecovery,
-				initiateSessionRecovery,
-			},
-			outputBuffer: {
-				appendToGroupChatBuffer,
-				getGroupChatBufferedOutput,
-				clearGroupChatBuffer,
-			},
-			outputParser: {
-				extractTextFromStreamJson,
-				parseParticipantSessionId,
-			},
-			usageAggregator: {
-				calculateContextTokens,
-			},
-			getStatsDB,
-			debugLog,
-			patterns: {
-				REGEX_MODERATOR_SESSION,
-				REGEX_MODERATOR_SESSION_TIMESTAMP,
-				REGEX_AI_SUFFIX,
-				REGEX_AI_TAB_ID,
-				REGEX_BATCH_SESSION,
-				REGEX_SYNOPSIS_SESSION,
-			},
-			logger,
-			getCueEngine: () => cueEngine,
-			isCueEnabled: () => {
-				const ef = store.get('encoreFeatures', {}) as Record<string, boolean>;
-				return !!ef.maestroCue;
-			},
-			getSshRemoteByName: (name: string) => {
-				const remotes = store.get('sshRemotes', []);
-				return remotes.find((r) => r.name === name) ?? null;
-			},
-			getAgentContextWindow: (agentId: string) => {
-				// Prefer a runtime-discovered context window from the capability
-				// snapshot if one was probed. Falls back to the static table and
-				// finally to the agent definition's configOption default.
-				const snapshot = capabilitySnapshots.get(agentId);
-				if (typeof snapshot?.contextWindow === 'number' && snapshot.contextWindow > 0) {
-					return snapshot.contextWindow;
-				}
-				const def = getAgentDefinition(agentId);
-				const contextOpt = def?.configOptions?.find((o) => o.key === 'contextWindow');
-				const fallbackDefault =
-					typeof contextOpt?.default === 'number' ? contextOpt.default : FALLBACK_CONTEXT_WINDOW;
-				return DEFAULT_CONTEXT_WINDOWS[agentId as AgentId] ?? fallbackDefault;
-			},
-		});
-
-		// WakaTime heartbeat listener (query-complete → heartbeat, exit → cleanup)
-		setupWakaTimeListener(processManager, wakatimeManager, store);
-	}
-}

--- a/src/main/ipc/bootstrap/index.ts
+++ b/src/main/ipc/bootstrap/index.ts
@@ -1,0 +1,507 @@
+/**
+ * Single-entry orchestrator for all IPC handler registrations plus a handful
+ * of inline wiring blocks (group-chat mention/session callbacks, the
+ * coworking bridge startup, window-registry persistence).
+ *
+ * Extracted verbatim out of main/index.ts's setupIpcHandlers() (Phase 5
+ * refactoring) - same call order preserved exactly, including the
+ * currently-dead-but-present raw `mainWindow` field passed alongside
+ * `getMainWindow` into registerAutorunHandlers/registerPlaybooksHandlers
+ * (only the getter is ever read; do not "clean this up", it's tracked as a
+ * separate follow-up).
+ */
+
+import {
+	registerGitHandlers,
+	registerAutorunHandlers,
+	registerPlaybooksHandlers,
+	registerHistoryHandlers,
+	registerAgentsHandlers,
+	registerProcessHandlers,
+	registerPersistenceHandlers,
+	registerSystemHandlers,
+	registerClaudeHandlers,
+	registerAgentSessionsHandlers,
+	registerGroupChatHandlers,
+	registerDebugHandlers,
+	registerSpeckitHandlers,
+	registerOpenSpecHandlers,
+	registerBmadHandlers,
+	registerContextHandlers,
+	registerMarketplaceHandlers,
+	registerStatsHandlers,
+	registerCueStatsHandlers,
+	registerDocumentGraphHandlers,
+	registerSshRemoteHandlers,
+	registerFilesystemHandlers,
+	registerAttachmentsHandlers,
+	registerWebHandlers,
+	registerLeaderboardHandlers,
+	registerNotificationsHandlers,
+	registerSymphonyHandlers,
+	registerTabNamingHandlers,
+	registerAgentErrorHandlers,
+	registerDirectorNotesHandlers,
+	registerCrossAgentHandlers,
+	registerCueHandlers,
+	registerCueBackupHandlers,
+	registerWakatimeHandlers,
+	registerFeedbackHandlers,
+	registerMaestroCliHandlers,
+	registerPromptsHandlers,
+	registerMemoryHandlers,
+	registerPianolaHandlers,
+	registerPluginsHandlers,
+	registerAgentRunHandlers,
+	registerCoworkingHandlers,
+	registerBrowserSessionHandlers,
+	registerWindowsHandlers,
+	wireWindowRegistryBroadcast,
+	wireEmptySecondaryWindowAutoClose,
+	setupLoggerEventForwarding,
+} from '../handlers';
+import { wireMultiWindowTelemetry } from '../../stats';
+import { saveWindowState } from '../../window-state-persistence';
+import { ensureCoworkingServerScript } from '../../coworking/coworking-server-paths';
+import { startCoworkingBridge } from '../../coworking/coworking-bridge';
+import { resolveSessionFromPidWalk } from '../../coworking/pid-resolution';
+import { initializeOutputParsers } from '../../parsers';
+import { initializeSessionStorages } from '../../storage';
+import { getCueProcessList } from '../../cue/cue-executor';
+import { getSshRemoteById } from '../../stores';
+import { createSshRemoteStoreAdapter } from '../../utils/ssh-remote-resolver';
+import { tunnelManager } from '../../tunnel-manager';
+import { captureException } from '../../utils/sentry';
+import { logger } from '../../utils/logger';
+import {
+	setGetSessionsCallback,
+	setGetCustomEnvVarsCallback,
+	setGetAgentConfigCallback,
+	setGetModeratorSettingsCallback,
+	setSshStore,
+	setGetCustomShellPathCallback,
+} from '../../group-chat/group-chat-router';
+import { mapSessionsForMentions } from './session-mention-mapper';
+import type { IpcBootstrapDependencies } from './types';
+
+export type { IpcBootstrapDependencies } from './types';
+
+export function setupIpcHandlers(deps: IpcBootstrapDependencies): void {
+	// Settings, sessions, and groups persistence - extracted to src/main/ipc/handlers/persistence.ts
+
+	// Web/Live handlers - extracted to src/main/ipc/handlers/web.ts
+	registerWebHandlers({
+		getWebServer: deps.getWebServer,
+		setWebServer: deps.setWebServer,
+		createWebServer: deps.createWebServer,
+		settingsStore: deps.settingsStore,
+	});
+
+	// Git operations - extracted to src/main/ipc/handlers/git.ts
+	registerGitHandlers({
+		settingsStore: deps.settingsStore,
+		getMainWindow: deps.getMainWindow,
+	});
+
+	// Auto Run operations - extracted to src/main/ipc/handlers/autorun.ts
+	registerAutorunHandlers({
+		mainWindow: deps.getMainWindow(),
+		getMainWindow: deps.getMainWindow,
+		app: deps.app,
+		settingsStore: deps.settingsStore,
+	});
+
+	// Playbook operations - extracted to src/main/ipc/handlers/playbooks.ts
+	registerPlaybooksHandlers({
+		mainWindow: deps.getMainWindow(),
+		getMainWindow: deps.getMainWindow,
+		app: deps.app,
+	});
+
+	// History operations - extracted to src/main/ipc/handlers/history.ts
+	// Uses HistoryManager singleton for per-session storage
+	registerHistoryHandlers({
+		safeSend: deps.safeSend,
+		emitPluginEvent: (event) => deps.getPluginEventBus()?.emit(event),
+		getMaxEntries: () => deps.settingsStore.get('maxLogBuffer', 5000) as number,
+		getSshRemoteById,
+		getSessionById: (id: string) => {
+			const sessions = (
+				deps.sessionsStore.get('sessions', []) as Array<Record<string, unknown>>
+			).filter((s) => typeof s === 'object' && s !== null);
+			return sessions.find((s) => s.id === id);
+		},
+	});
+
+	// Director's Notes - unified history + synopsis generation
+	registerDirectorNotesHandlers({
+		getProcessManager: deps.getProcessManager,
+		getAgentDetector: deps.getAgentDetector,
+		agentConfigsStore: deps.agentConfigsStore,
+		getMainWindow: deps.getMainWindow,
+	});
+
+	// Cross-agent @mention dispatch - streams a target agent's response back
+	// into the source agent's transcript (Phase 03).
+	registerCrossAgentHandlers({
+		getProcessManager: deps.getProcessManager,
+		getAgentDetector: deps.getAgentDetector,
+		sessionsStore: deps.sessionsStore,
+		agentConfigsStore: deps.agentConfigsStore,
+		settingsStore: deps.settingsStore,
+		sshStore: createSshRemoteStoreAdapter(deps.settingsStore),
+		getCustomEnvVars: deps.getCustomEnvVarsForAgent,
+		safeSend: deps.safeSend,
+	});
+
+	// Cue - event-driven automation engine
+	registerCueHandlers({
+		getCueEngine: deps.getCueEngine,
+	});
+
+	// Cue Backup - snapshot / restore .maestro/cue.yaml + prompts (Cue modal Backup tab)
+	registerCueBackupHandlers({
+		sessionsStore: deps.sessionsStore,
+	});
+
+	// Agent management operations - extracted to src/main/ipc/handlers/agents.ts
+	registerAgentsHandlers({
+		getAgentDetector: deps.getAgentDetector,
+		agentConfigsStore: deps.agentConfigsStore,
+		settingsStore: deps.settingsStore,
+		sessionsStore: deps.sessionsStore,
+	});
+
+	// Process management operations - extracted to src/main/ipc/handlers/process.ts
+	registerProcessHandlers({
+		getProcessManager: deps.getProcessManager,
+		getAgentDetector: deps.getAgentDetector,
+		agentConfigsStore: deps.agentConfigsStore,
+		settingsStore: deps.settingsStore,
+		getMainWindow: deps.getMainWindow,
+		safeSend: deps.safeSend,
+		sessionsStore: deps.sessionsStore,
+		interactiveReplayController: deps.getInteractiveReplayController() ?? undefined,
+		getCueProcesses: () => {
+			// Always query the executor's active process map - processes may still be
+			// running even if the engine has been disabled (in-flight runs complete
+			// independently of engine state).
+			const processList = getCueProcessList();
+			if (processList.length === 0) return [];
+			const activeRuns = deps.getCueEngine()?.getActiveRuns() ?? [];
+			// Merge PID/command data from executor with metadata from run manager
+			return processList.map((proc) => {
+				const run = activeRuns.find((r) => r.runId === proc.runId);
+				return {
+					...proc,
+					sessionName: run?.sessionName ?? '',
+					subscriptionName: run?.subscriptionName ?? '',
+					eventType: run?.event.type ?? '',
+				};
+			});
+		},
+	});
+
+	// Persistence operations - extracted to src/main/ipc/handlers/persistence.ts
+	const persistenceHandlers = registerPersistenceHandlers({
+		settingsStore: deps.settingsStore,
+		sessionsStore: deps.sessionsStore,
+		groupsStore: deps.groupsStore,
+		getWebServer: deps.getWebServer,
+		// Metadata-only session/agent lifecycle -> subscribed plugins. Null-safe:
+		// the bus is created during plugin init and re-authorizes every delivery
+		// against live grants, so this is a no-op when plugins are disabled.
+		emitPluginEvent: (event) => deps.getPluginEventBus()?.emit(event),
+	});
+	// Wire the plugin focus verbs into the persistence layer's session.activated
+	// dedupe so the two emit paths share one last-emitted id.
+	deps.setNoteSessionActivated(persistenceHandlers.noteSessionActivated);
+
+	// System operations - extracted to src/main/ipc/handlers/system.ts
+	registerSystemHandlers({
+		getMainWindow: deps.getMainWindow,
+		app: deps.app,
+		settingsStore: deps.settingsStore,
+		tunnelManager,
+		getWebServer: deps.getWebServer,
+		bootstrapStore: deps.bootstrapStore, // For iCloud/sync settings
+	});
+
+	// Claude Code sessions - extracted to src/main/ipc/handlers/claude.ts
+	registerClaudeHandlers({
+		claudeSessionOriginsStore: deps.claudeSessionOriginsStore,
+		getMainWindow: deps.getMainWindow,
+	});
+
+	// Initialize output parsers for all agents (Codex, OpenCode, Claude Code)
+	// This must be called before any agent output is processed
+	initializeOutputParsers();
+
+	// Initialize session storages and register generic agent sessions handlers
+	// This provides the new window.maestro.agentSessions.* API
+	// Pass the shared claudeSessionOriginsStore so session names/stars are consistent
+	initializeSessionStorages({ claudeSessionOriginsStore: deps.claudeSessionOriginsStore });
+	registerAgentSessionsHandlers({
+		getMainWindow: deps.getMainWindow,
+		agentSessionOriginsStore: deps.agentSessionOriginsStore,
+	});
+
+	// Register Group Chat handlers
+	registerGroupChatHandlers({
+		getMainWindow: deps.getMainWindow,
+		getProcessManager: deps.getProcessManager,
+		getAgentDetector: deps.getAgentDetector,
+		getCustomEnvVars: deps.getCustomEnvVarsForAgent,
+		getAgentConfig: deps.getAgentConfigForAgent,
+	});
+
+	// Register Debug Package handlers
+	registerDebugHandlers({
+		getMainWindow: deps.getMainWindow,
+		getAgentDetector: deps.getAgentDetector,
+		getProcessManager: deps.getProcessManager,
+		getWebServer: deps.getWebServer,
+		settingsStore: deps.settingsStore,
+		sessionsStore: deps.sessionsStore,
+		groupsStore: deps.groupsStore,
+		bootstrapStore: deps.bootstrapStore,
+	});
+
+	// Register Spec Kit handlers (no dependencies needed)
+	registerSpeckitHandlers();
+
+	// Register OpenSpec handlers (no dependencies needed)
+	registerOpenSpecHandlers();
+
+	// Register BMAD handlers (no dependencies needed)
+	registerBmadHandlers();
+
+	// Register Core Prompts handlers (no dependencies needed)
+	registerPromptsHandlers();
+
+	// Register project Memory handlers (Claude Code per-project memory viewer)
+	registerMemoryHandlers();
+
+	// Register Pianola handlers (autonomous manager: rules, decisions, and the
+	// supervised daemon). The supervisor is constructed during core-service init
+	// above, so it is available here; guard anyway to keep types honest.
+	const pianolaSupervisor = deps.getPianolaSupervisor();
+	if (pianolaSupervisor) {
+		registerPianolaHandlers({
+			settingsStore: deps.settingsStore,
+			supervisor: pianolaSupervisor,
+		});
+	}
+
+	// Register Plugins handlers (community plugin subsystem, list-only in Phase 0).
+	// The manager is constructed during core-service init above; guard for types.
+	const pluginManager = deps.getPluginManager();
+	const pluginAuthStore = deps.getPluginAuthStore();
+	if (pluginManager && pluginAuthStore) {
+		registerPluginsHandlers({
+			settingsStore: deps.settingsStore,
+			manager: pluginManager,
+			sandboxHost: deps.getPluginSandboxHost() ?? undefined,
+			authStore: pluginAuthStore,
+			groupingRegistry: deps.getPluginGroupingRegistry() ?? undefined,
+		});
+	}
+
+	// Register AgentRun control-plane handlers (neutral run/campaign ledger).
+	registerAgentRunHandlers({
+		getProcessManager: deps.getProcessManager,
+		settingsStore: deps.settingsStore,
+	});
+
+	// Register Browser Session handlers (clear per-partition browsing data)
+	registerBrowserSessionHandlers();
+
+	// Register Coworking handlers + start the IPC bridge socket and refresh the bundled
+	// MCP-server script. The bridge runs whenever Maestro is up; per-agent activation
+	// is opt-in via Settings -> Encore Features -> Coworking Setup. Bridge startup is
+	// non-fatal - feature degrades to "not available" until next launch.
+	registerCoworkingHandlers({ getMainWindow: deps.getMainWindow });
+	void (async () => {
+		try {
+			await ensureCoworkingServerScript();
+			await startCoworkingBridge({
+				resolveSessionFromPid: (pid) =>
+					resolveSessionFromPidWalk(
+						pid,
+						(candidate) => deps.getProcessManager()?.getSessionIdByPid(candidate) ?? null
+					),
+			});
+		} catch (err) {
+			// EADDRINUSE means another Maestro process already owns the bridge
+			// socket/pipe for this userData slug. Bridge startup is deliberately
+			// non-fatal (the feature degrades to "not available" until the next
+			// launch), so a second instance losing the race is an expected
+			// outcome rather than a defect worth reporting (MAESTRO-WH).
+			const code = (err as NodeJS.ErrnoException | null)?.code;
+			if (code !== 'EADDRINUSE') {
+				void captureException(err instanceof Error ? err : new Error(String(err)), {
+					operation: 'startup:coworkingBridge',
+				});
+			}
+			logger.warn(`Failed to start coworking bridge: ${String(err)}`, 'Startup');
+		}
+	})();
+	// Register multi-window handlers (windows:* channel surface). Registered here
+	// because the running app wires handlers through setupIpcHandlers(), not
+	// registerAllHandlers(). The registry and window manager are module-scope
+	// instances; lazy getters resolve the live instance at call time.
+	registerWindowsHandlers({
+		getWindowRegistry: () => deps.windowRegistry,
+		getWindowManager: () => deps.windowManager,
+	});
+	// Push registry ownership moves out to every window so each renderer's
+	// WindowContext can refresh which agents it surfaces (and the Left Bar's
+	// cross-window badges). The registry is a module-scope instance, so pass it
+	// directly rather than through the handlers' lazy getter.
+	wireWindowRegistryBroadcast(deps.windowRegistry);
+	// Close a secondary window as soon as its last agent moves out - an empty
+	// secondary shell can surface nothing (every agent is owned by some window),
+	// so the agent-level move flow tidies it up automatically.
+	wireEmptySecondaryWindowAutoClose(deps.windowRegistry);
+	// Persist a window rename or a panel-collapse toggle as soon as it happens
+	// (rather than only on quit), so both survive even an abrupt exit. A panel
+	// toggle fires no window move/resize, so without this its saved value would go
+	// stale. saveWindowState snapshots the whole live registry, so passing the
+	// affected window's id is enough.
+	deps.windowRegistry.onChange((change) => {
+		if ((change.type === 'name-changed' || change.type === 'panel-changed') && change.windowId) {
+			saveWindowState(deps.windowStateStore, deps.windowRegistry, change.windowId);
+		}
+	});
+
+	// Record aggregate multi-window usage telemetry (secondary windows opened +
+	// peak concurrent windows) as windows open. Gated on the user's
+	// `statsCollectionEnabled` analytics setting; records nothing when off, and a
+	// stats failure can never break window creation (see wireMultiWindowTelemetry).
+	wireMultiWindowTelemetry(deps.windowRegistry, { settingsStore: deps.settingsStore });
+	// Register Context Merge handlers for session context transfer and grooming
+	registerContextHandlers({
+		getMainWindow: deps.getMainWindow,
+		getProcessManager: deps.getProcessManager,
+		getAgentDetector: deps.getAgentDetector,
+		agentConfigsStore: deps.agentConfigsStore,
+	});
+
+	// Register Marketplace handlers for fetching and importing playbooks
+	registerMarketplaceHandlers({
+		app: deps.app,
+		settingsStore: deps.settingsStore,
+		getMainWindow: deps.getMainWindow,
+	});
+
+	// Register Stats handlers for usage tracking
+	registerStatsHandlers({
+		getMainWindow: deps.getMainWindow,
+		settingsStore: deps.settingsStore,
+	});
+
+	// Register Cue Stats handlers for the Cue Dashboard aggregation query.
+	// Pass `getCueEngine` so the handler can fall back to the live cue config
+	// when persisted `pipeline_id` is null (legacy events / events recorded
+	// before lineage tracking was enabled).
+	registerCueStatsHandlers({
+		settingsStore: deps.settingsStore,
+		getCueEngine: deps.getCueEngine,
+	});
+
+	// Register Document Graph handlers for file watching
+	registerDocumentGraphHandlers({
+		getMainWindow: deps.getMainWindow,
+		app: deps.app,
+	});
+
+	// Register SSH Remote handlers for managing SSH configurations
+	registerSshRemoteHandlers({
+		settingsStore: deps.settingsStore,
+	});
+
+	// Set up callback for group chat router to lookup sessions for auto-add @mentions
+	setGetSessionsCallback(() =>
+		mapSessionsForMentions(deps.sessionsStore.get('sessions', []), getSshRemoteById)
+	);
+
+	// Set up callback for group chat router to lookup custom env vars for agents
+	setGetCustomEnvVarsCallback(deps.getCustomEnvVarsForAgent);
+	setGetAgentConfigCallback(deps.getAgentConfigForAgent);
+
+	// Set up callback for group chat router to get moderator conductor profile
+	setGetModeratorSettingsCallback(() => ({
+		conductorProfile: (deps.settingsStore.get('conductorProfile', '') as string) || '',
+	}));
+
+	// Set up SSH store for group chat SSH remote execution support
+	setSshStore(createSshRemoteStoreAdapter(deps.settingsStore));
+
+	// Set up callback for group chat to get custom shell path (for Windows PowerShell preference)
+	// This is used by both group-chat-router.ts and group-chat-agent.ts via the shared config module
+	const getCustomShellPathFn = () =>
+		deps.settingsStore.get('customShellPath', '') as string | undefined;
+	setGetCustomShellPathCallback(getCustomShellPathFn);
+
+	// Setup logger event forwarding to renderer
+	setupLoggerEventForwarding(deps.getMainWindow);
+
+	// Register filesystem handlers (extracted to handlers/filesystem.ts)
+	registerFilesystemHandlers();
+
+	// System operations (dialog, fonts, shells, tunnel, devtools, updates, logger)
+	// extracted to src/main/ipc/handlers/system.ts
+
+	// Claude Code sessions - extracted to src/main/ipc/handlers/claude.ts
+
+	// Agent Error Handling API - extracted to src/main/ipc/handlers/agent-error.ts
+	registerAgentErrorHandlers();
+
+	// Register notification handlers (extracted to handlers/notifications.ts)
+	registerNotificationsHandlers({ getMainWindow: deps.getMainWindow });
+
+	// Register attachments handlers (extracted to handlers/attachments.ts)
+	registerAttachmentsHandlers({ app: deps.app });
+
+	// Register leaderboard handlers (extracted to handlers/leaderboard.ts)
+	registerLeaderboardHandlers({
+		app: deps.app,
+		settingsStore: deps.settingsStore,
+	});
+
+	// Register Symphony handlers for token donation / open source contributions
+	registerSymphonyHandlers({
+		app: deps.app,
+		getMainWindow: deps.getMainWindow,
+		sessionsStore: deps.sessionsStore,
+		settingsStore: deps.settingsStore,
+	});
+
+	// Register tab naming handlers for automatic tab naming
+	registerTabNamingHandlers({
+		getProcessManager: deps.getProcessManager,
+		getAgentDetector: deps.getAgentDetector,
+		agentConfigsStore: deps.agentConfigsStore,
+		settingsStore: deps.settingsStore,
+	});
+
+	// Register WakaTime handlers (CLI check, API key validation)
+	registerWakatimeHandlers(deps.wakatimeManager);
+
+	// Register Maestro CLI handlers (status check + install/update)
+	registerMaestroCliHandlers(deps.maestroCliManager);
+
+	// Register feedback handlers (gh auth + feedback submission)
+	registerFeedbackHandlers({
+		getProcessManager: deps.getProcessManager,
+		debugPackageDeps: {
+			getAgentDetector: deps.getAgentDetector,
+			getProcessManager: deps.getProcessManager,
+			getWebServer: deps.getWebServer,
+			settingsStore: deps.settingsStore,
+			sessionsStore: deps.sessionsStore,
+			groupsStore: deps.groupsStore,
+			bootstrapStore: deps.bootstrapStore,
+		},
+	});
+}

--- a/src/main/ipc/bootstrap/session-mention-mapper.ts
+++ b/src/main/ipc/bootstrap/session-mention-mapper.ts
@@ -1,0 +1,44 @@
+/**
+ * Maps raw persisted sessions into the shape the group-chat router needs to
+ * resolve @mention auto-add targets.
+ *
+ * Extracted verbatim out of main/index.ts's setupIpcHandlers()
+ * (setGetSessionsCallback) - the one piece of real logic in that function,
+ * isolated here for reviewability (Phase 5 refactoring).
+ */
+
+import os from 'os';
+import type { getSshRemoteById } from '../../stores';
+
+export function mapSessionsForMentions(
+	sessions: any[],
+	getSshRemoteByIdFn: typeof getSshRemoteById
+) {
+	return sessions.map((s: any) => {
+		// Resolve SSH remote name if session has SSH config
+		let sshRemoteName: string | undefined;
+		if (s.sessionSshRemoteConfig?.enabled && s.sessionSshRemoteConfig.remoteId) {
+			const sshConfig = getSshRemoteByIdFn(s.sessionSshRemoteConfig.remoteId);
+			sshRemoteName = sshConfig?.name;
+		}
+		return {
+			id: s.id,
+			name: s.name,
+			toolType: s.toolType,
+			cwd: s.cwd || s.fullPath || os.homedir(),
+			customArgs: s.customArgs,
+			customEnvVars: s.customEnvVars,
+			customModel: s.customModel,
+			// Claude token-source selection, so group chat participants honor
+			// the same maestro-p TUI / API / dynamic choice as their agent.
+			enableMaestroP: s.enableMaestroP,
+			maestroPMode: s.maestroPMode,
+			maestroPPath: s.maestroPPath,
+			sshRemoteName,
+			// Pass full SSH config for remote execution support
+			sshRemoteConfig: s.sessionSshRemoteConfig,
+			autoRunFolderPath: s.autoRunFolderPath,
+			worktreeBasePath: s.worktreeConfig?.basePath,
+		};
+	});
+}

--- a/src/main/ipc/bootstrap/types.ts
+++ b/src/main/ipc/bootstrap/types.ts
@@ -1,0 +1,68 @@
+import type { App, BrowserWindow } from 'electron';
+import type { ProcessManager } from '../../process-manager';
+import type { WebServer } from '../../web-server';
+import type { AgentDetector } from '../../agents';
+import type { CueEngine } from '../../cue/cue-engine';
+import type { PianolaSupervisor } from '../../pianola/pianola-supervisor';
+import type { PluginManager } from '../../plugins/plugin-manager';
+import type { PluginSandboxHost } from '../../plugins/plugin-sandbox-host';
+import type { PluginGroupingRegistry } from '../../plugins/plugin-grouping-registry';
+import type { AuthorizationStore } from '../../plugins/authorization-ledger';
+import type { PluginEventBusImpl } from '../../plugins/plugin-event-bus';
+import type { InteractiveReplayController } from '../../agents/claude-interactive-replay';
+import type { ProcessConfig as ProcessSpawnConfig } from '../../process-manager/types';
+import type { WakaTimeManager } from '../../wakatime-manager';
+import type { MaestroCliManager } from '../../maestro-cli-manager';
+import type { SafeSendFn } from '../../utils/safe-send';
+import type { WindowRegistry } from '../../window-registry';
+import type { createWindowManager } from '../../app-lifecycle';
+import type { createWebServerFactory } from '../../web-server/web-server-factory';
+import type {
+	getSettingsStore,
+	getSessionsStore,
+	getGroupsStore,
+	getAgentConfigsStore,
+	getWindowStateStore,
+	getClaudeSessionOriginsStore,
+	getAgentSessionOriginsStore,
+	initializeStores,
+} from '../../stores';
+
+export interface IpcBootstrapDependencies {
+	// getters - mutable `let` singletons that stay declared in index.ts
+	getMainWindow: () => BrowserWindow | null;
+	getProcessManager: () => ProcessManager | null;
+	getWebServer: () => WebServer | null;
+	getAgentDetector: () => AgentDetector | null;
+	getCueEngine: () => CueEngine | null;
+	getPianolaSupervisor: () => PianolaSupervisor | null;
+	getPluginManager: () => PluginManager | null;
+	getPluginSandboxHost: () => PluginSandboxHost | null;
+	getPluginGroupingRegistry: () => PluginGroupingRegistry | null;
+	getPluginAuthStore: () => AuthorizationStore | null;
+	getPluginEventBus: () => PluginEventBusImpl | null;
+	getInteractiveReplayController: () => InteractiveReplayController<ProcessSpawnConfig> | null;
+
+	// setters - out-params this module currently mutates back in index.ts
+	setWebServer: (server: WebServer | null) => void;
+	setNoteSessionActivated: (fn: (sessionId: string) => void) => void;
+
+	// plain values - stable consts in index.ts, never reassigned
+	app: App;
+	settingsStore: ReturnType<typeof getSettingsStore>;
+	sessionsStore: ReturnType<typeof getSessionsStore>;
+	groupsStore: ReturnType<typeof getGroupsStore>;
+	agentConfigsStore: ReturnType<typeof getAgentConfigsStore>;
+	windowStateStore: ReturnType<typeof getWindowStateStore>;
+	claudeSessionOriginsStore: ReturnType<typeof getClaudeSessionOriginsStore>;
+	agentSessionOriginsStore: ReturnType<typeof getAgentSessionOriginsStore>;
+	bootstrapStore: ReturnType<typeof initializeStores>['bootstrapStore'];
+	safeSend: SafeSendFn;
+	windowRegistry: WindowRegistry;
+	windowManager: ReturnType<typeof createWindowManager>;
+	createWebServer: ReturnType<typeof createWebServerFactory>;
+	wakatimeManager: WakaTimeManager;
+	maestroCliManager: MaestroCliManager;
+	getAgentConfigForAgent: (agentId: string) => Record<string, any>;
+	getCustomEnvVarsForAgent: (agentId: string) => Record<string, string> | undefined;
+}

--- a/src/main/ipc/handlers/cross-agent.ts
+++ b/src/main/ipc/handlers/cross-agent.ts
@@ -80,7 +80,8 @@ export function registerCrossAgentHandlers(deps: CrossAgentHandlerDependencies):
 	const getTargetSession = (sessionId: string): CrossAgentTargetSession | null => {
 		const sessions = sessionsStore.get('sessions', []) as Array<Record<string, unknown>>;
 		const s = sessions.find((x) => x && typeof x === 'object' && x.id === sessionId) as
-			Record<string, any> | undefined;
+			| Record<string, any>
+			| undefined;
 		if (!s) return null;
 		return {
 			id: s.id,

--- a/src/main/ipc/handlers/cue-stats.ts
+++ b/src/main/ipc/handlers/cue-stats.ts
@@ -122,8 +122,9 @@ export function registerCueStatsHandlers(deps: CueStatsHandlerDependencies): voi
 	// turned that flag on with a permanently blank Cue subtotal.
 	ipcMain.handle(
 		'cue-stats:get-historical-conductor-credit',
-		withIpcErrorLogging(handlerOpts('getHistoricalConductorCredit'), async (): Promise<number> =>
-			getHistoricalConductorCreditMs()
+		withIpcErrorLogging(
+			handlerOpts('getHistoricalConductorCredit'),
+			async (): Promise<number> => getHistoricalConductorCreditMs()
 		)
 	);
 }

--- a/src/main/ipc/handlers/system.ts
+++ b/src/main/ipc/handlers/system.ts
@@ -490,7 +490,13 @@ export function registerSystemHandlers(deps: SystemHandlerDependencies): void {
 			const typedFilter = filter
 				? {
 						level: filter.level as
-							'debug' | 'info' | 'warn' | 'error' | 'toast' | 'autorun' | undefined,
+							| 'debug'
+							| 'info'
+							| 'warn'
+							| 'error'
+							| 'toast'
+							| 'autorun'
+							| undefined,
 						context: filter.context,
 						limit: filter.limit,
 					}

--- a/src/main/parsers/codex-output-parser.ts
+++ b/src/main/parsers/codex-output-parser.ts
@@ -146,8 +146,7 @@ function readCodexConfig(): { model?: string; contextWindow?: number } {
  * Supports both current (response_item/event_msg) and legacy (item.completed) formats
  */
 interface CodexRawMessage {
-	type?:
-		// Current format (v0.111.0+)
+	type?: // Current format (v0.111.0+)
 		| 'session_meta'
 		| 'response_item'
 		| 'event_msg'

--- a/src/main/pianola/pianola-lifecycle.ts
+++ b/src/main/pianola/pianola-lifecycle.ts
@@ -1,0 +1,148 @@
+/**
+ * Constructs the Pianola supervised daemon and its scheduled re-learn job.
+ *
+ * Only construction and the two pure CLI-mining/rules-read helpers live here
+ * - the supervisor/scheduler instances themselves stay as `let`s in
+ * main/index.ts because they're read and mutated from several other
+ * unscoped locations there (start, stop, the first-party supervisor
+ * cross-wire, IPC registration). See CLAUDE.md's decomposition plan for
+ * src/main/index.ts (Phase 5 refactoring).
+ */
+
+import { spawn, type ChildProcess } from 'child_process';
+import { resolveMaestroCliScriptPath } from '../cue/cue-cli-executor';
+import { PianolaSupervisor } from './pianola-supervisor';
+import { PianolaRelearnScheduler } from './pianola-relearn-scheduler';
+import { runRelearnJob } from './pianola-relearn';
+import { readRules, writeSuggestions, getProfile } from './pianola-store-main';
+import type { DecisionPair } from '../../shared/pianola/transcript-mining';
+import type { PianolaRule } from '../../shared/pianola/types';
+import type { getSettingsStore, getSessionsStore } from '../stores';
+
+/** Cap on decision pairs the scheduled re-learn pulls from the CLI per run. */
+const RELEARN_MAX_PAIRS = 100_000;
+
+/**
+ * Mine the installed CLIs' native transcripts into a decision corpus by spawning
+ * the existing `pianola learn --json` crawler (the single source of transcript
+ * discovery + parsing) and parsing its `pairs`. Rejects on spawn/exit/parse
+ * failure so a failed mine leaves the previously staged suggestions untouched.
+ */
+export function mineDecisionPairsViaCli(): Promise<DecisionPair[]> {
+	const cliScriptPath = resolveMaestroCliScriptPath();
+	return new Promise<DecisionPair[]>((resolve, reject) => {
+		let child: ChildProcess;
+		try {
+			child = spawn(
+				process.execPath,
+				[cliScriptPath, 'pianola', 'learn', '--json', '--max-pairs', String(RELEARN_MAX_PAIRS)],
+				{
+					env: {
+						...process.env,
+						// In packaged Electron, process.execPath is the app binary, not
+						// Node; without this it would launch the app instead of the CLI.
+						ELECTRON_RUN_AS_NODE: '1',
+						MAESTRO_CLI_JS: cliScriptPath,
+					},
+					stdio: ['ignore', 'pipe', 'pipe'],
+				}
+			);
+		} catch (err) {
+			reject(err instanceof Error ? err : new Error(String(err)));
+			return;
+		}
+		let stdout = '';
+		let stderr = '';
+		child.stdout?.setEncoding('utf8');
+		child.stdout?.on('data', (d: string) => {
+			stdout += d;
+		});
+		child.stderr?.setEncoding('utf8');
+		child.stderr?.on('data', (d: string) => {
+			stderr += d;
+		});
+		child.on('error', (err) => reject(err));
+		child.on('exit', (code) => {
+			if (code !== 0) {
+				reject(new Error(`pianola learn exited ${code ?? 'null'}: ${stderr.trim().slice(0, 200)}`));
+				return;
+			}
+			try {
+				const parsed = JSON.parse(stdout) as { pairs?: unknown };
+				resolve(Array.isArray(parsed.pairs) ? (parsed.pairs as DecisionPair[]) : []);
+			} catch (err) {
+				reject(err instanceof Error ? err : new Error(String(err)));
+			}
+		});
+	});
+}
+
+/**
+ * Read the user's live rules and global decision-profile markdown for the
+ * re-learn baseline. A missing or malformed profiles file degrades to an empty
+ * baseline (getProfile already returns a well-formed empty result), so the job
+ * stages a fresh draft rather than crashing.
+ */
+export function readExistingForRelearn(): { rules: PianolaRule[]; profile: string } {
+	return { rules: readRules(), profile: getProfile().entry?.profile ?? '' };
+}
+
+export interface PianolaLifecycleDependencies {
+	settingsStore: ReturnType<typeof getSettingsStore>;
+	sessionsStore: ReturnType<typeof getSessionsStore>;
+	logger: { info: (msg: string, tag: string) => void };
+}
+
+export interface PianolaLifecycle {
+	supervisor: PianolaSupervisor;
+	relearnScheduler: PianolaRelearnScheduler;
+}
+
+export function createPianolaLifecycle(deps: PianolaLifecycleDependencies): PianolaLifecycle {
+	// Initialize the Pianola supervised daemon. It owns Pianola's background
+	// watchers and orchestrations as supervised child processes (restart on
+	// crash, relaunch on app start, visible health), replacing the unmanaged
+	// nohup model. It self-gates on encoreFeatures.pianola and reconciles from a
+	// shared store file that both the CLI and renderer write.
+	const supervisor = new PianolaSupervisor({
+		isEnabled: () => {
+			const ef = deps.settingsStore.get('encoreFeatures', {}) as Record<string, boolean>;
+			return ef.pianola === true;
+		},
+		getPianolaAgentId: () => {
+			const sessions = deps.sessionsStore.get('sessions', []) as Array<{
+				id?: string;
+				isPianola?: boolean;
+			}>;
+			return sessions.find((s) => s?.isPianola === true)?.id;
+		},
+	});
+
+	// Pianola scheduled re-learn: keeps the learned profile fresh as a PROPOSAL
+	// (stages suggestions; never overwrites the live profile/rules) and
+	// relaunches stale supervised targets, on a fixed cadence. Self-gates per
+	// tick on encoreFeatures.pianola. Mining reuses the existing `pianola learn`
+	// crawler via the bundled CLI; the composition is pure with injected deps.
+	const relearnScheduler = new PianolaRelearnScheduler({
+		isEnabled: () => {
+			const ef = deps.settingsStore.get('encoreFeatures', {}) as Record<string, boolean>;
+			return ef.pianola === true;
+		},
+		runJob: async () => {
+			await runRelearnJob({
+				isEnabled: () => {
+					const ef = deps.settingsStore.get('encoreFeatures', {}) as Record<string, boolean>;
+					return ef.pianola === true;
+				},
+				mine: mineDecisionPairsViaCli,
+				readExisting: readExistingForRelearn,
+				writeSuggestions,
+				relaunchStale: () => supervisor?.relaunchStale() ?? 0,
+				now: Date.now,
+				log: (line) => deps.logger.info(line, '[PianolaRelearn]'),
+			});
+		},
+	});
+
+	return { supervisor, relearnScheduler };
+}

--- a/src/main/plugin-host-view-bridge/bridge.ts
+++ b/src/main/plugin-host-view-bridge/bridge.ts
@@ -1,0 +1,59 @@
+import {
+	PluginHostViewRegistry,
+	type HostViewMutation,
+} from '../plugins/plugin-host-view-registry';
+import { forwardPluginHostViewToRenderer } from '../plugins/plugin-host-view-forwarder';
+import { deliverCadenzaToExistingHud } from '../app-lifecycle';
+import { isWebContentsAvailable } from '../utils/safe-send';
+import type { PluginHostViewBridgeDependencies } from './types';
+
+/**
+ * Concerto/plugin host-view forwarding gate + PluginHostViewRegistry
+ * construction. This is a cross-cutting concern between the Cadenza and
+ * plugin subsystems - it needs plugin state (getPluginManager) as much as
+ * cadenza state (deliverCadenza), so it's its own bridge rather than folded
+ * into cadenza-bridge/.
+ */
+export function createPluginHostViewBridge(deps: PluginHostViewBridgeDependencies) {
+	/** Host views are a bridge between two opt-in Encore features. Re-read both
+	 * flags on every mutation: a disabled feature must never retain a pending view. */
+	const arePluginHostViewsEnabled = (): boolean => {
+		const features = deps.settingsStore.get('encoreFeatures', {}) as Record<string, boolean>;
+		return features.plugins === true && features.concerto === true;
+	};
+
+	/** Forward one host-owned mutation over the exact Concerto renderer channels
+	 * used by the CLI bridge. No renderer handles or plugin code cross this seam. */
+	const forwardPluginHostView = (mutation: HostViewMutation): boolean => {
+		if (!(mutation.kind === 'remove' && mutation.force) && !arePluginHostViewsEnabled())
+			return false;
+		const mainWindow = deps.getMainWindow();
+		if (!mainWindow || mainWindow.isDestroyed() || !isWebContentsAvailable(mainWindow))
+			return false;
+		const targetWindow = mainWindow;
+		const pluginManager = deps.getPluginManager();
+		const sourcePlugin =
+			pluginManager?.getRegistry().records.find((record) => record.id === mutation.view.pluginId)
+				?.manifest?.name ?? mutation.view.pluginId;
+		return forwardPluginHostViewToRenderer(mutation, {
+			sourcePlugin,
+			isCadenzaEnabled: deps.settingsStore.get('encoreFeatures', {})?.concerto === true,
+			sendToMain: (channel, payload) => targetWindow.webContents.send(channel, payload),
+			deliverCadenza: deps.deliverCadenza,
+			deliverCadenzaToExistingHud,
+		});
+	};
+
+	const pluginHostViews = new PluginHostViewRegistry({
+		isEnabled: arePluginHostViewsEnabled,
+		getHostViews: () => deps.getPluginManager()?.getContributions().hostViews ?? [],
+		isPluginRecordPresent: (pluginId) =>
+			deps
+				.getPluginManager()
+				?.getRegistry()
+				.records.some((record) => record.id === pluginId) ?? false,
+		forward: forwardPluginHostView,
+	});
+
+	return { arePluginHostViewsEnabled, pluginHostViews };
+}

--- a/src/main/plugin-host-view-bridge/index.ts
+++ b/src/main/plugin-host-view-bridge/index.ts
@@ -1,0 +1,2 @@
+export { createPluginHostViewBridge } from './bridge';
+export type { PluginHostViewBridgeDependencies } from './types';

--- a/src/main/plugin-host-view-bridge/types.ts
+++ b/src/main/plugin-host-view-bridge/types.ts
@@ -1,0 +1,11 @@
+import type { BrowserWindow } from 'electron';
+import type { PluginManager } from '../plugins/plugin-manager';
+import type { getSettingsStore } from '../stores';
+import type { CadenzaPayload } from '../../shared/cadenza-types';
+
+export interface PluginHostViewBridgeDependencies {
+	getMainWindow: () => BrowserWindow | null;
+	getPluginManager: () => PluginManager | null;
+	settingsStore: ReturnType<typeof getSettingsStore>;
+	deliverCadenza: (payload: CadenzaPayload) => boolean;
+}

--- a/src/main/plugins/consent-minter.ts
+++ b/src/main/plugins/consent-minter.ts
@@ -130,7 +130,8 @@ export type MintRejection =
 	| 'bad-unattended'; // unattended named a cap not separately approved as high-risk
 
 export type MintOutcome =
-	{ ok: true; grants: PermissionGrant[] } | { ok: false; reason: MintRejection };
+	| { ok: true; grants: PermissionGrant[] }
+	| { ok: false; reason: MintRejection };
 
 export interface ConsentMinterDeps {
 	registry: ConsentNonceRegistry;

--- a/src/main/preload/feedback.ts
+++ b/src/main/preload/feedback.ts
@@ -31,7 +31,10 @@ export interface FeedbackAttachmentPayload {
 }
 
 export type FeedbackCategory =
-	'bug_report' | 'feature_request' | 'improvement' | 'general_feedback';
+	| 'bug_report'
+	| 'feature_request'
+	| 'improvement'
+	| 'general_feedback';
 
 export interface FeedbackDraftAttachment {
 	id: string;

--- a/src/main/process-listeners-wiring/index.ts
+++ b/src/main/process-listeners-wiring/index.ts
@@ -1,0 +1,157 @@
+/**
+ * Builds the process-listener dependency object from main/index.ts module
+ * state and wires it into the process-listeners module, plus the WakaTime
+ * heartbeat listener.
+ *
+ * Extracted from main/index.ts's setupProcessListeners() (Phase 5
+ * refactoring). Named as a sibling to process-listeners/ rather than nested
+ * inside it, since process-listeners/index.ts already exports a function
+ * literally named setupProcessListeners - nesting this here would create a
+ * same-directory import that shadows itself.
+ */
+
+import type { ProcessManager } from '../process-manager';
+import type { WebServer } from '../web-server';
+import type { AgentDetector } from '../agents';
+import type { CueEngine } from '../cue/cue-engine';
+import type { PluginEventBusImpl } from '../plugins/plugin-event-bus';
+import type { SafeSendFn } from '../utils/safe-send';
+import type { WakaTimeManager } from '../wakatime-manager';
+import type { getSettingsStore } from '../stores';
+import { setupProcessListeners } from '../process-listeners';
+import { setupWakaTimeListener } from '../process-listeners/wakatime-listener';
+import { powerManager } from '../power-manager';
+import { groupChatEmitters } from '../ipc/handlers/groupChat';
+import {
+	routeModeratorResponse,
+	routeAgentResponse,
+	markParticipantResponded,
+	spawnModeratorSynthesis,
+	getGroupChatReadOnlyState,
+	respawnParticipantWithRecovery,
+	clearActiveParticipantTaskSession,
+	clearModeratorResponseTimeout,
+} from '../group-chat/group-chat-router';
+import {
+	updateParticipant,
+	loadGroupChat,
+	updateGroupChat,
+} from '../group-chat/group-chat-storage';
+import { needsSessionRecovery, initiateSessionRecovery } from '../group-chat/session-recovery';
+import {
+	appendToGroupChatBuffer,
+	getGroupChatBufferedOutput,
+	clearGroupChatBuffer,
+} from '../group-chat/output-buffer';
+import { parseParticipantSessionId } from '../group-chat/session-parser';
+import { extractTextFromStreamJson } from '../group-chat/output-parser';
+import { calculateContextTokens } from '../parsers/usage-aggregator';
+import { getStatsDB } from '../stats';
+import {
+	REGEX_MODERATOR_SESSION,
+	REGEX_MODERATOR_SESSION_TIMESTAMP,
+	REGEX_AI_SUFFIX,
+	REGEX_AI_TAB_ID,
+	REGEX_BATCH_SESSION,
+	REGEX_SYNOPSIS_SESSION,
+	debugLog,
+} from '../constants';
+import { logger } from '../utils/logger';
+import { capabilitySnapshots } from '../agents/capability-snapshot';
+import { getAgentDefinition } from '../agents/definitions';
+import { DEFAULT_CONTEXT_WINDOWS, FALLBACK_CONTEXT_WINDOW } from '../../shared/agentConstants';
+import type { AgentId } from '../../shared/agentIds';
+
+export interface ProcessListenersWiringDependencies {
+	getProcessManager: () => ProcessManager | null;
+	getWebServer: () => WebServer | null;
+	getAgentDetector: () => AgentDetector | null;
+	getCueEngine: () => CueEngine | null;
+	getPluginEventBus: () => PluginEventBusImpl | null;
+	safeSend: SafeSendFn;
+	settingsStore: ReturnType<typeof getSettingsStore>;
+	wakatimeManager: WakaTimeManager;
+}
+
+export function wireProcessListeners(deps: ProcessListenersWiringDependencies): void {
+	const processManager = deps.getProcessManager();
+	if (!processManager) return;
+
+	setupProcessListeners(processManager, {
+		getProcessManager: deps.getProcessManager,
+		getWebServer: deps.getWebServer,
+		getAgentDetector: deps.getAgentDetector,
+		safeSend: deps.safeSend,
+		powerManager,
+		groupChatEmitters,
+		emitPluginEvent: (event) => deps.getPluginEventBus()?.emit(event),
+		groupChatRouter: {
+			routeModeratorResponse,
+			routeAgentResponse,
+			markParticipantResponded,
+			spawnModeratorSynthesis,
+			getGroupChatReadOnlyState,
+			respawnParticipantWithRecovery,
+			clearActiveParticipantTaskSession,
+			clearModeratorResponseTimeout,
+		},
+		groupChatStorage: {
+			loadGroupChat,
+			updateGroupChat,
+			updateParticipant,
+		},
+		sessionRecovery: {
+			needsSessionRecovery,
+			initiateSessionRecovery,
+		},
+		outputBuffer: {
+			appendToGroupChatBuffer,
+			getGroupChatBufferedOutput,
+			clearGroupChatBuffer,
+		},
+		outputParser: {
+			extractTextFromStreamJson,
+			parseParticipantSessionId,
+		},
+		usageAggregator: {
+			calculateContextTokens,
+		},
+		getStatsDB,
+		debugLog,
+		patterns: {
+			REGEX_MODERATOR_SESSION,
+			REGEX_MODERATOR_SESSION_TIMESTAMP,
+			REGEX_AI_SUFFIX,
+			REGEX_AI_TAB_ID,
+			REGEX_BATCH_SESSION,
+			REGEX_SYNOPSIS_SESSION,
+		},
+		logger,
+		getCueEngine: deps.getCueEngine,
+		isCueEnabled: () => {
+			const ef = deps.settingsStore.get('encoreFeatures', {}) as Record<string, boolean>;
+			return !!ef.maestroCue;
+		},
+		getSshRemoteByName: (name: string) => {
+			const remotes = deps.settingsStore.get('sshRemotes', []);
+			return remotes.find((r) => r.name === name) ?? null;
+		},
+		getAgentContextWindow: (agentId: string) => {
+			// Prefer a runtime-discovered context window from the capability
+			// snapshot if one was probed. Falls back to the static table and
+			// finally to the agent definition's configOption default.
+			const snapshot = capabilitySnapshots.get(agentId);
+			if (typeof snapshot?.contextWindow === 'number' && snapshot.contextWindow > 0) {
+				return snapshot.contextWindow;
+			}
+			const def = getAgentDefinition(agentId);
+			const contextOpt = def?.configOptions?.find((o) => o.key === 'contextWindow');
+			const fallbackDefault =
+				typeof contextOpt?.default === 'number' ? contextOpt.default : FALLBACK_CONTEXT_WINDOW;
+			return DEFAULT_CONTEXT_WINDOWS[agentId as AgentId] ?? fallbackDefault;
+		},
+	});
+
+	// WakaTime heartbeat listener (query-complete -> heartbeat, exit -> cleanup)
+	setupWakaTimeListener(processManager, deps.wakatimeManager, deps.settingsStore);
+}

--- a/src/main/utils/ipcHandler.ts
+++ b/src/main/utils/ipcHandler.ts
@@ -56,7 +56,8 @@ export type IpcResponse<T = unknown> = IpcSuccessResponse<T> | IpcErrorResponse;
  * (e.g., { success: true, files: [], tree: [] })
  */
 export type IpcCustomResponse<T extends Record<string, unknown>> =
-	(T & { success: true }) | { success: false; error: string };
+	| (T & { success: true })
+	| { success: false; error: string };
 
 /**
  * Options for the IPC handler wrapper

--- a/src/main/utils/safe-send.ts
+++ b/src/main/utils/safe-send.ts
@@ -19,7 +19,10 @@ import { broadcastBridgeEvent } from '../web-server/handlers/bridgeHandlers';
  * `electron` value usage and remains trivially unit-testable.
  */
 export type GetBroadcastWindows = () =>
-	BrowserWindow | null | undefined | ReadonlyArray<BrowserWindow | null | undefined>;
+	| BrowserWindow
+	| null
+	| undefined
+	| ReadonlyArray<BrowserWindow | null | undefined>;
 
 /**
  * Creates a safeSend function with the provided window enumerator.

--- a/src/main/utils/sentry.ts
+++ b/src/main/utils/sentry.ts
@@ -12,7 +12,13 @@ export type SentrySeverityLevel = 'fatal' | 'error' | 'warning' | 'log' | 'info'
 
 /** Breadcrumb categories for tracking user actions before crashes */
 export type BreadcrumbCategory =
-	'session' | 'agent' | 'navigation' | 'ui' | 'ipc' | 'memory' | 'file';
+	| 'session'
+	| 'agent'
+	| 'navigation'
+	| 'ui'
+	| 'ipc'
+	| 'memory'
+	| 'file';
 
 /** Sentry module type for crash reporting */
 interface SentryModule {

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -368,7 +368,8 @@ export class WebServer {
 
 	private writeToTerminalCallback: ((sessionId: string, data: string) => boolean) | null = null;
 	private resizeTerminalCallback:
-		((sessionId: string, cols: number, rows: number) => boolean) | null = null;
+		| ((sessionId: string, cols: number, rows: number) => boolean)
+		| null = null;
 	private spawnTerminalForWebCallback:
 		| ((
 				sessionId: string,

--- a/src/main/web-server/handlers/messageHandlers/autoRun.ts
+++ b/src/main/web-server/handlers/messageHandlers/autoRun.ts
@@ -82,7 +82,8 @@ export function handleConfigureAutoRun(
 ): void {
 	const sessionId = message.sessionId as string;
 	const documents = message.documents as
-		Array<{ filename: string; resetOnCompletion?: boolean }> | undefined;
+		| Array<{ filename: string; resetOnCompletion?: boolean }>
+		| undefined;
 	logger.info(
 		`[Web] Received configure_auto_run message: session=${sessionId}, documents=${documents?.length || 0}`,
 		LOG_CONTEXT

--- a/src/main/window-registry.ts
+++ b/src/main/window-registry.ts
@@ -39,7 +39,12 @@ export interface RegisteredWindow {
 
 /** The kinds of mutations the registry emits a change signal for. */
 export type WindowRegistryChangeType =
-	'created' | 'removed' | 'sessions-changed' | 'session-moved' | 'name-changed' | 'panel-changed';
+	| 'created'
+	| 'removed'
+	| 'sessions-changed'
+	| 'session-moved'
+	| 'name-changed'
+	| 'panel-changed';
 
 /**
  * Payload describing a registry mutation. Persistence (the window-state store)

--- a/src/prompts/_history-format.md
+++ b/src/prompts/_history-format.md
@@ -7,7 +7,9 @@ Your session history is stored at `{{AGENT_HISTORY_PATH}}` as a JSON file with t
 	"version": 1,
 	"sessionId": "<provider session id>",
 	"projectPath": "<absolute path>",
-	"entries": [/* HistoryEntry[], newest entries appended last; not pre-sorted */]
+	"entries": [
+		/* HistoryEntry[], newest entries appended last; not pre-sorted */
+	]
 }
 ```
 

--- a/src/renderer/components/CuePipelineEditor/utils/pipelineRoots.ts
+++ b/src/renderer/components/CuePipelineEditor/utils/pipelineRoots.ts
@@ -93,7 +93,8 @@ export function resolveNodeWriteRoot(
  * sessions purely by name.
  */
 export type PipelineOwnerCwdsResult =
-	{ ok: true; cwds: Set<string> } | { ok: false; reason: 'no-bindings' | 'unresolved' };
+	| { ok: true; cwds: Set<string> }
+	| { ok: false; reason: 'no-bindings' | 'unresolved' };
 
 export function resolvePipelineOwnerCwds(
 	pipeline: Pick<CuePipeline, 'nodes'>,

--- a/src/renderer/components/DirectorNotes/UnifiedHistoryTab.tsx
+++ b/src/renderer/components/DirectorNotes/UnifiedHistoryTab.tsx
@@ -582,7 +582,8 @@ export const UnifiedHistoryTab = forwardRef<TabFocusHandle, UnifiedHistoryTabPro
 			(agentSessionId: string) => {
 				if (!onResumeSession) return;
 				const entry = entries.find((e) => e.agentSessionId === agentSessionId) as
-					UnifiedHistoryEntry | undefined;
+					| UnifiedHistoryEntry
+					| undefined;
 				if (entry) {
 					onResumeSession(entry.sourceSessionId, agentSessionId);
 				}

--- a/src/renderer/components/ImageAnnotator/useAnnotatorState.ts
+++ b/src/renderer/components/ImageAnnotator/useAnnotatorState.ts
@@ -95,7 +95,9 @@ export interface AnnotatorView {
 const INITIAL_VIEW: AnnotatorView = { x: 0, y: 0, scale: 1 };
 
 type HistoryEntry =
-	{ kind: 'stroke'; id: string } | { kind: 'shape'; id: string } | { kind: 'text'; id: string };
+	| { kind: 'stroke'; id: string }
+	| { kind: 'shape'; id: string }
+	| { kind: 'text'; id: string };
 
 export interface UseAnnotatorStateReturn {
 	strokes: Stroke[];

--- a/src/renderer/components/LeaderboardRegistrationModal.tsx
+++ b/src/renderer/components/LeaderboardRegistrationModal.tsx
@@ -109,7 +109,13 @@ interface LeaderboardRegistrationModalProps {
 }
 
 type SubmitState =
-	'idle' | 'submitting' | 'success' | 'awaiting_confirmation' | 'polling' | 'error' | 'opted_out';
+	| 'idle'
+	| 'submitting'
+	| 'success'
+	| 'awaiting_confirmation'
+	| 'polling'
+	| 'error'
+	| 'opted_out';
 
 // Generate a random client token for polling
 function generateClientToken(): string {

--- a/src/renderer/components/LogViewer.tsx
+++ b/src/renderer/components/LogViewer.tsx
@@ -717,7 +717,8 @@ export function LogViewer({
 										{(() => {
 											if (log.level !== 'toast') return null;
 											const data = log.data as
-												{ project?: string; sessionId?: string; tabId?: string } | undefined;
+												| { project?: string; sessionId?: string; tabId?: string }
+												| undefined;
 											const project = data?.project;
 											if (!project) return null;
 											const canNavigate = onSessionClick && data?.sessionId;

--- a/src/renderer/components/Markdown/chatComponents.tsx
+++ b/src/renderer/components/Markdown/chatComponents.tsx
@@ -147,7 +147,8 @@ export function createChatMarkdownComponents(
 			// Use LocalImage component to handle file:// URLs via IPC.
 			// Extract width from data-maestro-width attribute if present.
 			const widthStr = (props as Record<string, unknown>)['data-maestro-width'] as
-				string | undefined;
+				| string
+				| undefined;
 			const width = widthStr ? parseInt(widthStr, 10) : undefined;
 
 			return (

--- a/src/renderer/components/PromptComposerModal.tsx
+++ b/src/renderer/components/PromptComposerModal.tsx
@@ -235,13 +235,15 @@ export function PromptComposerModal({
 
 		// Agent chat mode: show file suggestions only
 		const fileSuggestions = getFileSuggestions(mentionFilter);
-		return fileSuggestions.map((s): MentionItem => ({
-			type: 'file',
-			fileType: s.type,
-			displayText: s.displayText,
-			fullPath: s.fullPath,
-			source: s.source,
-		}));
+		return fileSuggestions.map(
+			(s): MentionItem => ({
+				type: 'file',
+				fileType: s.type,
+				displayText: s.displayText,
+				fullPath: s.fullPath,
+				source: s.source,
+			})
+		);
 	}, [mentionFilter, getFileSuggestions, hasAgentMentions, agentMentionItems]);
 
 	// Scroll selected mention into view

--- a/src/renderer/components/Settings/tabs/DisplayTab/hooks/useFontConfigurationState.ts
+++ b/src/renderer/components/Settings/tabs/DisplayTab/hooks/useFontConfigurationState.ts
@@ -17,7 +17,8 @@ export function useFontConfigurationState(): FontConfigurationState {
 			setSystemFonts(detected);
 
 			const savedCustomFonts = (await window.maestro.settings.get('customFonts')) as
-				string[] | undefined;
+				| string[]
+				| undefined;
 			if (savedCustomFonts && Array.isArray(savedCustomFonts)) {
 				setCustomFonts(savedCustomFonts);
 			}

--- a/src/renderer/components/Settings/tabs/EncoreTab/hooks/useDirectorNotesAgentState.ts
+++ b/src/renderer/components/Settings/tabs/EncoreTab/hooks/useDirectorNotesAgentState.ts
@@ -35,7 +35,8 @@ export function useDirectorNotesAgentState({
 		(agent) => agent.id === directorNotesSettings.provider
 	);
 	const selectedTile = AGENT_TILES.find((tile) => tile.id === directorNotesSettings.provider) as
-		DirectorNotesTile | undefined;
+		| DirectorNotesTile
+		| undefined;
 
 	const handleAgentChange = (agentId: ToolType) => {
 		setDirectorNotesSettings({

--- a/src/renderer/components/Wizard/WizardContext/types.ts
+++ b/src/renderer/components/Wizard/WizardContext/types.ts
@@ -2,7 +2,11 @@ import type { ReactNode } from 'react';
 import type { AdditionalDirectory, ToolType, AgentConfig } from '../../../types';
 
 export type WizardStep =
-	'agent-selection' | 'directory-selection' | 'conversation' | 'preparing-plan' | 'phase-review';
+	| 'agent-selection'
+	| 'directory-selection'
+	| 'conversation'
+	| 'preparing-plan'
+	| 'phase-review';
 
 export type WizardAutoRunMode = 'none' | 'first' | 'all';
 

--- a/src/renderer/components/Wizard/services/austinFacts.ts
+++ b/src/renderer/components/Wizard/services/austinFacts.ts
@@ -171,7 +171,8 @@ export function resetAustinFactQueue(): void {
  * ]
  */
 export type FactSegment =
-	{ type: 'text'; content: string } | { type: 'link'; text: string; url: string };
+	| { type: 'text'; content: string }
+	| { type: 'link'; text: string; url: string };
 
 export function parseFactWithLinks(fact: string): FactSegment[] {
 	const segments: FactSegment[] = [];

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -449,7 +449,14 @@ interface MaestroAPI {
 				op: 'open' | 'update' | 'close';
 				id: string;
 				viewType?:
-					'tracker' | 'file' | 'markdown' | 'image' | 'code' | 'view' | 'decision' | 'html';
+					| 'tracker'
+					| 'file'
+					| 'markdown'
+					| 'image'
+					| 'code'
+					| 'view'
+					| 'decision'
+					| 'html';
 				title?: string;
 				body?: string;
 				path?: string;
@@ -504,7 +511,8 @@ interface MaestroAPI {
 			callback: (
 				id: string,
 				action:
-					{ kind: 'click'; selector: string } | { kind: 'type'; selector: string; value: string },
+					| { kind: 'click'; selector: string }
+					| { kind: 'type'; selector: string; value: string },
 				expectedRevision: number,
 				responseChannel: string
 			) => void

--- a/src/renderer/hooks/agent/internal/useAgentToolExecutionListener.ts
+++ b/src/renderer/hooks/agent/internal/useAgentToolExecutionListener.ts
@@ -66,7 +66,8 @@ export function useAgentToolExecutionListener(): void {
 						// dropping events / deleting logs caused (the flicker bug).
 
 						const newState = toolEvent.state as
-							NonNullable<LogEntry['metadata']>['toolState'] | undefined;
+							| NonNullable<LogEntry['metadata']>['toolState']
+							| undefined;
 
 						// Tag tool entries with `renderStyle: 'text-stream'` when the
 						// session's resolved Claude mode is interactive so the TUI/API

--- a/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
+++ b/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
@@ -989,7 +989,8 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 			// gitService methods route through createIpcMethod with a defaultValue,
 			// so they swallow IPC errors (and report to Sentry) rather than throwing.
 			const sshConfig = config?.sessionSshRemoteConfig as
-				{ enabled?: boolean; remoteId?: string | null } | undefined;
+				| { enabled?: boolean; remoteId?: string | null }
+				| undefined;
 			const isRemoteSession = !!(sshConfig?.enabled && sshConfig.remoteId);
 			let isGitRepo = false;
 			let gitBranches: string[] | undefined;

--- a/src/renderer/hooks/session/useBatchedSessionUpdates.ts
+++ b/src/renderer/hooks/session/useBatchedSessionUpdates.ts
@@ -45,7 +45,8 @@ export const DEFAULT_BATCH_FLUSH_INTERVAL = 200;
 export function mergeContextWindow(
 	delta: Pick<UsageStats, 'contextWindow' | 'contextWindowResolved' | 'contextWindowModel'>,
 	existing:
-		Pick<UsageStats, 'contextWindow' | 'contextWindowResolved' | 'contextWindowModel'> | undefined
+		| Pick<UsageStats, 'contextWindow' | 'contextWindowResolved' | 'contextWindowModel'>
+		| undefined
 ): { contextWindow: number; contextWindowResolved?: boolean; contextWindowModel?: string } {
 	const sameModel = delta.contextWindowModel === existing?.contextWindowModel;
 	if (existing?.contextWindowResolved && !delta.contextWindowResolved && sameModel) {

--- a/src/renderer/services/feedbackConversation.ts
+++ b/src/renderer/services/feedbackConversation.ts
@@ -24,7 +24,10 @@ export interface FeedbackMessage {
 }
 
 export type FeedbackCategory =
-	'bug_report' | 'feature_request' | 'improvement' | 'general_feedback';
+	| 'bug_report'
+	| 'feature_request'
+	| 'improvement'
+	| 'general_feedback';
 
 export interface FeedbackStructured {
 	expectedBehavior: string;

--- a/src/renderer/stores/feedbackDraftStore.ts
+++ b/src/renderer/stores/feedbackDraftStore.ts
@@ -11,7 +11,10 @@ import { create } from 'zustand';
 import type { FeedbackMessage, FeedbackParsedResponse } from '../services/feedbackConversation';
 
 export type FeedbackDraftCategory =
-	'bug_report' | 'feature_request' | 'improvement' | 'general_feedback';
+	| 'bug_report'
+	| 'feature_request'
+	| 'improvement'
+	| 'general_feedback';
 
 export interface FeedbackDraftAttachment {
 	id: string;

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -1980,7 +1980,8 @@ export async function loadAllSettings(): Promise<void> {
 		} else {
 			// One-time migration: copy from globalStats.totalActiveTimeMs if it exists and is > 0
 			const legacyGlobalStats = allSettings['globalStats'] as
-				{ totalActiveTimeMs?: number } | undefined;
+				| { totalActiveTimeMs?: number }
+				| undefined;
 			if (legacyGlobalStats?.totalActiveTimeMs && legacyGlobalStats.totalActiveTimeMs > 0) {
 				patch.totalActiveTimeMs = legacyGlobalStats.totalActiveTimeMs;
 				window.maestro.settings.set('totalActiveTimeMs', legacyGlobalStats.totalActiveTimeMs);
@@ -2178,7 +2179,12 @@ export async function loadAllSettings(): Promise<void> {
 			const validTimeRanges = ['day', 'week', 'month', 'quarter', 'year', 'all'];
 			if (validTimeRanges.includes(allSettings['defaultStatsTimeRange'] as string)) {
 				patch.defaultStatsTimeRange = allSettings['defaultStatsTimeRange'] as
-					'day' | 'week' | 'month' | 'quarter' | 'year' | 'all';
+					| 'day'
+					| 'week'
+					| 'month'
+					| 'quarter'
+					| 'year'
+					| 'all';
 			}
 		}
 

--- a/src/renderer/stores/tabStore.ts
+++ b/src/renderer/stores/tabStore.ts
@@ -77,7 +77,12 @@ import { logger } from '../utils/logger';
  * covers the X button, middle-click, overlay menu, and close-others/left/right.
  */
 export type TerminalCloseReason =
-	'user-action' | 'pty-exit' | 'spawn-failure' | 'close-others' | 'close-left' | 'close-right';
+	| 'user-action'
+	| 'pty-exit'
+	| 'spawn-failure'
+	| 'close-others'
+	| 'close-left'
+	| 'close-right';
 
 // ============================================================================
 // Store Types

--- a/src/renderer/stores/uiStore.ts
+++ b/src/renderer/stores/uiStore.ts
@@ -24,7 +24,8 @@ import { notifyCenterFlash } from './centerFlashStore';
  * time - landing on a starred/group-chat row sets selectedSidebarIndex to -1.
  */
 export type SidebarExtraSelection =
-	{ kind: 'starred'; key: string } | { kind: 'groupChat'; id: string };
+	| { kind: 'starred'; key: string }
+	| { kind: 'groupChat'; id: string };
 
 /** Per-window state for the AI chat "Find" bar (one slot per agent+AI-tab). */
 export interface OutputSearchSlot {

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -79,7 +79,12 @@ export type UsageDashboardViewMode =
 	| 'cue'
 	| 'shortcuts';
 export type SettingsTab =
-	'general' | 'shortcuts' | 'theme' | 'notifications' | 'aicommands' | 'prompts';
+	| 'general'
+	| 'shortcuts'
+	| 'theme'
+	| 'notifications'
+	| 'aicommands'
+	| 'prompts';
 // Note: ScratchPadMode was removed as part of the Scratchpad → Auto Run migration
 export type FocusArea = 'sidebar' | 'main' | 'right';
 export type LLMProvider = 'openrouter' | 'requesty' | 'anthropic' | 'ollama';

--- a/src/renderer/utils/browserTabPersistence.ts
+++ b/src/renderer/utils/browserTabPersistence.ts
@@ -10,7 +10,8 @@ export const DEFAULT_BROWSER_TAB_URL = 'about:blank';
 export const DEFAULT_BROWSER_TAB_TITLE = 'New Tab';
 
 export type BrowserTabNavigationTarget =
-	{ kind: 'url'; url: string } | { kind: 'error'; message: string };
+	| { kind: 'url'; url: string }
+	| { kind: 'error'; message: string };
 
 function sanitizeBrowserPartitionKey(sessionId: string): string {
 	const normalized = sessionId.trim().replace(/[^a-zA-Z0-9_-]+/g, '-');

--- a/src/shared/agentCapabilities.ts
+++ b/src/shared/agentCapabilities.ts
@@ -21,7 +21,12 @@ import type { AgentId } from './agentIds';
  * - `failed` - last detection attempt threw / errored unexpectedly.
  */
 export type AgentStatus =
-	'ok' | 'not_installed' | 'auth_required' | 'not_configured' | 'probing' | 'failed';
+	| 'ok'
+	| 'not_installed'
+	| 'auth_required'
+	| 'not_configured'
+	| 'probing'
+	| 'failed';
 
 /**
  * A point-in-time capability snapshot for one agent in one environment.

--- a/src/shared/cadenza-types.ts
+++ b/src/shared/cadenza-types.ts
@@ -28,7 +28,14 @@
  *              the owning agent with that option's value (a live prompt inject)
  */
 export type CadenzaViewType =
-	'tracker' | 'file' | 'markdown' | 'image' | 'code' | 'view' | 'html' | 'decision';
+	| 'tracker'
+	| 'file'
+	| 'markdown'
+	| 'image'
+	| 'code'
+	| 'view'
+	| 'html'
+	| 'decision';
 
 /** One choice on a `decision` cadenza. Clicking sends `value` to the agent. */
 export interface CadenzaDecisionOption {

--- a/src/shared/campaign/types.ts
+++ b/src/shared/campaign/types.ts
@@ -1,5 +1,10 @@
 export type CampaignStatus =
-	'queued' | 'running' | 'needs_review' | 'blocked' | 'complete' | 'archived';
+	| 'queued'
+	| 'running'
+	| 'needs_review'
+	| 'blocked'
+	| 'complete'
+	| 'archived';
 
 export type CampaignTaskStatus =
 	| 'queued'

--- a/src/shared/concerto-html.ts
+++ b/src/shared/concerto-html.ts
@@ -48,7 +48,8 @@ export interface MovementDesignerInspection {
 }
 
 export type ConcertoDesignerAction =
-	{ kind: 'click'; selector: string } | { kind: 'type'; selector: string; value: string };
+	| { kind: 'click'; selector: string }
+	| { kind: 'type'; selector: string; value: string };
 
 export interface ConcertoDesignerActionResult {
 	ok: boolean;

--- a/src/shared/directorNotesNarrative.ts
+++ b/src/shared/directorNotesNarrative.ts
@@ -57,14 +57,16 @@ export interface DirectorNotesNarrative {
 
 /** Discriminated result of {@link parseDirectorNotesNarrative}. */
 export type ParseNarrativeResult =
-	{ ok: true; narrative: DirectorNotesNarrative } | { ok: false; error: string };
+	| { ok: true; narrative: DirectorNotesNarrative }
+	| { ok: false; error: string };
 
 /**
  * Discriminated result of {@link recoverDirectorNotesNarrative}. `reason`
  * explains what had to be salvaged so the UI can say so out loud.
  */
 export type RecoverNarrativeResult =
-	{ ok: true; narrative: DirectorNotesNarrative; reason: string } | { ok: false; error: string };
+	| { ok: true; narrative: DirectorNotesNarrative; reason: string }
+	| { ok: false; error: string };
 
 const VALID_KINDS: ReadonlySet<string> = new Set<NarrativeSectionKind>([
 	'accomplishments',

--- a/src/shared/goalDriven/types.ts
+++ b/src/shared/goalDriven/types.ts
@@ -63,11 +63,16 @@ export interface GoalIterationRecord {
 
 /** The reason a goal-driven run stopped. */
 export type GoalExitReason =
-	'completed' | 'deadlock' | 'max-iterations' | 'stalled' | 'stopped-by-user';
+	| 'completed'
+	| 'deadlock'
+	| 'max-iterations'
+	| 'stalled'
+	| 'stopped-by-user';
 
 /** The evaluator's decision after an iteration: keep going or stop (and why). */
 export type GoalExitDecision =
-	{ action: 'continue' } | { action: 'stop'; reason: GoalExitReason; detail: string };
+	| { action: 'continue' }
+	| { action: 'stop'; reason: GoalExitReason; detail: string };
 
 /**
  * Number of consecutive non-progressing iterations that trips stall detection.

--- a/src/shared/movement-types.ts
+++ b/src/shared/movement-types.ts
@@ -27,7 +27,11 @@ export const MOVEMENT_OPS: readonly MovementOp[] = [
 ] as const;
 
 export type ConcertoCreationPhase =
-	'composing' | 'refining' | 'arranging' | 'reviewing' | 'testing';
+	| 'composing'
+	| 'refining'
+	| 'arranging'
+	| 'reviewing'
+	| 'testing';
 
 export const CONCERTO_CREATION_PHASES: readonly ConcertoCreationPhase[] = [
 	'composing',

--- a/src/shared/pianola/pianola-tasks.ts
+++ b/src/shared/pianola/pianola-tasks.ts
@@ -17,7 +17,14 @@
  *  mirror the AgentRun/CampaignTask states so a task can reflect a ledger-driven
  *  review/fix cycle, not just busy-to-idle completion. */
 export type PianolaTaskStatus =
-	'pending' | 'running' | 'needs_review' | 'fixing' | 'done' | 'failed' | 'blocked' | 'skipped';
+	| 'pending'
+	| 'running'
+	| 'needs_review'
+	| 'fixing'
+	| 'done'
+	| 'failed'
+	| 'blocked'
+	| 'skipped';
 
 /** One unit of work in a plan, with its dependency edges and runtime binding. */
 export interface PianolaTask {

--- a/src/shared/pianola/types.ts
+++ b/src/shared/pianola/types.ts
@@ -24,7 +24,13 @@ export type PianolaSignalKind = (typeof SIGNAL_KINDS)[number];
 
 /** Role of a message, mirroring the WS SessionHistoryMessage contract. */
 export type PianolaMessageRole =
-	'user' | 'assistant' | 'system' | 'tool' | 'thinking' | 'error' | 'unknown';
+	| 'user'
+	| 'assistant'
+	| 'system'
+	| 'tool'
+	| 'thinking'
+	| 'error'
+	| 'unknown';
 
 /**
  * Structured signal emitted by the parser layer when an agent is unambiguously

--- a/src/shared/plugins/plugin-manifest.ts
+++ b/src/shared/plugins/plugin-manifest.ts
@@ -35,7 +35,13 @@ export const PLUGIN_TIERS: readonly PluginTier[] = [0, 1, 2];
  * Extensions view. Optional in a manifest; absent is treated as 'other'.
  */
 export type PluginCategory =
-	'automation' | 'agents' | 'insights' | 'ui' | 'data' | 'devtools' | 'other';
+	| 'automation'
+	| 'agents'
+	| 'insights'
+	| 'ui'
+	| 'data'
+	| 'devtools'
+	| 'other';
 
 export const PLUGIN_CATEGORIES: readonly PluginCategory[] = [
 	'automation',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -903,7 +903,13 @@ export interface DirectoryEntry {
  */
 export interface UpdateStatus {
 	status:
-		'idle' | 'checking' | 'available' | 'not-available' | 'downloading' | 'downloaded' | 'error';
+		| 'idle'
+		| 'checking'
+		| 'available'
+		| 'not-available'
+		| 'downloading'
+		| 'downloaded'
+		| 'error';
 	info?: { version: string };
 	progress?: { percent: number; bytesPerSecond: number; total: number; transferred: number };
 	error?: string;

--- a/src/web/hooks/useMobileAutoReconnect.ts
+++ b/src/web/hooks/useMobileAutoReconnect.ts
@@ -24,7 +24,12 @@ import { webLogger } from '../utils/logger';
  * WebSocket connection states
  */
 export type ConnectionState =
-	'connecting' | 'authenticating' | 'connected' | 'authenticated' | 'disconnected' | 'error';
+	| 'connecting'
+	| 'authenticating'
+	| 'connected'
+	| 'authenticated'
+	| 'disconnected'
+	| 'error';
 
 /**
  * Default countdown duration in seconds

--- a/src/web/hooks/useWebSocket.ts
+++ b/src/web/hooks/useWebSocket.ts
@@ -18,7 +18,11 @@ import { webLogger } from '../utils/logger';
  * WebSocket connection states
  */
 export type WebSocketState =
-	'disconnected' | 'connecting' | 'connected' | 'authenticating' | 'authenticated';
+	| 'disconnected'
+	| 'connecting'
+	| 'connected'
+	| 'authenticating'
+	| 'authenticated';
 
 /**
  * Usage stats for session cost/token tracking (all fields optional in web context)


### PR DESCRIPTION
- extract setupProcessListeners, setupIpcHandlers, Pianola relearn
  construction, and Cadenza/plugin-host-view wiring into their own modules
- preserve exact call order, dependency wiring, and IPC registration
  timing throughout - zero behavior change
- verified via full test suite, an independent regression
  review, and manual testing in the running app