### PR TITLE
fix(context): stop the context gauge latching at 0% after an accumulated turn

### DIFF
--- a/src/__tests__/main/parsers/claude-output-parser.test.ts
+++ b/src/__tests__/main/parsers/claude-output-parser.test.ts
@@ -271,6 +271,165 @@ describe('ClaudeOutputParser', () => {
 		});
 	});
 
+	describe('absoluteUsage occupancy snapshot (finding Q1)', () => {
+		// A fresh parser per test: the snapshot is per-turn state on the instance,
+		// and the shared `parser` above has been fed unrelated messages.
+		const assistantMessage = (usage: Record<string, number>, extra: Record<string, unknown> = {}) =>
+			JSON.stringify({
+				type: 'assistant',
+				session_id: 'sess-q1',
+				message: {
+					id: 'msg-1',
+					role: 'assistant',
+					content: [{ type: 'text', text: 'working' }],
+					usage,
+				},
+				...extra,
+			});
+
+		const resultMessage = (modelUsage: Record<string, unknown>) =>
+			JSON.stringify({
+				type: 'result',
+				result: 'done',
+				session_id: 'sess-q1',
+				modelUsage,
+				total_cost_usd: 0.5,
+			});
+
+		it('attaches the LAST assistant call usage, not the sum and not the first call', () => {
+			const p = new ClaudeOutputParser();
+
+			p.parseJsonLine(
+				assistantMessage({
+					input_tokens: 2,
+					output_tokens: 90,
+					cache_read_input_tokens: 15007,
+					cache_creation_input_tokens: 9468,
+				})
+			);
+			p.parseJsonLine(
+				assistantMessage({
+					input_tokens: 3,
+					output_tokens: 40,
+					cache_read_input_tokens: 20000,
+					cache_creation_input_tokens: 100,
+				})
+			);
+			p.parseJsonLine(
+				assistantMessage({
+					input_tokens: 2,
+					output_tokens: 12,
+					cache_read_input_tokens: 24475,
+					cache_creation_input_tokens: 109,
+				})
+			);
+
+			// The CLI's own per-model sum across all three calls - the quantity that
+			// overflows the window and pinned the gauge at 0%.
+			const event = p.parseJsonLine(
+				resultMessage({
+					'claude-opus-5': {
+						inputTokens: 7,
+						outputTokens: 142,
+						cacheReadInputTokens: 59482,
+						cacheCreationInputTokens: 9677,
+						contextWindow: 1000000,
+					},
+				})
+			);
+
+			const usage = p.extractUsage(event!);
+			// Top-level fields stay the CLI's turn totals (token spend).
+			expect(usage?.inputTokens).toBe(7);
+			expect(usage?.cacheReadTokens).toBe(59482);
+			// The snapshot is the third call only: 2 / 12 / 24475 / 109.
+			expect(usage?.absoluteUsage).toEqual({
+				inputTokens: 2,
+				outputTokens: 12,
+				cacheReadInputTokens: 24475,
+				cacheCreationInputTokens: 109,
+				reasoningTokens: 0,
+			});
+		});
+
+		it('is idempotent when stream-json emits an assistant message twice', () => {
+			const p = new ClaudeOutputParser();
+			const line = assistantMessage({
+				input_tokens: 2,
+				output_tokens: 12,
+				cache_read_input_tokens: 24475,
+				cache_creation_input_tokens: 109,
+			});
+
+			p.parseJsonLine(line);
+			p.parseJsonLine(line);
+
+			const event = p.parseJsonLine(resultMessage({ 'claude-opus-5': { inputTokens: 7 } }));
+			expect(event?.usage?.absoluteUsage?.cacheReadInputTokens).toBe(24475);
+		});
+
+		it('ignores subagent assistant messages, which have their own context window', () => {
+			const p = new ClaudeOutputParser();
+
+			p.parseJsonLine(
+				assistantMessage({
+					input_tokens: 2,
+					output_tokens: 12,
+					cache_read_input_tokens: 24475,
+					cache_creation_input_tokens: 109,
+				})
+			);
+			p.parseJsonLine(
+				assistantMessage(
+					{
+						input_tokens: 5,
+						output_tokens: 20,
+						cache_read_input_tokens: 900,
+						cache_creation_input_tokens: 3,
+					},
+					{ parent_tool_use_id: 'toolu_subagent' }
+				)
+			);
+
+			const event = p.parseJsonLine(resultMessage({ 'claude-opus-5': { inputTokens: 7 } }));
+			// The main-transcript call, not the subagent's much smaller one.
+			expect(event?.usage?.absoluteUsage?.cacheReadInputTokens).toBe(24475);
+		});
+
+		it('does not leak a snapshot across turns', () => {
+			const p = new ClaudeOutputParser();
+
+			p.parseJsonLine(
+				assistantMessage({
+					input_tokens: 2,
+					output_tokens: 12,
+					cache_read_input_tokens: 24475,
+					cache_creation_input_tokens: 109,
+				})
+			);
+			p.parseJsonLine(resultMessage({ 'claude-opus-5': { inputTokens: 7 } }));
+
+			// Second turn: no assistant message carried usage this time.
+			const event = p.parseJsonLine(resultMessage({ 'claude-opus-5': { inputTokens: 9 } }));
+			expect(event?.usage).toBeDefined();
+			expect(event?.usage?.absoluteUsage).toBeUndefined();
+		});
+
+		it('omits the snapshot when assistant messages carry no usage', () => {
+			const p = new ClaudeOutputParser();
+
+			p.parseJsonLine(
+				JSON.stringify({
+					type: 'assistant',
+					message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
+				})
+			);
+
+			const event = p.parseJsonLine(resultMessage({ 'claude-opus-5': { inputTokens: 7 } }));
+			expect(event?.usage?.absoluteUsage).toBeUndefined();
+		});
+	});
+
 	describe('extractSlashCommands', () => {
 		it('should extract slash commands from init message', () => {
 			const event = parser.parseJsonLine(

--- a/src/__tests__/renderer/hooks/agent/internal/useAgentUsageListener.test.tsx
+++ b/src/__tests__/renderer/hooks/agent/internal/useAgentUsageListener.test.tsx
@@ -305,4 +305,166 @@ describe('useAgentUsageListener', () => {
 		const last = calls[calls.length - 1];
 		expect(last?.[1]).toBeLessThanOrEqual(75);
 	});
+
+	describe('occupancy snapshot bootstrap (finding Q1, D1)', () => {
+		// The reported repro: a claude-code session whose FIRST turn is tool-heavy.
+		// The CLI's result message sums every internal API call, so the turn totals
+		// blow past the window; the last call's usage rides along as absoluteUsage
+		// and is the real occupancy.
+		const OVERFLOWING_FIRST_TURN = {
+			inputTokens: 2_400_000,
+			outputTokens: 5_000,
+			cacheReadInputTokens: 0,
+			cacheCreationInputTokens: 0,
+			absoluteUsage: {
+				inputTokens: 2_000,
+				outputTokens: 500,
+				cacheReadInputTokens: 200_000,
+				cacheCreationInputTokens: 38_000,
+				reasoningTokens: 0,
+			},
+		};
+
+		it('establishes a nonzero baseline from the snapshot when the first turn overflows', () => {
+			const session = createMockSession({
+				id: 'sess-1',
+				toolType: 'claude-code',
+				contextUsage: 0,
+			});
+			useSessionStore.setState({ sessions: [session] } as any);
+
+			const batched = makeBatched();
+			renderHook(() =>
+				useAgentUsageListener({ batchedUpdater: batched, contextWarningYellowThreshold: 80 })
+			);
+
+			handler!('sess-1', { ...OVERFLOWING_FIRST_TURN, contextWindow: 1_000_000 });
+
+			// 2000 + 200000 + 38000 = 240000 of a 1M window. Before the fix the turn
+			// totals overflowed, no baseline existed, and the gauge stayed at 0%.
+			expect(batched.updateContextUsage).toHaveBeenCalledWith('sess-1', 24);
+		});
+
+		it('bootstraps against the session window when the event reports none', () => {
+			// The event carries no window, so the primary estimate sizes the snapshot
+			// against the static 200k table and still overflows; only the hook's
+			// resolved window (here a per-agent 1M override) can size it correctly.
+			const session = createMockSession({
+				id: 'sess-1',
+				toolType: 'claude-code',
+				contextUsage: 0,
+				customContextWindow: 1_000_000,
+			});
+			useSessionStore.setState({ sessions: [session] } as any);
+
+			const batched = makeBatched();
+			renderHook(() =>
+				useAgentUsageListener({ batchedUpdater: batched, contextWarningYellowThreshold: 80 })
+			);
+
+			handler!('sess-1', { ...OVERFLOWING_FIRST_TURN, contextWindow: 0 });
+
+			expect(batched.updateContextUsage).toHaveBeenCalledWith('sess-1', 24);
+		});
+
+		it('is not capped to the yellow-warning gap - a snapshot is a measurement', () => {
+			const session = createMockSession({
+				id: 'sess-1',
+				toolType: 'claude-code',
+				contextUsage: 0,
+			});
+			useSessionStore.setState({ sessions: [session] } as any);
+
+			const batched = makeBatched();
+			renderHook(() =>
+				useAgentUsageListener({ batchedUpdater: batched, contextWarningYellowThreshold: 80 })
+			);
+
+			handler!('sess-1', {
+				...OVERFLOWING_FIRST_TURN,
+				contextWindow: 200_000,
+				absoluteUsage: { ...OVERFLOWING_FIRST_TURN.absoluteUsage, cacheReadInputTokens: 140_000 },
+			});
+
+			// 2000 + 140000 + 38000 = 180000 of 200k = 90%, above the 75 cap the
+			// extrapolated growth estimate is held under.
+			expect(batched.updateContextUsage).toHaveBeenCalledWith('sess-1', 90);
+		});
+
+		it('leaves the existing behavior intact when an overflowing first turn has no snapshot', () => {
+			const session = createMockSession({
+				id: 'sess-1',
+				toolType: 'claude-code',
+				contextUsage: 0,
+			});
+			useSessionStore.setState({ sessions: [session] } as any);
+
+			const batched = makeBatched();
+			renderHook(() =>
+				useAgentUsageListener({ batchedUpdater: batched, contextWarningYellowThreshold: 80 })
+			);
+
+			const { absoluteUsage: _snapshot, ...noSnapshot } = OVERFLOWING_FIRST_TURN;
+			handler!('sess-1', { ...noSnapshot, contextWindow: 1_000_000 });
+
+			// Nothing real to seed from, so no value is invented: the hook stays
+			// silent rather than fabricating a baseline.
+			expect(batched.updateContextUsage).not.toHaveBeenCalled();
+		});
+
+		it('keeps the growth estimate for a session that already has a baseline', () => {
+			const session = createMockSession({
+				id: 'sess-1',
+				toolType: 'claude-code',
+				contextUsage: 25,
+			});
+			useSessionStore.setState({ sessions: [session] } as any);
+
+			const batched = makeBatched();
+			renderHook(() =>
+				useAgentUsageListener({ batchedUpdater: batched, contextWarningYellowThreshold: 80 })
+			);
+
+			const { absoluteUsage: _snapshot, ...noSnapshot } = OVERFLOWING_FIRST_TURN;
+			handler!('sess-1', { ...noSnapshot, contextWindow: 1_000_000 });
+
+			const calls = (batched.updateContextUsage as any).mock.calls;
+			expect(calls[calls.length - 1]?.[1]).toBeLessThanOrEqual(75);
+		});
+
+		it('records a claude-code output-only turn once it carries a snapshot', () => {
+			// Behavior change flagged by Task 4: the output-only guard is written as
+			// `!usageStats.absoluteUsage && ...`, so claude output-only turns stop
+			// being skipped by the timeline now that claude attaches a snapshot. That
+			// is the intended reading - with real occupancy the row is meaningful.
+			const session = createMockSession({ id: 'sess-1', toolType: 'claude-code' });
+			useSessionStore.setState({ sessions: [session] } as any);
+
+			const batched = makeBatched();
+			renderHook(() =>
+				useAgentUsageListener({ batchedUpdater: batched, contextWarningYellowThreshold: 80 })
+			);
+
+			handler!('sess-1', {
+				inputTokens: 0,
+				outputTokens: 300,
+				cacheReadInputTokens: 0,
+				cacheCreationInputTokens: 0,
+				contextWindow: 200_000,
+				absoluteUsage: {
+					inputTokens: 1_000,
+					outputTokens: 300,
+					cacheReadInputTokens: 59_000,
+					cacheCreationInputTokens: 0,
+					reasoningTokens: 0,
+				},
+			});
+
+			const points = useContextTimelineStore.getState().buffers['sess-1']?.points ?? [];
+			expect(points).toHaveLength(1);
+			// Claude semantics: output does not occupy the input window.
+			expect(points[0].contextTokens).toBe(60_000);
+			expect(points[0].percentage).toBe(30);
+		});
+	});
 });

--- a/src/__tests__/renderer/hooks/agent/internal/useAgentUsageListener.test.tsx
+++ b/src/__tests__/renderer/hooks/agent/internal/useAgentUsageListener.test.tsx
@@ -367,6 +367,46 @@ describe('useAgentUsageListener', () => {
 			expect(batched.updateContextUsage).toHaveBeenCalledWith('sess-1', 24);
 		});
 
+		// CodeRabbit on PR #1351: the gauge percentage was computed BEFORE
+		// `resolvedWindow`, so it divided by the event's reported window while the
+		// timeline point divided by the configured one. A session with a
+		// per-agent override therefore saw two different denominators on two
+		// surfaces - the gauge/timeline disagreement PR #1221 fixed.
+		//
+		// This case deliberately has NO absoluteUsage: the D1 bootstrap branch
+		// below already divides by `resolvedWindow`, so a snapshot-bearing event
+		// masks the defect. A plain in-window turn goes through
+		// `estimateContextUsage` directly, which is the path that was using the
+		// wrong denominator.
+		it('sizes the gauge against the configured window, not the reported one', () => {
+			const session = createMockSession({
+				id: 'sess-1',
+				toolType: 'claude-code',
+				contextUsage: 0,
+				// The user configured 1M; the provider reports a 200k default.
+				customContextWindow: 1_000_000,
+			});
+			useSessionStore.setState({ sessions: [session] } as any);
+
+			const batched = makeBatched();
+			renderHook(() =>
+				useAgentUsageListener({ batchedUpdater: batched, contextWarningYellowThreshold: 80 })
+			);
+
+			handler!('sess-1', {
+				inputTokens: 2_000,
+				outputTokens: 500,
+				cacheReadInputTokens: 200_000,
+				cacheCreationInputTokens: 38_000,
+				contextWindow: 200_000,
+			});
+
+			// 240000 occupancy. Against the configured 1M that is 24%; against the
+			// reported 200k it overflows, yields null, and (with no prior baseline
+			// and no snapshot) the gauge is never updated at all.
+			expect(batched.updateContextUsage).toHaveBeenCalledWith('sess-1', 24);
+		});
+
 		it('is not capped to the yellow-warning gap - a snapshot is a measurement', () => {
 			const session = createMockSession({
 				id: 'sess-1',

--- a/src/__tests__/renderer/hooks/useContextWindow.test.ts
+++ b/src/__tests__/renderer/hooks/useContextWindow.test.ts
@@ -146,6 +146,54 @@ describe('useContextWindow', () => {
 		expect(result.current.activeTabContextUsage).toBeLessThanOrEqual(100);
 	});
 
+	it('holds the last good values when an overflow frame has a zero contextUsage fallback', async () => {
+		// Finding Q1 / D3: a zero fallback used to be laundered into a
+		// trustworthy `0 tokens / 0%` result, which `lastGoodRef` then cached as
+		// last-known-good and re-latched on every later frame. With the `> 0`
+		// guard in calculateContextDisplay the overflow frame is untrustworthy,
+		// so the cache keeps the real reading from the in-window frame.
+		const session = makeSession({ customContextWindow: 200000, contextUsage: 30 });
+		const inWindowTab = {
+			id: 'tab-1',
+			usageStats: {
+				inputTokens: 50000,
+				outputTokens: 1000,
+				cacheCreationInputTokens: 0,
+				cacheReadInputTokens: 10000,
+			},
+		};
+
+		const { result, rerender } = renderHook(
+			({ s, t }: { s: Session; t: any }) => useContextWindow(s, t),
+			{ initialProps: { s: session, t: inWindowTab } }
+		);
+
+		await waitFor(() => {
+			expect(result.current.activeTabContextWindow).toBe(200000);
+		});
+		// 60,000 of 200,000 = 30%
+		expect(result.current.activeTabContextTokens).toBe(60000);
+		expect(result.current.activeTabContextUsage).toBe(30);
+
+		// A tool-heavy turn reports accumulated tokens above the window while the
+		// session has no preserved percentage to fall back on.
+		const overflowSession = makeSession({ customContextWindow: 200000, contextUsage: 0 });
+		const overflowTab = {
+			id: 'tab-1',
+			usageStats: {
+				inputTokens: 2_400_000,
+				outputTokens: 5000,
+				cacheCreationInputTokens: 0,
+				cacheReadInputTokens: 0,
+			},
+		};
+
+		rerender({ s: overflowSession, t: overflowTab });
+
+		expect(result.current.activeTabContextTokens).toBe(60000);
+		expect(result.current.activeTabContextUsage).toBe(30);
+	});
+
 	it('returns zero tokens when no usage stats', async () => {
 		mockGetConfig.mockResolvedValue({ contextWindow: 200000 });
 		const session = makeSession();

--- a/src/__tests__/renderer/utils/contextUsage.test.ts
+++ b/src/__tests__/renderer/utils/contextUsage.test.ts
@@ -423,6 +423,27 @@ describe('calculateContextDisplay', () => {
 		expect(result.trustworthy).toBe(false);
 	});
 
+	it('should return untrustworthy zeros when accumulated values overflow with a zero fallback', () => {
+		// Finding Q1: a zero fallback is the ABSENCE of a prior measurement, not a
+		// measurement of zero. Accepting it derived tokens = 0 and flagged the frame
+		// trustworthy, which latched the gauge at 0% for the life of any session
+		// whose first turn already overflowed the window.
+		const result = calculateContextDisplay(
+			{
+				inputTokens: 50000,
+				cacheReadInputTokens: 758000,
+				cacheCreationInputTokens: 200000,
+			},
+			200000,
+			'claude-code',
+			0 // no baseline established yet
+		);
+		expect(result.tokens).toBe(0);
+		expect(result.percentage).toBe(0);
+		expect(result.contextWindow).toBe(200000);
+		expect(result.trustworthy).toBe(false);
+	});
+
 	it('should clamp fallback percentages above 100 before deriving tokens', () => {
 		const result = calculateContextDisplay(
 			{

--- a/src/main/parsers/agent-output-parser.ts
+++ b/src/main/parsers/agent-output-parser.ts
@@ -117,6 +117,23 @@ export interface ParsedEvent {
 		 * These are already included in outputTokens but tracked separately for UI display.
 		 */
 		reasoningTokens?: number;
+		/**
+		 * Absolute context-occupancy snapshot for the turn, when the provider can
+		 * report one. Distinct from the fields above, which for some providers are
+		 * per-turn token SPEND (claude-code sums every internal API call of a turn,
+		 * so a tool-heavy turn can exceed the context window). Set by the
+		 * claude-code parser from the LAST internal API call's `message.usage`,
+		 * which is real occupancy because a single call's input is what was
+		 * physically sent to the model. Copied straight onto `UsageStats.absoluteUsage`
+		 * by StdoutHandler.buildUsageStats.
+		 */
+		absoluteUsage?: {
+			inputTokens: number;
+			outputTokens: number;
+			cacheReadInputTokens: number;
+			cacheCreationInputTokens: number;
+			reasoningTokens: number;
+		};
 	};
 
 	/**

--- a/src/main/parsers/claude-output-parser.ts
+++ b/src/main/parsers/claude-output-parser.ts
@@ -42,6 +42,20 @@ interface ClaudeContentBlock {
 }
 
 /**
+ * Token usage as Claude reports it, both per API call (on `assistant` messages)
+ * and as the turn total (on `result` messages).
+ */
+interface ClaudeCallUsage {
+	input_tokens?: number;
+	output_tokens?: number;
+	cache_read_input_tokens?: number;
+	cache_creation_input_tokens?: number;
+}
+
+/** Absolute context-occupancy snapshot, in the shape `UsageStats.absoluteUsage` expects. */
+type OccupancySnapshot = NonNullable<NonNullable<ParsedEvent['usage']>['absoluteUsage']>;
+
+/**
  * Raw message structure from Claude Code stream-json output
  */
 interface ClaudeRawMessage {
@@ -59,15 +73,16 @@ interface ClaudeRawMessage {
 		id?: string;
 		role?: string;
 		content?: string | ClaudeContentBlock[];
+		/**
+		 * Per-call token usage, present on every `assistant` message. This is the
+		 * usage of ONE internal API call, unlike the result message's `modelUsage`
+		 * which is the CLI's own sum across every call of the turn.
+		 */
+		usage?: ClaudeCallUsage;
 	};
 	slash_commands?: string[];
 	modelUsage?: Record<string, ModelStats>;
-	usage?: {
-		input_tokens?: number;
-		output_tokens?: number;
-		cache_read_input_tokens?: number;
-		cache_creation_input_tokens?: number;
-	};
+	usage?: ClaudeCallUsage;
 	total_cost_usd?: number;
 }
 
@@ -131,6 +146,24 @@ export class ClaudeOutputParser implements AgentOutputParser {
 	 * Claude runs tools in parallel.
 	 */
 	private readonly toolNamesById = new Map<string, string>();
+
+	/**
+	 * Occupancy snapshot taken from the most recent main-transcript `assistant`
+	 * message of the CURRENT turn, attached to that turn's usage event as
+	 * `absoluteUsage` and cleared at the `result` message (the turn boundary) so
+	 * a snapshot can never leak into the next turn.
+	 *
+	 * Why the LAST call and not the turn total: the result message's `modelUsage`
+	 * is the CLI's own sum across every internal API call of the turn, which is
+	 * token SPEND. A tool-heavy turn therefore reports far more than the window
+	 * holds (a captured two-call turn summed to 49,063 against a real occupancy
+	 * of 24,586), which is what pinned the context gauge at 0% (finding Q1). A
+	 * single call's input is what was physically sent to the model, so it cannot
+	 * exceed the window, and it grows across a turn as each call re-reads the
+	 * prior context from cache - making the last call the end-of-turn occupancy.
+	 * It also tracks auto-compaction correctly, which no accumulated figure can.
+	 */
+	private lastCallOccupancy: OccupancySnapshot | undefined = undefined;
 
 	/**
 	 * Parse a single JSON line from Claude Code output.
@@ -209,11 +242,17 @@ export class ClaudeOutputParser implements AgentOutputParser {
 				event.usage = usage;
 			}
 
+			// The result message ends the turn, so the next turn starts without a
+			// snapshot rather than inheriting this one.
+			this.lastCallOccupancy = undefined;
+
 			return event;
 		}
 
 		// Handle assistant messages (streaming partial responses)
 		if (msg.type === 'assistant') {
+			this.trackCallOccupancy(msg);
+
 			const text = this.extractTextFromMessage(msg);
 			const thinkingText = this.extractThinkingFromMessage(msg);
 			const toolUseBlocks = this.extractToolUseBlocks(msg);
@@ -427,6 +466,34 @@ export class ClaudeOutputParser implements AgentOutputParser {
 	}
 
 	/**
+	 * Record an `assistant` message's per-call usage as the turn's running
+	 * occupancy snapshot (see `lastCallOccupancy`). Last-wins, which is also what
+	 * makes it idempotent under stream-json's habit of emitting each assistant
+	 * message twice.
+	 *
+	 * Subagent messages are skipped: a Task subagent runs in its own context
+	 * window, so its calls say nothing about the main transcript's occupancy.
+	 */
+	private trackCallOccupancy(msg: ClaudeRawMessage): void {
+		if (normalizeParentToolUseId(msg)) {
+			return;
+		}
+
+		const usage = msg.message?.usage;
+		if (!usage) {
+			return;
+		}
+
+		this.lastCallOccupancy = {
+			inputTokens: usage.input_tokens || 0,
+			outputTokens: usage.output_tokens || 0,
+			cacheReadInputTokens: usage.cache_read_input_tokens || 0,
+			cacheCreationInputTokens: usage.cache_creation_input_tokens || 0,
+			reasoningTokens: 0,
+		};
+	}
+
+	/**
 	 * Extract usage statistics from raw Claude message
 	 */
 	private extractUsageFromRaw(msg: ClaudeRawMessage): ParsedEvent['usage'] | null {
@@ -448,6 +515,9 @@ export class ClaudeOutputParser implements AgentOutputParser {
 			cacheCreationTokens: aggregated.cacheCreationInputTokens,
 			contextWindow: aggregated.contextWindow,
 			costUsd: aggregated.totalCostUsd,
+			// The fields above are the turn's summed SPEND and can exceed the window;
+			// this is the same turn's real occupancy, when the stream gave us one.
+			...(this.lastCallOccupancy ? { absoluteUsage: this.lastCallOccupancy } : {}),
 		};
 	}
 

--- a/src/main/process-manager/handlers/StdoutHandler.ts
+++ b/src/main/process-manager/handlers/StdoutHandler.ts
@@ -45,6 +45,7 @@ function normalizeUsageToDelta(
 		totalCostUsd: number;
 		contextWindow: number;
 		reasoningTokens?: number;
+		absoluteUsage?: UsageStats['absoluteUsage'];
 	}
 ): typeof usageStats & { absoluteUsage?: UsageStats['absoluteUsage'] } {
 	const totals: UsageTotals = {
@@ -94,10 +95,19 @@ function normalizeUsageToDelta(
 	// Preserve the pre-normalization cumulative totals as `absoluteUsage`, but ONLY
 	// for combined-context providers (Codex) whose cumulative total IS the current
 	// window occupancy. This function also runs for Claude Code, which can look
-	// monotonic for the first turns of a session; Claude's per-call values are NOT
-	// cumulative occupancy, so attaching an absolute snapshot there would let the
-	// timeline plot cumulative token spend as context fill. The first event of a
+	// monotonic for the first turns of a session; Claude's TURN TOTALS here are the
+	// CLI's own sum across the turn's internal API calls (token spend), so attaching
+	// them would let the timeline plot spend as context fill. The first event of a
 	// session returns raw above (no `last` yet) and is already absolute.
+	//
+	// Claude Code still gets an `absoluteUsage`, just not from here: its parser
+	// attaches the LAST internal call's usage, which is a genuine occupancy
+	// snapshot (a single call's input cannot exceed the window) and a different
+	// quantity from the cumulative totals this branch rejects. Every path in this
+	// function preserves an incoming `absoluteUsage` - the three early returns pass
+	// `usageStats` through verbatim, and the spread below re-attaches only for
+	// COMBINED_CONTEXT_AGENTS, which claude-code is not - so it can never be
+	// overwritten or double-attached.
 	const attachesAbsolute = COMBINED_CONTEXT_AGENTS.has(managedProcess.toolType as never);
 	return {
 		...usageStats,
@@ -828,6 +838,7 @@ export class StdoutHandler {
 			contextWindow?: number;
 			reasoningTokens?: number;
 			model?: string;
+			absoluteUsage?: UsageStats['absoluteUsage'];
 		}
 	): UsageStats {
 		const stats: UsageStats = {
@@ -836,6 +847,10 @@ export class StdoutHandler {
 			cacheReadInputTokens: usage.cacheReadTokens || 0,
 			cacheCreationInputTokens: usage.cacheCreationTokens || 0,
 			totalCostUsd: usage.costUsd || 0,
+			// Occupancy snapshot the parser attached (claude-code's last-call usage).
+			// This object is CONSTRUCTED rather than spread, so anything the parser
+			// adds has to be copied here explicitly or it is silently dropped.
+			absoluteUsage: usage.absoluteUsage,
 			// Prioritize Claude Code's reported contextWindow over spawn config
 			// This ensures we use the actual model's context limit, not a stale config value
 			contextWindow: usage.contextWindow || managedProcess.contextWindow || FALLBACK_CONTEXT_WINDOW,

--- a/src/renderer/hooks/agent/internal/useAgentUsageListener.ts
+++ b/src/renderer/hooks/agent/internal/useAgentUsageListener.ts
@@ -63,7 +63,28 @@ export function useAgentUsageListener(deps: UseAgentUsageListenerDeps): void {
 			const sessionRemoteId = sessionForUsage.sessionSshRemoteConfig?.enabled
 				? (sessionForUsage.sessionSshRemoteConfig.remoteId ?? undefined)
 				: sessionForUsage.sshRemoteId;
-			const contextPercentage = estimateContextUsage(usageStats, agentToolType, sessionRemoteId);
+			// Prefer the absolute occupancy snapshot whenever the provider attached
+			// one. The top-level fields are NOT occupancy for every provider: Codex
+			// sends per-turn deltas of a cumulative total, and claude-code's result
+			// message sums every internal API call of the turn, so a tool-heavy turn
+			// can exceed the window and drop this estimate into the null fallback
+			// below - which is what pinned the gauge at 0% (finding Q1). The snapshot
+			// is real occupancy in both cases, and the Context Timeline already plots
+			// from it, so reading the same source here keeps the gauge and the
+			// timeline from disagreeing.
+			//
+			// The snapshot carries no window of its own, so hand the event's reported
+			// window across with it; estimateContextUsage falls back to the capability
+			// snapshot and the static table when that is 0, exactly as it does for the
+			// top-level stats.
+			const occupancyStats = usageStats.absoluteUsage
+				? { ...usageStats.absoluteUsage, contextWindow: usageStats.contextWindow }
+				: usageStats;
+			const contextPercentage = estimateContextUsage(
+				occupancyStats,
+				agentToolType,
+				sessionRemoteId
+			);
 
 			// Resolve the effective context window ONCE, matching the header gauge's
 			// precedence (resolveConfiguredContextWindow): a per-agent custom window,
@@ -165,17 +186,18 @@ export function useAgentUsageListener(deps: UseAgentUsageListenerDeps): void {
 				!hasNoTurnActivity &&
 				!isContextWindowCorrection
 			) {
-				// For providers whose usage arrives as per-turn deltas of a cumulative
-				// session total (Codex), the delta undercounts the context that is
-				// actually occupying the window - plotting it makes a long run look
-				// low and flat. `absoluteUsage` carries the pre-normalization running
-				// total for exactly this case; fall back to the per-turn stats for
-				// per-call providers (Claude/Copilot/OpenCode), whose values are
-				// already absolute for the turn. The per-turn token fields recorded on
-				// the point below are intentionally left as the deltas (this turn's
-				// activity); only the context-fill figures use the absolute source.
-				const contextSource = usageStats.absoluteUsage ?? usageStats;
-				const contextTokens = calculateContextTokens(contextSource, agentToolType);
+				// `occupancyStats` (resolved above) is the absolute snapshot when the
+				// provider attached one - the pre-normalization running total for
+				// Codex, whose deltas would make a long run look low and flat, and the
+				// last internal call's usage for claude-code, whose summed turn totals
+				// are token spend rather than window fill. Providers whose per-turn
+				// stats are already absolute (Copilot, OpenCode) fall through to those.
+				// The per-turn token fields recorded on the point below are
+				// intentionally left as the deltas (this turn's activity); only the
+				// context-fill figures use the absolute source.
+				// Same source the gauge estimate above reads, so the two can never
+				// disagree about how full the window is.
+				const contextTokens = calculateContextTokens(occupancyStats, agentToolType);
 				// Percentage against the SAME (configured-aware) window the point
 				// stores, so the row is internally consistent and matches the header.
 				// null when tokens exceed the window (accumulated multi-tool turn) -
@@ -212,6 +234,27 @@ export function useAgentUsageListener(deps: UseAgentUsageListenerDeps): void {
 					const yellowThreshold = deps.contextWarningYellowThreshold;
 					const maxEstimate = yellowThreshold - ESTIMATED_USAGE_YELLOW_GAP_PCT;
 					deps.batchedUpdater.updateContextUsage(actualSessionId, Math.min(estimated, maxEstimate));
+				} else if (usageStats.absoluteUsage && resolvedWindow > 0) {
+					// Bootstrap the baseline (finding Q1, D1). The growth estimate above
+					// needs a previous value to grow FROM, so a session whose very first
+					// turn already overflows never establishes one and the gauge stays
+					// pinned at 0% for the life of the session. An occupancy snapshot is
+					// real within-window data, so seed the baseline from it directly.
+					// This branch also rescues the case where the estimate above could
+					// not resolve a window on its own but this hook could - a per-agent
+					// custom window, a `[1m]` model marker, or the cached provider
+					// window - since `resolvedWindow` sees all three.
+					//
+					// Deliberately NOT capped to `maxEstimate`: that cap exists so an
+					// EXTRAPOLATED value cannot trip the yellow warning by itself. A
+					// snapshot is a measurement, so it is allowed to.
+					const snapshotTokens = calculateContextTokens(usageStats.absoluteUsage, agentToolType);
+					if (snapshotTokens > 0 && snapshotTokens <= resolvedWindow) {
+						deps.batchedUpdater.updateContextUsage(
+							actualSessionId,
+							Math.round((snapshotTokens / resolvedWindow) * 100)
+						);
+					}
 				}
 			}
 			if (!isContextWindowCorrection) {

--- a/src/renderer/hooks/agent/internal/useAgentUsageListener.ts
+++ b/src/renderer/hooks/agent/internal/useAgentUsageListener.ts
@@ -80,11 +80,6 @@ export function useAgentUsageListener(deps: UseAgentUsageListenerDeps): void {
 			const occupancyStats = usageStats.absoluteUsage
 				? { ...usageStats.absoluteUsage, contextWindow: usageStats.contextWindow }
 				: usageStats;
-			const contextPercentage = estimateContextUsage(
-				occupancyStats,
-				agentToolType,
-				sessionRemoteId
-			);
 
 			// Resolve the effective context window ONCE, matching the header gauge's
 			// precedence (resolveConfiguredContextWindow): a per-agent custom window,
@@ -130,6 +125,21 @@ export function useAgentUsageListener(deps: UseAgentUsageListenerDeps): void {
 											useAgentStore.getState().getCapabilitySnapshot(agentToolType, sessionRemoteId)
 										)
 									: 0;
+
+			// Gauge percentage, computed AFTER `resolvedWindow` so it divides by the
+			// same denominator the timeline point stores. Computing it earlier used
+			// the event's reported window, so a session with a configured or
+			// model-marker window could update the gauge against one denominator
+			// while the timeline recorded another - the exact gauge/timeline
+			// disagreement PR #1221 fixed. `estimateContextUsage` prefers
+			// `stats.contextWindow` when it is positive and otherwise falls back to
+			// the capability snapshot and the static table, so handing it
+			// `resolvedWindow` makes the precedence identical on both surfaces.
+			const contextPercentage = estimateContextUsage(
+				resolvedWindow > 0 ? { ...occupancyStats, contextWindow: resolvedWindow } : occupancyStats,
+				agentToolType,
+				sessionRemoteId
+			);
 
 			// A context-window correction (omp's catalog primed after the first turn's
 			// fallback usage already emitted) replays an already-counted turn purely to

--- a/src/renderer/utils/contextUsage.ts
+++ b/src/renderer/utils/contextUsage.ts
@@ -241,9 +241,21 @@ export function calculateContextDisplay(
 		if (
 			fallbackPercentage != null &&
 			Number.isFinite(fallbackPercentage) &&
-			fallbackPercentage >= 0
+			fallbackPercentage > 0
 		) {
 			// Accumulated multi-tool turn: derive tokens from preserved percentage.
+			//
+			// The guard is `> 0`, not `>= 0`: a zero fallback is the ABSENCE of a
+			// prior measurement, not a measurement of zero. Accepting it computed
+			// `tokens = round(0/100 * window) = 0` and returned `trustworthy: true`,
+			// which latched the gauge (and the Context Details popover) at 0% for the
+			// whole life of any session whose first turn already overflowed the
+			// window (finding Q1).
+			//
+			// Accepted edge case: a session whose stored contextUsage legitimately
+			// rounded to 0 (real usage under 0.5%) now produces an untrustworthy
+			// overflow frame, so callers hold their previous values - which are also
+			// zero - and the rendered result is identical. Nothing is lost.
 			const boundedFallback = Math.min(100, fallbackPercentage);
 			tokens = Math.round((boundedFallback / 100) * contextWindow);
 		} else {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -320,16 +320,26 @@ export interface UsageStats {
 	 */
 	reasoningTokens?: number;
 	/**
-	 * Pre-normalization absolute token totals, set ONLY for providers whose CLI
-	 * reports cumulative session usage that we delta-normalize before emitting
-	 * (currently Codex - see normalizeUsageToDelta in StdoutHandler). For those
-	 * providers the top-level fields above are per-turn DELTAS, which are correct
-	 * for token accumulation but wrong for context-fill display: the cumulative
-	 * total is what actually occupies the model window. Consumers that plot
-	 * context occupancy (the Context Timeline inspector) read from here when
-	 * present and fall back to the top-level fields otherwise. Undefined for
-	 * per-call providers (Claude, Copilot, OpenCode), whose top-level fields are
-	 * already absolute for the current turn.
+	 * Absolute context-occupancy snapshot for the turn, set by providers whose
+	 * top-level fields above are NOT occupancy. Two sources today:
+	 *
+	 * - Codex: its CLI reports cumulative session usage which we delta-normalize
+	 *   before emitting (see normalizeUsageToDelta in StdoutHandler), so the
+	 *   top-level fields are per-turn DELTAS - correct for token accumulation,
+	 *   wrong for context fill. The pre-normalization cumulative total is the
+	 *   occupancy.
+	 * - Claude Code: its result message sums every internal API call of the turn,
+	 *   so the top-level fields are token SPEND and a tool-heavy turn can exceed
+	 *   the window entirely. Its parser attaches the LAST internal call's usage
+	 *   here, which is real occupancy (a single call's input is what was
+	 *   physically sent to the model). Note `outputTokens` in that case is the
+	 *   last call's output, not the turn's - occupancy consumers read the input
+	 *   side.
+	 *
+	 * Consumers that plot context occupancy (the Context Timeline inspector, the
+	 * context gauge) read from here when present and fall back to the top-level
+	 * fields otherwise. Undefined for providers whose top-level fields are already
+	 * absolute for the current turn (Copilot, OpenCode).
 	 */
 	absoluteUsage?: {
 		inputTokens: number;


### PR DESCRIPTION
Closes finding Q1 (severity high). **Bottom of a 3-PR stack** - see the stack note at the end.

## Problem

The context gauge and Context Details popover read `0%` on a session that is demonstrably deep into its context: 2.4M input tokens against a 1M window, but `Context Tokens 0` and `Usage 0%`.

A claude-code *turn* fans out into many internal API calls and the parser sums them, so one tool-heavy turn legitimately reports more input than the window. The intended mitigation is to fall back to the last known-good percentage, but that fallback could never arm:

1. `estimateContextUsage` returns `null` on overflow.
2. The `null` branch only estimates growth when a baseline already exists (`if (currentUsage > 0)`), so a session whose **first** usage event overflows never establishes one.
3. `calculateContextDisplay` then reads `fallbackPercentage = 0`, which **passes** its `fallbackPercentage >= 0` guard, and returns `0 tokens / 0%` flagged `trustworthy: true`.
4. Because the frame is flagged trustworthy, `lastGoodRef` caches `0` as a good value. The gauge is pinned at 0% for the life of the session.

Step 3 is the ugly part: the `trustworthy` flag exists specifically to stop bogus readings (#762), and here it launders a zero into a "good" value.

## Fix

- Require `fallbackPercentage > 0`. A zero fallback is the *absence* of a measurement, not a measurement of zero, so the frame is now correctly untrustworthy and the caller holds its previous value.
- Stop the last-good cache from storing a zero-fallback overflow frame.
- Establish a first baseline from claude-code's last-call occupancy snapshot, attached as `absoluteUsage` in the main process and consumed in the renderer. This is the structurally correct fix: the renderer cannot un-sum what the parser already added together, so the per-call figure has to come from the parser.

## Testing

Scoped tests only. The highest-value regression: `calculateContextDisplay` with `raw > contextWindow` and `fallbackPercentage = 0` must return `trustworthy: false` (it returned `true` with `0/0`). Plus parser-level coverage for the occupancy snapshot and renderer coverage for the baseline bootstrap.

## Stack

1. **this PR** - Q1, the numerator collapsing to zero
2. `fix/p1-context-window-precedence` - P1, which *denominator* the gauge divides by
3. `fix/r1-context-overlimit-display` - R1, how over-limit context renders

They all edit the same block of `useAgentUsageListener.ts`, so they must land bottom-up in that order. A fourth layer (S1, Context Timeline persistence) follows later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added more accurate context-usage snapshots for Claude sessions.
  - Context gauges and timelines now reflect the latest available occupancy data.
  - Initial snapshots can populate context tracking, including custom context windows.
  - Timeline history preserves per-turn usage while displaying current occupancy.

- **Bug Fixes**
  - Preserved the last reliable context values when overflow data reports zero usage.
  - Prevented unavailable zero-value fallbacks from appearing as trustworthy measurements.
  - Maintained aggregated usage totals independently from per-call context snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->