### PR TITLE
Preserve transcript scroll on window focus

### DIFF
--- a/src/__tests__/renderer/components/TerminalOutput.test.tsx
+++ b/src/__tests__/renderer/components/TerminalOutput.test.tsx
@@ -2713,6 +2713,34 @@ describe('TerminalOutput', () => {
 			// In tests this is mocked, so we just verify the prop is used
 		});
 
+		it('keeps a persisted bottom-pinned tab at the current bottom instead of restoring stale pixels', async () => {
+			const { container } = render(
+				<TerminalOutput
+					{...createDefaultProps({ initialScrollTop: 300, initialIsAtBottom: true })}
+				/>
+			);
+			const scrollContainer = container.querySelector('.overflow-y-auto') as HTMLElement;
+			const scrollTopWrites = vi.fn();
+			Object.defineProperties(scrollContainer, {
+				scrollTop: {
+					configurable: true,
+					get: () => 0,
+					set: scrollTopWrites,
+				},
+				scrollHeight: { configurable: true, value: 1000 },
+				clientHeight: { configurable: true, value: 400 },
+			});
+			const scrollToSpy = vi.fn();
+			scrollContainer.scrollTo = scrollToSpy;
+
+			await act(async () => {
+				vi.advanceTimersByTime(50);
+			});
+
+			expect(scrollTopWrites).not.toHaveBeenCalledWith(300);
+			expect(scrollToSpy).toHaveBeenCalledWith({ top: 1000, behavior: 'auto' });
+		});
+
 		it('preserves a middle position across window blur and focus without persisting transient zero', async () => {
 			const onScrollPositionChange = vi.fn();
 			const { container } = render(

--- a/src/__tests__/renderer/components/TerminalOutput.test.tsx
+++ b/src/__tests__/renderer/components/TerminalOutput.test.tsx
@@ -2681,6 +2681,30 @@ describe('TerminalOutput', () => {
 			expect(onScrollPositionChange).toHaveBeenCalledWith(100);
 		});
 
+		it('persists a jump to bottom before an immediate agent switch unmounts the transcript', () => {
+			const onScrollPositionChange = vi.fn();
+			const onAtBottomChange = vi.fn();
+			const logs = [createLogEntry({ id: 'response-1', text: 'Long response' })];
+			const session = createDefaultSession({
+				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+			});
+			const { container, unmount } = render(
+				<TerminalOutput
+					{...createDefaultProps({ session, onScrollPositionChange, onAtBottomChange })}
+				/>
+			);
+			const scrollContainer = container.querySelector('.overflow-y-auto') as HTMLElement;
+			configureScrollableTranscript(scrollContainer, 300);
+			scrollContainer.scrollTo = vi.fn();
+			fireEvent.scroll(scrollContainer);
+
+			fireEvent.click(screen.getByTitle('Scroll to bottom (click to pin)'));
+			unmount();
+
+			expect(onScrollPositionChange).toHaveBeenLastCalledWith(600);
+			expect(onAtBottomChange).toHaveBeenLastCalledWith(true);
+		});
+
 		it('restores scroll position from initialScrollTop', () => {
 			const props = createDefaultProps({ initialScrollTop: 500 });
 			const { container } = render(<TerminalOutput {...props} />);

--- a/src/__tests__/renderer/components/TerminalOutput.test.tsx
+++ b/src/__tests__/renderer/components/TerminalOutput.test.tsx
@@ -2741,6 +2741,30 @@ describe('TerminalOutput', () => {
 			expect(scrollToSpy).toHaveBeenCalledWith({ top: 1000, behavior: 'auto' });
 		});
 
+		it('does not degrade pinned state when programmatic bottom restoration reports an intermediate position', async () => {
+			const onAtBottomChange = vi.fn();
+			const { container } = render(
+				<TerminalOutput {...createDefaultProps({ initialIsAtBottom: true, onAtBottomChange })} />
+			);
+			const scrollContainer = container.querySelector('.overflow-y-auto') as HTMLElement;
+			configureScrollableTranscript(scrollContainer, 300);
+			scrollContainer.scrollTo = vi.fn();
+
+			await act(async () => {
+				vi.advanceTimersByTime(20);
+			});
+			fireEvent.scroll(scrollContainer);
+
+			expect(onAtBottomChange).not.toHaveBeenCalledWith(false);
+
+			await act(async () => {
+				vi.advanceTimersByTime(40);
+			});
+			fireEvent.scroll(scrollContainer);
+
+			expect(onAtBottomChange).toHaveBeenCalledWith(false);
+		});
+
 		it('preserves a middle position across window blur and focus without persisting transient zero', async () => {
 			const onScrollPositionChange = vi.fn();
 			const { container } = render(

--- a/src/__tests__/renderer/components/TerminalOutput.test.tsx
+++ b/src/__tests__/renderer/components/TerminalOutput.test.tsx
@@ -2636,6 +2636,32 @@ describe('TerminalOutput', () => {
 	});
 
 	describe('scroll position persistence', () => {
+		const configureScrollableTranscript = (
+			container: HTMLElement,
+			initialScrollTop: number,
+			scrollHeight = 1000,
+			clientHeight = 400
+		) => {
+			let scrollTop = initialScrollTop;
+			Object.defineProperties(container, {
+				scrollTop: {
+					configurable: true,
+					get: () => scrollTop,
+					set: (value: number) => {
+						scrollTop = value;
+					},
+				},
+				scrollHeight: { configurable: true, value: scrollHeight },
+				clientHeight: { configurable: true, value: clientHeight },
+			});
+			return {
+				getScrollTop: () => scrollTop,
+				setScrollTop: (value: number) => {
+					scrollTop = value;
+				},
+			};
+		};
+
 		it('calls onScrollPositionChange when scrolling (throttled)', async () => {
 			const onScrollPositionChange = vi.fn();
 			const props = createDefaultProps({ onScrollPositionChange });
@@ -2661,6 +2687,127 @@ describe('TerminalOutput', () => {
 
 			// The scroll restoration happens via requestAnimationFrame
 			// In tests this is mocked, so we just verify the prop is used
+		});
+
+		it('preserves a middle position across window blur and focus without persisting transient zero', async () => {
+			const onScrollPositionChange = vi.fn();
+			const { container } = render(
+				<TerminalOutput
+					{...createDefaultProps({ initialScrollTop: 400, onScrollPositionChange })}
+				/>
+			);
+			const scrollContainer = container.querySelector('.overflow-y-auto') as HTMLElement;
+			const scroll = configureScrollableTranscript(scrollContainer, 400);
+			fireEvent.scroll(scrollContainer);
+			await act(async () => {
+				vi.advanceTimersByTime(250);
+			});
+			onScrollPositionChange.mockClear();
+
+			fireEvent.blur(window);
+			scroll.setScrollTop(0);
+			fireEvent.scroll(scrollContainer);
+			fireEvent.focus(window);
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+			});
+
+			expect(scroll.getScrollTop()).toBe(400);
+			expect(onScrollPositionChange).not.toHaveBeenCalledWith(0);
+		});
+
+		it('keeps a bottom-pinned transcript pinned across window blur and focus', async () => {
+			const onScrollPositionChange = vi.fn();
+			const { container } = render(
+				<TerminalOutput
+					{...createDefaultProps({ initialScrollTop: 600, onScrollPositionChange })}
+				/>
+			);
+			const scrollContainer = container.querySelector('.overflow-y-auto') as HTMLElement;
+			const scroll = configureScrollableTranscript(scrollContainer, 600);
+
+			fireEvent.blur(window);
+			scroll.setScrollTop(0);
+			fireEvent.scroll(scrollContainer);
+			fireEvent.focus(window);
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+			});
+
+			expect(scroll.getScrollTop()).toBe(600);
+			expect(onScrollPositionChange).not.toHaveBeenCalledWith(0);
+		});
+
+		it('keeps different saved positions isolated when switching agents after focus', async () => {
+			const firstSession = createDefaultSession({ id: 'session-1' });
+			const secondSession = createDefaultSession({ id: 'session-2' });
+			const { container, rerender } = render(
+				<TerminalOutput
+					key="session-1-tab-1"
+					{...createDefaultProps({ session: firstSession, initialScrollTop: 250 })}
+				/>
+			);
+			let scrollContainer = container.querySelector('.overflow-y-auto') as HTMLElement;
+			let scroll = configureScrollableTranscript(scrollContainer, 250);
+			fireEvent.scroll(scrollContainer);
+			await act(async () => {
+				vi.advanceTimersByTime(250);
+			});
+
+			fireEvent.blur(window);
+			scroll.setScrollTop(0);
+			fireEvent.focus(window);
+			await act(async () => {
+				vi.advanceTimersByTime(50);
+			});
+			expect(scroll.getScrollTop()).toBe(250);
+
+			rerender(
+				<TerminalOutput
+					key="session-2-tab-1"
+					{...createDefaultProps({ session: secondSession, initialScrollTop: 500 })}
+				/>
+			);
+			scrollContainer = container.querySelector('.overflow-y-auto') as HTMLElement;
+			scroll = configureScrollableTranscript(scrollContainer, 500);
+			fireEvent.scroll(scrollContainer);
+			await act(async () => {
+				vi.advanceTimersByTime(250);
+			});
+
+			fireEvent.blur(window);
+			scroll.setScrollTop(0);
+			fireEvent.focus(window);
+			await act(async () => {
+				vi.advanceTimersByTime(50);
+			});
+
+			expect(scroll.getScrollTop()).toBe(500);
+		});
+
+		it('still persists an intentional user scroll to the top after focus restoration settles', async () => {
+			const onScrollPositionChange = vi.fn();
+			const { container } = render(
+				<TerminalOutput
+					{...createDefaultProps({ initialScrollTop: 400, onScrollPositionChange })}
+				/>
+			);
+			const scrollContainer = container.querySelector('.overflow-y-auto') as HTMLElement;
+			const scroll = configureScrollableTranscript(scrollContainer, 400);
+
+			fireEvent.blur(window);
+			fireEvent.focus(window);
+			await act(async () => {
+				vi.advanceTimersByTime(50);
+			});
+			onScrollPositionChange.mockClear();
+			scroll.setScrollTop(0);
+			fireEvent.scroll(scrollContainer);
+			await act(async () => {
+				vi.advanceTimersByTime(250);
+			});
+
+			expect(onScrollPositionChange).toHaveBeenCalledWith(0);
 		});
 	});
 

--- a/src/__tests__/renderer/components/TerminalOutput.test.tsx
+++ b/src/__tests__/renderer/components/TerminalOutput.test.tsx
@@ -2883,6 +2883,46 @@ describe('TerminalOutput', () => {
 			expect(scroll.getScrollTop()).toBe(500);
 		});
 
+		it('keeps a restored middle position unpinned across repeated agent remounts', async () => {
+			const firstSession = createDefaultSession({ id: 'session-1' });
+			const secondSession = createDefaultSession({ id: 'session-2' });
+			const renderAgent = (session: Session, scrollTop: number) => (
+				<TerminalOutput
+					key={`${session.id}-tab-1`}
+					{...createDefaultProps({
+						session,
+						initialScrollTop: scrollTop,
+						initialIsAtBottom: false,
+					})}
+				/>
+			);
+			const { container, rerender } = render(renderAgent(firstSession, 250));
+
+			for (const [session, savedPosition] of [
+				[secondSession, 500],
+				[firstSession, 250],
+				[secondSession, 500],
+				[firstSession, 250],
+			] as const) {
+				rerender(renderAgent(session, savedPosition));
+				const scrollContainer = container.querySelector('.overflow-y-auto') as HTMLElement;
+				const scroll = configureScrollableTranscript(scrollContainer, 0);
+				const scrollToSpy = vi.fn();
+				scrollContainer.scrollTo = scrollToSpy;
+
+				await act(async () => {
+					vi.advanceTimersByTime(20);
+				});
+				expect(scroll.getScrollTop()).toBe(savedPosition);
+
+				await act(async () => {
+					scrollContainer.appendChild(document.createElement('span'));
+					vi.advanceTimersByTime(20);
+				});
+				expect(scrollToSpy).not.toHaveBeenCalled();
+			}
+		});
+
 		it('still persists an intentional user scroll to the top after focus restoration settles', async () => {
 			const onScrollPositionChange = vi.fn();
 			const { container } = render(

--- a/src/__tests__/renderer/components/TerminalOutput.test.tsx
+++ b/src/__tests__/renderer/components/TerminalOutput.test.tsx
@@ -2716,6 +2716,28 @@ describe('TerminalOutput', () => {
 			expect(onScrollPositionChange).not.toHaveBeenCalledWith(0);
 		});
 
+		it('snapshots a user scroll before an immediate blur without waiting for a rerender', async () => {
+			const onScrollPositionChange = vi.fn();
+			const { container } = render(
+				<TerminalOutput
+					{...createDefaultProps({ initialScrollTop: 600, onScrollPositionChange })}
+				/>
+			);
+			const scrollContainer = container.querySelector('.overflow-y-auto') as HTMLElement;
+			const scroll = configureScrollableTranscript(scrollContainer, 400);
+
+			fireEvent.scroll(scrollContainer);
+			fireEvent.blur(window);
+			scroll.setScrollTop(0);
+			fireEvent.focus(window);
+			await act(async () => {
+				vi.advanceTimersByTime(50);
+			});
+
+			expect(scroll.getScrollTop()).toBe(400);
+			expect(onScrollPositionChange).toHaveBeenCalledWith(400);
+		});
+
 		it('keeps a bottom-pinned transcript pinned across window blur and focus', async () => {
 			const onScrollPositionChange = vi.fn();
 			const { container } = render(

--- a/src/renderer/components/MainPanel/MainPanelContent.tsx
+++ b/src/renderer/components/MainPanel/MainPanelContent.tsx
@@ -668,6 +668,7 @@ export const MainPanelContent = React.memo(function MainPanelContent(props: Main
 								onScrollPositionChange={onScrollPositionChange}
 								onAtBottomChange={onAtBottomChange}
 								initialScrollTop={activeTab?.scrollTop}
+								initialIsAtBottom={activeTab?.isAtBottom}
 								markdownEditMode={chatRawTextMode}
 								setMarkdownEditMode={useSettingsStore.getState().setChatRawTextMode}
 								onReplayMessage={onReplayMessage}

--- a/src/renderer/components/TerminalOutput.tsx
+++ b/src/renderer/components/TerminalOutput.tsx
@@ -2089,6 +2089,7 @@ export const TerminalOutput = memo(
 			const { scrollTop, scrollHeight, clientHeight } = scrollContainerRef.current;
 			// Consider "at bottom" if within 50px of the bottom
 			const atBottom = scrollHeight - scrollTop - clientHeight < 50;
+			isAtBottomRef.current = atBottom;
 			setIsAtBottom(atBottom);
 
 			// Notify parent when isAtBottom changes (for hasUnread logic)
@@ -2102,6 +2103,7 @@ export const TerminalOutput = memo(
 				setHasNewMessages(false);
 				setNewMessageCount(0);
 				// Resume auto-scroll when user scrolls back to bottom
+				autoScrollPausedRef.current = false;
 				setAutoScrollPaused(false);
 				// Save read state for current tab
 				if (activeTabId) {
@@ -2116,6 +2118,7 @@ export const TerminalOutput = memo(
 					isProgrammaticScrollRef.current = false;
 				} else {
 					// Genuine user scroll away from bottom — pause auto-scroll
+					autoScrollPausedRef.current = true;
 					setAutoScrollPaused(true);
 				}
 			}

--- a/src/renderer/components/TerminalOutput.tsx
+++ b/src/renderer/components/TerminalOutput.tsx
@@ -2091,6 +2091,10 @@ export const TerminalOutput = memo(
 			const { scrollTop, scrollHeight, clientHeight } = scrollContainerRef.current;
 			// Consider "at bottom" if within 50px of the bottom
 			const atBottom = scrollHeight - scrollTop - clientHeight < 50;
+			// A scrollTo-bottom can report an intermediate non-bottom position while
+			// transcript layout is still expanding. Keep the semantic pinned state;
+			// the fallback timer clears this guard for the next genuine user scroll.
+			if (isProgrammaticScrollRef.current && !atBottom) return;
 			isAtBottomRef.current = atBottom;
 			setIsAtBottom(atBottom);
 
@@ -2112,17 +2116,9 @@ export const TerminalOutput = memo(
 					tabReadStateRef.current.set(activeTabId, filteredLogs.length);
 				}
 			} else {
-				if (isProgrammaticScrollRef.current) {
-					// This scroll event was triggered by our own scrollTo() call —
-					// consume the guard flag here inside the throttled handler to avoid
-					// the race where queueMicrotask clears the flag before a deferred
-					// throttled invocation fires (throttle delay is 16ms > microtask).
-					isProgrammaticScrollRef.current = false;
-				} else {
-					// Genuine user scroll away from bottom — pause auto-scroll
-					autoScrollPausedRef.current = true;
-					setAutoScrollPaused(true);
-				}
+				// Genuine user scroll away from bottom — pause auto-scroll
+				autoScrollPausedRef.current = true;
+				setAutoScrollPaused(true);
 			}
 
 			// Throttled scroll position save (200ms)
@@ -2272,8 +2268,7 @@ export const TerminalOutput = memo(
 				requestAnimationFrame(() => {
 					if (scrollContainerRef.current) {
 						// Set guard flag BEFORE scrollTo — the throttled scroll handler
-						// checks this flag and consumes it (clears it) when it fires,
-						// preventing the programmatic scroll from being misinterpreted
+						// checks this flag, preventing the programmatic scroll from being misinterpreted
 						// as a user scroll-up that should pause auto-scroll.
 						isProgrammaticScrollRef.current = true;
 						scrollContainerRef.current.scrollTo({

--- a/src/renderer/components/TerminalOutput.tsx
+++ b/src/renderer/components/TerminalOutput.tsx
@@ -1377,6 +1377,7 @@ interface TerminalOutputProps {
 	onScrollPositionChange?: (scrollTop: number) => void; // Callback to save scroll position
 	onAtBottomChange?: (isAtBottom: boolean) => void; // Callback when user scrolls to/away from bottom
 	initialScrollTop?: number; // Initial scroll position to restore
+	initialIsAtBottom?: boolean; // Whether the restored transcript should remain pinned to bottom
 	markdownEditMode: boolean; // Whether to show raw markdown or rendered markdown for AI responses
 	setMarkdownEditMode: (value: boolean) => void; // Toggle markdown mode
 	onReplayMessage?: (text: string, images?: string[]) => void; // Replay a user message
@@ -1442,6 +1443,7 @@ export const TerminalOutput = memo(
 			onScrollPositionChange,
 			onAtBottomChange,
 			initialScrollTop,
+			initialIsAtBottom,
 			markdownEditMode,
 			setMarkdownEditMode,
 			onReplayMessage,
@@ -1509,21 +1511,21 @@ export const TerminalOutput = memo(
 		const [saveModalContent, setSaveModalContent] = useState<string | null>(null);
 
 		// New message indicator state
-		const [isAtBottom, setIsAtBottom] = useState(true);
+		const [isAtBottom, setIsAtBottom] = useState(initialIsAtBottom ?? true);
 		const [hasNewMessages, setHasNewMessages] = useState(false);
 		const [newMessageCount, setNewMessageCount] = useState(0);
 		const lastLogCountRef = useRef(0);
 		// Track previous isAtBottom to detect changes for callback
-		const prevIsAtBottomRef = useRef(true);
+		const prevIsAtBottomRef = useRef(initialIsAtBottom ?? true);
 		// Ref mirror of isAtBottom for MutationObserver closure (avoids stale state)
-		const isAtBottomRef = useRef(true);
+		const isAtBottomRef = useRef(initialIsAtBottom ?? true);
 		isAtBottomRef.current = isAtBottom;
 		// Track whether auto-scroll is paused because user scrolled up (state so button re-renders)
-		const [autoScrollPaused, setAutoScrollPaused] = useState(false);
+		const [autoScrollPaused, setAutoScrollPaused] = useState(initialIsAtBottom === false);
 		// Ref mirror of autoScrollPaused for the MutationObserver closure so a freshly
 		// restored scroll position can suppress auto-scroll synchronously, before the
 		// state-driven re-render re-runs the observer effect (avoids a one-frame yank).
-		const autoScrollPausedRef = useRef(false);
+		const autoScrollPausedRef = useRef(initialIsAtBottom === false);
 		autoScrollPausedRef.current = autoScrollPaused;
 		// Guard flag: prevents the scroll handler from pausing auto-scroll
 		// during programmatic scrollTo() calls from the MutationObserver effect.
@@ -2313,7 +2315,12 @@ export const TerminalOutput = memo(
 		// Uses requestAnimationFrame to ensure DOM is ready
 		useEffect(() => {
 			// Only restore if we have a saved position and haven't restored yet for this mount
-			if (initialScrollTop !== undefined && initialScrollTop > 0 && !hasRestoredScrollRef.current) {
+			if (
+				initialIsAtBottom !== true &&
+				initialScrollTop !== undefined &&
+				initialScrollTop > 0 &&
+				!hasRestoredScrollRef.current
+			) {
 				hasRestoredScrollRef.current = true;
 				requestAnimationFrame(() => {
 					// A cross-tab search jump asked for a specific message in this tab.
@@ -2344,7 +2351,7 @@ export const TerminalOutput = memo(
 					}
 				});
 			}
-		}, [initialScrollTop]);
+		}, [initialScrollTop, initialIsAtBottom]);
 
 		// Reset restore flag when session/tab changes (handled by key prop on TerminalOutput)
 		useEffect(() => {

--- a/src/renderer/components/TerminalOutput.tsx
+++ b/src/renderer/components/TerminalOutput.tsx
@@ -31,6 +31,7 @@ import { useLayerStack } from '../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { getActiveTab } from '../utils/tabHelpers';
 import { useDebouncedValue, useThrottledCallback, useProgressiveRenderWindow } from '../hooks';
+import { useEventListener } from '../hooks/utils/useEventListener';
 import {
 	processLogTextHelper,
 	filterTextByLinesHelper,
@@ -1527,6 +1528,13 @@ export const TerminalOutput = memo(
 		// Guard flag: prevents the scroll handler from pausing auto-scroll
 		// during programmatic scrollTo() calls from the MutationObserver effect.
 		const isProgrammaticScrollRef = useRef(false);
+		// Chromium can briefly report scrollTop=0 while restoring a focused window's
+		// layout. Focus-transition and restoration scrolls are not user intent.
+		const suppressScrollPersistenceRef = useRef(false);
+		const focusScrollSnapshotRef = useRef<{ scrollTop: number; pinnedToBottom: boolean } | null>(
+			null
+		);
+		const focusRestoreFrameRef = useRef<number | null>(null);
 		// Guard flag: a cross-tab search jump is landing, so the follow-the-tail
 		// auto-scroll must stand down. Switching tabs re-renders every row, and the
 		// MutationObserver below reacts to that by slamming the container to the
@@ -2113,7 +2121,7 @@ export const TerminalOutput = memo(
 			}
 
 			// Throttled scroll position save (200ms)
-			if (onScrollPositionChange) {
+			if (onScrollPositionChange && !suppressScrollPersistenceRef.current) {
 				if (scrollSaveTimerRef.current) {
 					clearTimeout(scrollSaveTimerRef.current);
 				}
@@ -2126,6 +2134,51 @@ export const TerminalOutput = memo(
 
 		// PERF: Throttle at 16ms (60fps) instead of 4ms to reduce state updates during scroll
 		const handleScroll = useThrottledCallback(handleScrollInner, 16);
+
+		useEventListener('blur', () => {
+			const container = scrollContainerRef.current;
+			if (!container) return;
+
+			focusScrollSnapshotRef.current = {
+				scrollTop: container.scrollTop,
+				pinnedToBottom: isAtBottomRef.current && !autoScrollPausedRef.current,
+			};
+			onScrollPositionChange?.(container.scrollTop);
+			suppressScrollPersistenceRef.current = true;
+			if (scrollSaveTimerRef.current) {
+				clearTimeout(scrollSaveTimerRef.current);
+				scrollSaveTimerRef.current = null;
+			}
+		});
+
+		useEventListener('focus', () => {
+			const snapshot = focusScrollSnapshotRef.current;
+			if (!snapshot) return;
+
+			if (focusRestoreFrameRef.current !== null) {
+				cancelAnimationFrame(focusRestoreFrameRef.current);
+			}
+			focusRestoreFrameRef.current = requestAnimationFrame(() => {
+				focusRestoreFrameRef.current = null;
+				const container = scrollContainerRef.current;
+				if (!container) {
+					suppressScrollPersistenceRef.current = false;
+					return;
+				}
+
+				const maxScroll = Math.max(0, container.scrollHeight - container.clientHeight);
+				const targetScroll = snapshot.pinnedToBottom
+					? maxScroll
+					: Math.min(snapshot.scrollTop, maxScroll);
+				if (container.scrollTop !== targetScroll) {
+					container.scrollTop = targetScroll;
+				}
+				focusScrollSnapshotRef.current = null;
+				requestAnimationFrame(() => {
+					suppressScrollPersistenceRef.current = false;
+				});
+			});
+		});
 
 		// Restore read state when switching tabs
 		useEffect(() => {
@@ -2280,7 +2333,11 @@ export const TerminalOutput = memo(
 							setAutoScrollPaused(true);
 							setIsAtBottom(false);
 						}
+						suppressScrollPersistenceRef.current = true;
 						scrollContainerRef.current.scrollTop = targetScroll;
+						requestAnimationFrame(() => {
+							suppressScrollPersistenceRef.current = false;
+						});
 					}
 				});
 			}
@@ -2296,6 +2353,9 @@ export const TerminalOutput = memo(
 			return () => {
 				if (scrollSaveTimerRef.current) {
 					clearTimeout(scrollSaveTimerRef.current);
+				}
+				if (focusRestoreFrameRef.current !== null) {
+					cancelAnimationFrame(focusRestoreFrameRef.current);
 				}
 			};
 		}, []);

--- a/src/renderer/components/TerminalOutput.tsx
+++ b/src/renderer/components/TerminalOutput.tsx
@@ -2716,10 +2716,24 @@ export const TerminalOutput = memo(
 					<button
 						onClick={() => {
 							// Jump to bottom and resume auto-scroll
+							autoScrollPausedRef.current = false;
 							setAutoScrollPaused(false);
+							isAtBottomRef.current = true;
+							setIsAtBottom(true);
+							prevIsAtBottomRef.current = true;
+							onAtBottomChange?.(true);
 							setHasNewMessages(false);
 							setNewMessageCount(0);
 							if (scrollContainerRef.current) {
+								if (scrollSaveTimerRef.current) {
+									clearTimeout(scrollSaveTimerRef.current);
+									scrollSaveTimerRef.current = null;
+								}
+								const maxScroll = Math.max(
+									0,
+									scrollContainerRef.current.scrollHeight - scrollContainerRef.current.clientHeight
+								);
+								onScrollPositionChange?.(maxScroll);
 								scrollContainerRef.current.scrollTo({
 									top: scrollContainerRef.current.scrollHeight,
 									behavior: 'smooth',

--- a/src/renderer/components/TerminalOutput.tsx
+++ b/src/renderer/components/TerminalOutput.tsx
@@ -2213,7 +2213,10 @@ export const TerminalOutput = memo(
 				tabReadStateRef.current.set(activeTabId, currentCount);
 				setHasNewMessages(false);
 				setNewMessageCount(0);
-				setIsAtBottom(true);
+				// Do not redefine the restored scroll state here. TerminalOutput is keyed by
+				// agent and tab, so this local map is empty after every tab switch. Treating
+				// that remount as pinned overrides initialIsAtBottom and lets the mutation
+				// observer pull a restored middle position back to the bottom.
 			}
 
 			lastLogCountRef.current = currentCount;


### PR DESCRIPTION
## Root cause

`TerminalOutput` treated every native scroll event as user intent. During a window blur/focus transition, Chromium can temporarily report `scrollTop === 0` while restoring layout. The existing debounced persistence path saved that transient value to the active AI tab. Programmatic initial restoration used the same unguarded path, so its scroll event could also replace the stored position.

## Fix

- Snapshot and synchronously persist the valid viewport position when the window blurs.
- Track whether the transcript was pinned to the bottom separately from its numeric position.
- Suppress persistence for focus-transition and programmatic restoration scroll events.
- On focus, restore only if the DOM position changed during the transition. Bottom-pinned transcripts restore to the current bottom and keep following output.
- Resume normal persistence after layout settles, preserving intentional user scrolling to the top.

## Tests

- `npm run format:check:all`
- `npm run lint`
- `npm run lint:eslint`
- `npm run test` (1,155 files passed, 32,545 tests passed, 108 skipped)
- Added regressions for a middle position, bottom-pinned transcript, different positions across multiple agents, transient zero suppression, and intentional scrolling to the top.

## Remaining edge cases

The focus restore clamps a saved middle position if transcript content shrinks while Maestro is unfocused. This matches the existing initial restoration behavior and avoids restoring beyond the new scrollable range.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved terminal output scroll positions when switching away from and returning to the app.
  * Prevented unexpected jumps to the bottom during focus changes.
  * Kept scroll positions isolated across terminal sessions and tabs.
  * Preserved intentional scrolling after restoring a previous position.
  * Improved reliability when scrolling to the bottom before leaving or refocusing.
  * Prevented temporary layout changes from overwriting saved positions.
  * Maintained bottom-pinned output as new terminal content appears.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->