### PR TITLE
feat(agent-flow): lazy lane seeding, current-agent filter, and reachable keybindings

### DIFF
--- a/examples/plugins/agent-flow/main.js
+++ b/examples/plugins/agent-flow/main.js
@@ -6,8 +6,8 @@
 // JS intrinsics (JSON, Date, Map, Math, setTimeout) are available.
 //
 // Behavior: subscribe to the metadata-only host event stream, maintain a
-// per-session execution-graph model (one lane per session, tool-call nodes per
-// lane), and push coalesced snapshots to the `flow` panel via
+// per-session execution-graph model (one lane per ACTIVE session, tool-call
+// nodes per lane), and push coalesced snapshots to the `flow` panel via
 // `maestro.ui.panelPost`. Everything observed here is metadata only - tool
 // names, timing, and lifecycle phase - never arguments, results, or output.
 //
@@ -51,12 +51,19 @@ var SNAPSHOT_MAX_BYTES = 60000;
 // where `open` maps an in-flight toolCallId to the node it opened, and each
 // node is { toolCallId, toolName, phase, startedAt, endedAt, durationMs }.
 var lanes = new Map();
+// sessionId -> { title, agentId, status }. Metadata for sessions that have NOT
+// (yet) earned a lane: the startup seed and the metadata-only session events
+// write here instead of materializing a lane, so a user with a hundred idle
+// agents does not open the overlay onto a wall of empty dots. A lane born later
+// from real activity picks its title/agentId/status up from this map, so it is
+// labelled the moment it appears.
+var sessionMeta = new Map();
 var lastEventAt = 0;
 var snapshotTimer = 0;
 // Session id of the agent the user is currently looking at, from the
 // metadata-only `session.activated` event. Sent along in every snapshot so the
-// overlay can highlight that node; the "focus current agent only" filter itself
-// is Phase 2.
+// overlay can highlight that node, and consumed by the panel's "current agent
+// only" filter.
 var focusedSessionId = '';
 /** @type {MaestroSdk | null} */
 var sdk = null;
@@ -64,11 +71,12 @@ var sdk = null;
 function getLane(sessionId) {
 	var lane = lanes.get(sessionId);
 	if (!lane) {
+		var meta = sessionMeta.get(sessionId);
 		lane = {
 			sessionId: sessionId,
-			title: '',
-			agentId: '',
-			status: '',
+			title: meta && typeof meta.title === 'string' ? meta.title : '',
+			agentId: meta && typeof meta.agentId === 'string' ? meta.agentId : '',
+			status: meta && typeof meta.status === 'string' ? meta.status : '',
 			usage: null,
 			nodes: [],
 			lastActivity: 0,
@@ -91,6 +99,30 @@ function getLane(sessionId) {
 
 function touch(lane, at) {
 	if (typeof at === 'number' && at > lane.lastActivity) lane.lastActivity = at;
+}
+
+// Record what we know about a session without materializing a lane for it.
+// `fields` is a partial { title, agentId, status }; only string members are
+// taken, so a payload missing a field never clobbers a known one. Returns the
+// stored record.
+function recordMeta(sessionId, fields) {
+	var meta = sessionMeta.get(sessionId);
+	if (!meta) {
+		meta = { title: '', agentId: '', status: '' };
+		sessionMeta.set(sessionId, meta);
+	}
+	if (fields) {
+		if (typeof fields.title === 'string') meta.title = fields.title;
+		if (typeof fields.agentId === 'string') meta.agentId = fields.agentId;
+		if (typeof fields.status === 'string') meta.status = fields.status;
+	}
+	return meta;
+}
+
+// Does this session already have a lane? Metadata-only events update an existing
+// lane but must never create one.
+function existingLane(sessionId) {
+	return lanes.get(sessionId);
 }
 
 // Trim a lane to the most recent LANE_NODE_CAP nodes, forgetting any open
@@ -196,6 +228,10 @@ function applyTool(payload, at) {
 	touch(lane, at);
 }
 
+// Clear the graph. `sessionMeta` deliberately survives: it is not graph state
+// but the labels for sessions that still exist, and the `clear` command means
+// "forget the activity", not "forget who the agents are". A lane recreated by
+// the next event still comes up named. `deactivate` clears it separately.
 function resetModel() {
 	lanes.clear();
 }
@@ -335,16 +371,24 @@ var HANDLERS = {
 		lane.lastActivityAt = Date.now();
 		touch(lane, at);
 	},
+	// Metadata only: existence of a session is not activity, so this records the
+	// title/agentId and updates the lane ONLY if activity already created one.
 	'session.created': function (payload, at) {
 		if (!payload || typeof payload.sessionId !== 'string') return;
-		var lane = getLane(payload.sessionId);
+		recordMeta(payload.sessionId, payload);
+		var lane = existingLane(payload.sessionId);
+		if (!lane) return;
 		if (typeof payload.title === 'string') lane.title = payload.title;
 		if (typeof payload.agentId === 'string') lane.agentId = payload.agentId;
 		touch(lane, at);
 	},
+	// Metadata only, same rule as session.created: a rename or a status change on
+	// a session that has never done anything does not earn it a lane.
 	'session.updated': function (payload, at) {
 		if (!payload || typeof payload.sessionId !== 'string') return;
-		var lane = getLane(payload.sessionId);
+		recordMeta(payload.sessionId, payload);
+		var lane = existingLane(payload.sessionId);
+		if (!lane) return;
 		if (typeof payload.title === 'string') lane.title = payload.title;
 		if (typeof payload.status === 'string') lane.status = payload.status;
 		lane.lastActivityAt = Date.now();
@@ -353,18 +397,20 @@ var HANDLERS = {
 	'session.removed': function (payload) {
 		if (!payload || typeof payload.sessionId !== 'string') return;
 		lanes.delete(payload.sessionId);
+		sessionMeta.delete(payload.sessionId);
 		// The highlighted node is gone; drop the highlight rather than pointing at
 		// a lane that no longer exists.
 		if (focusedSessionId === payload.sessionId) focusedSessionId = '';
 	},
 	// Ids only - no title, no path, nothing derived from session content. The host
-	// already debounces rapid focus changes, so this is just a field assignment;
-	// the lane may not exist yet (the user can focus an agent that has produced no
-	// events), which is fine: the panel simply has nothing to highlight until it
-	// does.
-	'session.activated': function (payload) {
+	// already debounces rapid focus changes. This is the one non-activity event
+	// that DOES materialize a lane: the agent the user is looking at always needs
+	// a node for the panel's focus highlight (and the "current agent only" filter)
+	// to land on, even before it has produced any events.
+	'session.activated': function (payload, at) {
 		if (!payload || typeof payload.sessionId !== 'string') return;
 		focusedSessionId = payload.sessionId;
+		touch(getLane(payload.sessionId), at);
 	},
 };
 
@@ -528,8 +574,12 @@ function scheduleSnapshot() {
 
 // ---- startup ---------------------------------------------------------------
 
-// Seed lane titles / agent ids from currently-open sessions. Tolerates denial
-// if the sessions:read grant is missing.
+// Seed session titles / agent ids from currently-open sessions. This fills the
+// `sessionMeta` side map ONLY: it deliberately creates no lanes, so the overlay
+// opens showing the agents that are actually doing something rather than one
+// idle dot per configured agent. A lane created later by activity reads its
+// labels back out of this map. Tolerates denial if the sessions:read grant is
+// missing.
 function seedFromSessions() {
 	if (!sdk) return;
 	try {
@@ -541,10 +591,19 @@ function seedFromSessions() {
 				for (var i = 0; i < list.length; i++) {
 					var s = list[i];
 					if (!s || typeof s.id !== 'string') continue;
-					var lane = getLane(s.id);
-					if (typeof s.title === 'string') lane.title = s.title;
-					if (typeof s.agentId === 'string') lane.agentId = s.agentId;
-					if (typeof s.status === 'string') lane.status = s.status;
+					var meta = recordMeta(s.id, {
+						title: s.title,
+						agentId: s.agentId,
+						status: s.status,
+					});
+					// sessions.list() resolves asynchronously, so an event may already
+					// have created a lane for this session; label it now that we know.
+					var lane = existingLane(s.id);
+					if (lane) {
+						if (!lane.title) lane.title = meta.title;
+						if (!lane.agentId) lane.agentId = meta.agentId;
+						if (!lane.status) lane.status = meta.status;
+					}
 				}
 				scheduleSnapshot();
 			},
@@ -633,6 +692,7 @@ function deactivate() {
 		snapshotTimer = 0;
 	}
 	resetModel();
+	sessionMeta.clear();
 	focusedSessionId = '';
 	sdk = null;
 }

--- a/examples/plugins/agent-flow/main.js
+++ b/examples/plugins/agent-flow/main.js
@@ -105,16 +105,27 @@ function touch(lane, at) {
 // `fields` is a partial { title, agentId, status }; only string members are
 // taken, so a payload missing a field never clobbers a known one. Returns the
 // stored record.
-function recordMeta(sessionId, fields) {
+function recordMeta(sessionId, fields, onlyIfUnset) {
 	var meta = sessionMeta.get(sessionId);
 	if (!meta) {
 		meta = { title: '', agentId: '', status: '' };
 		sessionMeta.set(sessionId, meta);
 	}
 	if (fields) {
-		if (typeof fields.title === 'string') meta.title = fields.title;
-		if (typeof fields.agentId === 'string') meta.agentId = fields.agentId;
-		if (typeof fields.status === 'string') meta.status = fields.status;
+		// `onlyIfUnset` is the startup seed: `sessions.list()` resolves
+		// asynchronously, and event handlers are registered before it does, so a
+		// `session.created` / `session.updated` that lands in between carries
+		// NEWER data than the list snapshot. Filling only blank fields keeps the
+		// seed from overwriting it. Live events pass this falsy and always win.
+		// (review)
+		var take = function (key, value) {
+			if (typeof value !== 'string') return;
+			if (onlyIfUnset && meta[key]) return;
+			meta[key] = value;
+		};
+		take('title', fields.title);
+		take('agentId', fields.agentId);
+		take('status', fields.status);
 	}
 	return meta;
 }
@@ -380,6 +391,10 @@ var HANDLERS = {
 		if (!lane) return;
 		if (typeof payload.title === 'string') lane.title = payload.title;
 		if (typeof payload.agentId === 'string') lane.agentId = payload.agentId;
+		// `recordMeta` above already stored the status; copy it onto the live lane
+		// too, otherwise the lane shows a stale status until the next
+		// `session.updated` happens to arrive. (review)
+		if (typeof payload.status === 'string') lane.status = payload.status;
 		touch(lane, at);
 	},
 	// Metadata only, same rule as session.created: a rename or a status change on
@@ -591,11 +606,18 @@ function seedFromSessions() {
 				for (var i = 0; i < list.length; i++) {
 					var s = list[i];
 					if (!s || typeof s.id !== 'string') continue;
-					var meta = recordMeta(s.id, {
-						title: s.title,
-						agentId: s.agentId,
-						status: s.status,
-					});
+					// `true` = seed mode: only fill fields no event has set yet. A
+					// `session.created`/`updated` that arrived while this list was in
+					// flight carries newer data and must not be clobbered. (review)
+					var meta = recordMeta(
+						s.id,
+						{
+							title: s.title,
+							agentId: s.agentId,
+							status: s.status,
+						},
+						true
+					);
 					// sessions.list() resolves asynchronously, so an event may already
 					// have created a lane for this session; label it now that we know.
 					var lane = existingLane(s.id);

--- a/examples/plugins/agent-flow/panel.html
+++ b/examples/plugins/agent-flow/panel.html
@@ -93,6 +93,15 @@
 				font-size: 11px;
 				white-space: nowrap;
 			}
+			#filterHint {
+				color: var(--amber);
+				font-size: 11px;
+				white-space: nowrap;
+				flex: 0 0 auto;
+			}
+			#filterHint.hidden {
+				display: none;
+			}
 			.btn {
 				border: 1px solid var(--border);
 				background: var(--panel2);
@@ -110,6 +119,13 @@
 			#clear:hover {
 				border-color: var(--red);
 				color: var(--red);
+			}
+			/* The filter toggle stays visibly ON so its default-OFF state is never
+			   mistaken for "this fleet only has one agent". */
+			.btn.on {
+				border-color: var(--accent);
+				color: var(--accent);
+				background: rgba(88, 166, 255, 0.15);
 			}
 			#graphWrap {
 				position: relative;
@@ -240,6 +256,16 @@
 				<div id="title">Agent Flow</div>
 				<div id="summary"></div>
 				<div id="hint">Click an agent to jump · wheel to zoom · double-click to reset</div>
+				<div id="filterHint" class="hidden"></div>
+				<button
+					id="focusOnly"
+					class="btn"
+					type="button"
+					aria-pressed="false"
+					title="Show only the agent you are currently looking at"
+				>
+					Current agent only
+				</button>
 				<button id="reset" class="btn" title="Reset the view">Reset view</button>
 				<button id="clear" class="btn" title="Clear the graph">Clear</button>
 			</header>
@@ -270,6 +296,10 @@
 
 			// ---- state -----------------------------------------------------------
 			var latest = null; // most recent snapshot { v, at, lanes, summary, focusedSessionId }
+			// "Current agent only" filter. Default OFF: the fleet view is the headline
+			// feature, and lazy lane seeding already keeps idle agents off the canvas.
+			// Panel-lifetime state only - a plain var, no storage API in the guest.
+			var focusOnly = false;
 			var view = { tx: 0, ty: 0, scale: 1 }; // pan/zoom, preserved across renders
 			var userMoved = false; // once the user pans/zooms, stop auto-fitting
 			var contentBox = null; // { w, h } of the laid-out graph, for fitView
@@ -284,6 +314,8 @@
 			var emptyEl = document.getElementById('empty');
 			var summaryEl = document.getElementById('summary');
 			var graphWrap = document.getElementById('graphWrap');
+			var filterHintEl = document.getElementById('filterHint');
+			var focusOnlyBtn = document.getElementById('focusOnly');
 
 			// ---- helpers ---------------------------------------------------------
 			function el(tag, attrs, text) {
@@ -512,8 +544,23 @@
 				}
 			}
 
+			// Resolve which lanes to draw. With the filter ON we keep only the lane
+			// whose sessionId matches the snapshot's focusedSessionId; when there is no
+			// focused agent (or it has no lane yet) we fall back to the whole fleet and
+			// say so in the header, because a blank canvas reads as a broken panel.
+			function resolveLanes() {
+				var all = latest && Array.isArray(latest.lanes) ? latest.lanes : [];
+				if (!focusOnly || !all.length) return { lanes: all, fellBack: false };
+				var focusedId = latest && latest.focusedSessionId ? latest.focusedSessionId : '';
+				var only = [];
+				for (var i = 0; i < all.length; i++) {
+					if (all[i].sessionId === focusedId) only.push(all[i]);
+				}
+				return only.length ? { lanes: only, fellBack: false } : { lanes: all, fellBack: true };
+			}
+
 			function lanesOf() {
-				return latest && Array.isArray(latest.lanes) ? latest.lanes : [];
+				return resolveLanes().lanes;
 			}
 
 			// ---- jump ------------------------------------------------------------
@@ -780,11 +827,18 @@
 				return g;
 			}
 
+			function renderFilterHint(fellBack) {
+				filterHintEl.textContent = fellBack ? 'No current agent yet · showing all' : '';
+				filterHintEl.classList.toggle('hidden', !fellBack);
+			}
+
 			// ---- graph -----------------------------------------------------------
 			function renderGraph() {
 				clear(viewport);
 				healthGroups = Object.create(null);
-				var lanes = lanesOf();
+				var resolved = resolveLanes();
+				var lanes = resolved.lanes;
+				renderFilterHint(resolved.fellBack);
 				emptyEl.classList.toggle('hidden', lanes.length > 0);
 				if (!lanes.length) {
 					contentBox = null;
@@ -910,6 +964,14 @@
 				invoke('clear');
 			});
 			document.getElementById('reset').addEventListener('click', resetView);
+			focusOnlyBtn.addEventListener('click', function () {
+				focusOnly = !focusOnly;
+				focusOnlyBtn.classList.toggle('on', focusOnly);
+				focusOnlyBtn.setAttribute('aria-pressed', focusOnly ? 'true' : 'false');
+				// The lane count changes, so let the next paint refit unless the user has
+				// already framed the view themselves.
+				render();
+			});
 
 			// Escape inside the guest cannot reach the host's modal layer stack (this is
 			// a separate renderer process), so dismiss the overlay through the plugin's

--- a/examples/plugins/agent-flow/plugin.json
+++ b/examples/plugins/agent-flow/plugin.json
@@ -1,7 +1,7 @@
 {
 	"id": "agent-flow",
 	"name": "Agent Flow",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"tier": 2,
 	"maestro": { "minHostApi": "1.16.0" },
 	"description": "Live per-session execution-graph visualization built from host tool + agent lifecycle events.",

--- a/src/__tests__/plugins/agent-flow-main.test.ts
+++ b/src/__tests__/plugins/agent-flow-main.test.ts
@@ -226,6 +226,39 @@ describe('agent-flow plugin main.js', () => {
 			expect(shown[0].title).toBe('Renamed');
 		});
 
+		// CodeRabbit/Greptile on PR #1354: event handlers are registered before
+		// sessions.list() resolves, so an event landing in that window carries
+		// NEWER metadata than the list snapshot. The seed used to overwrite it.
+		it('does not let the startup seed clobber metadata an event already set', async () => {
+			plugin.deactivate();
+			stub = makeStub(SEED);
+			plugin.activate(stub.sdk);
+			// Fires BEFORE the sessions.list() promise settles.
+			stub.emit('session.updated', { sessionId: 's1', title: 'Renamed mid-flight' });
+			await Promise.resolve();
+			await Promise.resolve();
+
+			stub.emit('tool.executed', { sessionId: 's1', toolName: 'Read', timestamp: 1000 });
+			const shown = lanes();
+			expect(shown).toHaveLength(1);
+			// The stale list entry says "One"; the event said "Renamed mid-flight".
+			expect(shown[0].title).toBe('Renamed mid-flight');
+			// A field the event did NOT carry still comes from the seed.
+			expect(shown[0].agentId).toBe('a1');
+		});
+
+		// CodeRabbit on PR #1354: session.created recorded the status into the meta
+		// map but never copied it onto an already-live lane, so the lane displayed a
+		// stale status until some later session.updated happened to arrive.
+		it('copies status onto an existing lane on session.created', async () => {
+			await activateWithSessions(SEED);
+			stub.emit('tool.executed', { sessionId: 's1', toolName: 'Read', timestamp: 1000 });
+			expect(lanes()[0].status).toBe('idle');
+
+			stub.emit('session.created', { sessionId: 's1', title: 'One', status: 'busy' });
+			expect(lanes()[0].status).toBe('busy');
+		});
+
 		it('gives the focused session a lane so the highlight has a target', async () => {
 			await activateWithSessions(SEED);
 			stub.emit('session.activated', { sessionId: 's3' });

--- a/src/__tests__/plugins/agent-flow-main.test.ts
+++ b/src/__tests__/plugins/agent-flow-main.test.ts
@@ -23,6 +23,13 @@ const MAIN_JS = path.resolve(
 type EventHandler = (payload: unknown, meta?: unknown) => void;
 type CommandHandler = (args?: unknown) => void;
 
+interface SeedSession {
+	id: string;
+	title?: string;
+	agentId?: string;
+	status?: string;
+}
+
 interface Stub {
 	sdk: Record<string, unknown>;
 	emit: (topic: string, payload: unknown) => void;
@@ -35,7 +42,7 @@ interface Stub {
 	snapshot: () => Record<string, unknown> | undefined;
 }
 
-function makeStub(): Stub {
+function makeStub(seed: SeedSession[] = []): Stub {
 	const events = new Map<string, EventHandler[]>();
 	const commands = new Map<string, CommandHandler>();
 	const panelPost = vi.fn(() => Promise.resolve(undefined));
@@ -57,7 +64,7 @@ function makeStub(): Stub {
 				register: (id: string, handler: CommandHandler) => commands.set(id, handler),
 			},
 			ui: { panelPost, togglePanel, closePanel },
-			sessions: { list: () => Promise.resolve([]), focus },
+			sessions: { list: () => Promise.resolve(seed), focus },
 		},
 		emit: (topic, payload) => (events.get(topic) ?? []).forEach((h) => h(payload, undefined)),
 		run: (commandId, args) => commands.get(commandId)?.(args),
@@ -166,5 +173,68 @@ describe('agent-flow plugin main.js', () => {
 		stub.emit('session.activated', null);
 		stub.run('sync');
 		expect(stub.snapshot()?.focusedSessionId).toBe('s1');
+	});
+
+	describe('lazy lane seeding', () => {
+		const SEED: SeedSession[] = [
+			{ id: 's1', title: 'One', agentId: 'a1', status: 'idle' },
+			{ id: 's2', title: 'Two', agentId: 'a2', status: 'idle' },
+			{ id: 's3', title: 'Three', agentId: 'a3', status: 'idle' },
+		];
+
+		/** Re-activate against a stubbed session list and let the seed promise settle. */
+		async function activateWithSessions(seed: SeedSession[]): Promise<void> {
+			plugin.deactivate();
+			stub = makeStub(seed);
+			plugin.activate(stub.sdk);
+			// sessions.list() resolves on a microtask; let the seed handler run.
+			await Promise.resolve();
+			await Promise.resolve();
+		}
+
+		function lanes(): Array<Record<string, unknown>> {
+			stub.run('sync');
+			return (stub.snapshot()?.lanes as Array<Record<string, unknown>>) ?? [];
+		}
+
+		it('creates no lanes for the sessions listed at activate', async () => {
+			await activateWithSessions(SEED);
+			expect(lanes()).toHaveLength(0);
+		});
+
+		it('materializes a lane carrying the seeded title on the first tool activity', async () => {
+			await activateWithSessions(SEED);
+			stub.emit('tool.executed', { sessionId: 's2', toolName: 'Read', timestamp: 1000 });
+
+			const shown = lanes();
+			expect(shown).toHaveLength(1);
+			expect(shown[0].sessionId).toBe('s2');
+			expect(shown[0].title).toBe('Two');
+			expect(shown[0].agentId).toBe('a2');
+		});
+
+		it('does not create a lane for a metadata-only update to a never-active session', async () => {
+			await activateWithSessions(SEED);
+			stub.emit('session.updated', { sessionId: 's1', title: 'Renamed', status: 'busy' });
+			stub.emit('session.created', { sessionId: 's9', title: 'Brand new', agentId: 'a9' });
+			expect(lanes()).toHaveLength(0);
+
+			// The metadata was still recorded: activity later shows the new title.
+			stub.emit('tool.executed', { sessionId: 's1', toolName: 'Bash', timestamp: 1000 });
+			const shown = lanes();
+			expect(shown).toHaveLength(1);
+			expect(shown[0].title).toBe('Renamed');
+		});
+
+		it('gives the focused session a lane so the highlight has a target', async () => {
+			await activateWithSessions(SEED);
+			stub.emit('session.activated', { sessionId: 's3' });
+
+			const shown = lanes();
+			expect(shown).toHaveLength(1);
+			expect(shown[0].sessionId).toBe('s3');
+			expect(shown[0].title).toBe('Three');
+			expect(stub.snapshot()?.focusedSessionId).toBe('s3');
+		});
 	});
 });

--- a/src/__tests__/plugins/agent-flow-panel.test.ts
+++ b/src/__tests__/plugins/agent-flow-panel.test.ts
@@ -273,3 +273,80 @@ describe('agent-flow panel', () => {
 		expect(posted.map((m) => m.commandId)).toContain('clear');
 	});
 });
+
+describe('agent-flow panel "current agent only" filter', () => {
+	function toggleFilter(): void {
+		document.getElementById('focusOnly')?.dispatchEvent(new MouseEvent('click'));
+	}
+
+	function filterHint(): HTMLElement | null {
+		return document.getElementById('filterHint');
+	}
+
+	function pushThree(focusedSessionId: string): void {
+		pushSnapshot({
+			v: 1,
+			at: 0,
+			lanes: [
+				lane(),
+				lane({ sessionId: 's2', title: 'Beta' }),
+				lane({ sessionId: 's3', title: 'Gamma' }),
+			],
+			focusedSessionId,
+		});
+	}
+
+	it('is off by default so the fleet view renders untouched', () => {
+		pushThree('s2');
+
+		expect(agentNodes()).toHaveLength(3);
+		expect(document.getElementById('focusOnly')?.getAttribute('aria-pressed')).toBe('false');
+		expect(filterHint()?.classList.contains('hidden')).toBe(true);
+		// The all-agents view keeps its focused-agent highlight.
+		expect(agentNodes()[1].getAttribute('class')).toBe('agent focused');
+	});
+
+	it('renders only the focused agent when toggled on, and restores the fleet when off', () => {
+		pushThree('s2');
+
+		toggleFilter();
+
+		const filtered = agentNodes();
+		expect(filtered).toHaveLength(1);
+		expect(filtered[0].getAttribute('data-session')).toBe('s2');
+		expect(document.getElementById('focusOnly')?.getAttribute('aria-pressed')).toBe('true');
+		expect(filterHint()?.classList.contains('hidden')).toBe(true);
+
+		toggleFilter();
+
+		expect(agentNodes().map((n) => n.getAttribute('data-session'))).toEqual(['s1', 's2', 's3']);
+	});
+
+	it('keeps the filter across snapshots and follows the focus as it moves', () => {
+		pushThree('s2');
+		toggleFilter();
+
+		pushThree('s3');
+
+		expect(agentNodes().map((n) => n.getAttribute('data-session'))).toEqual(['s3']);
+	});
+
+	it('falls back to showing every agent with a hint when nothing is focused', () => {
+		pushThree('');
+
+		toggleFilter();
+
+		expect(agentNodes()).toHaveLength(3);
+		expect(filterHint()?.classList.contains('hidden')).toBe(false);
+		expect(filterHint()?.textContent).toContain('showing all');
+	});
+
+	it('falls back with the hint when the focused agent has no lane yet', () => {
+		pushThree('s9');
+
+		toggleFilter();
+
+		expect(agentNodes()).toHaveLength(3);
+		expect(filterHint()?.classList.contains('hidden')).toBe(false);
+	});
+});

--- a/src/__tests__/renderer/hooks/usePluginKeybindings.test.ts
+++ b/src/__tests__/renderer/hooks/usePluginKeybindings.test.ts
@@ -123,15 +123,32 @@ describe('usePluginKeybindings - overlay summon chord', () => {
 		expect(pluginBridge.invokeCommand).not.toHaveBeenCalled();
 	});
 
-	it('never hijacks typing in an input', async () => {
-		await mountWithChords();
+	it('never hijacks typing in an input (bare chord)', async () => {
+		// A plugin that bound a bare letter must stay inert while the user types.
+		await mountWithChords([{ ...OVERLAY_CHORD, key: 'F' }]);
 
-		const input = document.createElement('input');
-		document.body.appendChild(input);
-		press({ key: 'F', altKey: true, shiftKey: true, target: input });
-		input.remove();
+		const textarea = document.createElement('textarea');
+		document.body.appendChild(textarea);
+		press({ key: 'F', target: textarea });
+		press({ key: 'F', shiftKey: true, target: textarea }); // Shift+letter is typing too
+		textarea.remove();
 
 		expect(pluginBridge.invokeCommand).not.toHaveBeenCalled();
+	});
+
+	it('still fires a modifier-bearing chord while a textarea has focus', async () => {
+		// The composer textarea is Maestro's resting focus state, so Alt+Shift+F
+		// must work there or the chord is inert in the default state (finding AA1).
+		await mountWithChords();
+
+		const textarea = document.createElement('textarea');
+		document.body.appendChild(textarea);
+		const event = press({ key: 'F', altKey: true, shiftKey: true, target: textarea });
+		textarea.remove();
+
+		expect(pluginBridge.invokeCommand).toHaveBeenCalledTimes(1);
+		expect(pluginBridge.invokeCommand).toHaveBeenCalledWith('acme.flow/overlay');
+		expect(event.defaultPrevented).toBe(true);
 	});
 
 	it('stops matching once the chord is unmounted', async () => {

--- a/src/__tests__/renderer/hooks/usePluginKeybindings.test.ts
+++ b/src/__tests__/renderer/hooks/usePluginKeybindings.test.ts
@@ -172,6 +172,49 @@ describe('usePluginKeybindings - overlay summon chord', () => {
 		expect(event.defaultPrevented).toBe(false);
 	});
 
+	// CodeRabbit on PR #1354: AltGr is text entry, not a chord. On the layouts
+	// that have it the browser sets ctrlKey AND altKey, so `AltGr+Q` - the `@` on
+	// a German keyboard - is indistinguishable from a `Ctrl+Alt+Q` plugin chord
+	// unless getModifierState('AltGraph') is consulted. Swallowing it would make
+	// the composer unable to type `@` or `€`.
+	it.each([
+		['@ (AltGr+Q on a German layout)', { key: '@', code: 'KeyQ' }],
+		['€ (AltGr+E on a German layout)', { key: '€', code: 'KeyE' }],
+	])('lets AltGr text entry %s through to a textarea', async (_label, init) => {
+		await mountWithChords([{ ...OVERLAY_CHORD, key: `Ctrl+Alt+${init.code.replace('Key', '')}` }]);
+
+		const textarea = document.createElement('textarea');
+		document.body.appendChild(textarea);
+		const event = press({
+			...init,
+			// Exactly what a browser reports for AltGr on Windows/Linux.
+			ctrlKey: true,
+			altKey: true,
+			modifierAltGraph: true,
+			target: textarea,
+		});
+		textarea.remove();
+
+		// Guard the premise: if jsdom ever stops honouring modifierAltGraph this
+		// test would pass for the wrong reason.
+		expect(event.getModifierState('AltGraph')).toBe(true);
+		expect(pluginBridge.invokeCommand).not.toHaveBeenCalled();
+		expect(event.defaultPrevented).toBe(false);
+	});
+
+	it('still fires an AltGr-looking chord when NO text surface has focus', async () => {
+		// The AltGr skip is scoped to editable targets for the same reason the
+		// reserved-chord skip is: outside a text surface there is no character to
+		// swallow, so the chord stays usable.
+		await mountWithChords([{ ...OVERLAY_CHORD, key: 'Ctrl+Alt+Q' }]);
+
+		press({ key: '@', code: 'KeyQ', ctrlKey: true, altKey: true, modifierAltGraph: true });
+
+		expect(pluginBridge.invokeCommand).toHaveBeenCalledWith(
+			`${OVERLAY_CHORD.pluginId}/${OVERLAY_CHORD.command}`
+		);
+	});
+
 	it('still fires a reserved-looking chord when NO text surface has focus', async () => {
 		// The guard is scoped to editable targets. Outside one, Ctrl+Z is fair game.
 		await mountWithChords([{ ...OVERLAY_CHORD, key: 'Ctrl+z' }]);

--- a/src/__tests__/renderer/hooks/usePluginKeybindings.test.ts
+++ b/src/__tests__/renderer/hooks/usePluginKeybindings.test.ts
@@ -123,17 +123,64 @@ describe('usePluginKeybindings - overlay summon chord', () => {
 		expect(pluginBridge.invokeCommand).not.toHaveBeenCalled();
 	});
 
-	it('never hijacks typing in an input (bare chord)', async () => {
+	it('never hijacks typing in a textarea (bare chord)', async () => {
 		// A plugin that bound a bare letter must stay inert while the user types.
 		await mountWithChords([{ ...OVERLAY_CHORD, key: 'F' }]);
 
 		const textarea = document.createElement('textarea');
 		document.body.appendChild(textarea);
-		press({ key: 'F', target: textarea });
-		press({ key: 'F', shiftKey: true, target: textarea }); // Shift+letter is typing too
+		const bare = press({ key: 'F', target: textarea });
+		const shifted = press({ key: 'F', shiftKey: true, target: textarea }); // Shift+letter is typing too
 		textarea.remove();
 
 		expect(pluginBridge.invokeCommand).not.toHaveBeenCalled();
+		// Not calling the command is only half of it: a preventDefault() would
+		// swallow the keystroke and the character would never reach the textarea.
+		expect(bare.defaultPrevented).toBe(false);
+		expect(shifted.defaultPrevented).toBe(false);
+	});
+
+	// Greptile P1 on PR #1354: narrowing the input-focus skip to bare keys made
+	// contributed chords usable from the composer, but it also handed plugins
+	// every Ctrl/Cmd and Alt combination the app does not bind. Since a match
+	// calls preventDefault(), a plugin binding Ctrl+Z would silently break undo
+	// while the user is editing.
+	it.each([
+		['ctrl+z (undo)', { key: 'z', ctrlKey: true }],
+		['meta+z (undo, mac)', { key: 'z', metaKey: true }],
+		['ctrl+shift+z (redo)', { key: 'z', ctrlKey: true, shiftKey: true }],
+		['ctrl+a (select all)', { key: 'a', ctrlKey: true }],
+		['ctrl+v (paste)', { key: 'v', ctrlKey: true }],
+		['ctrl+arrowleft (word motion)', { key: 'ArrowLeft', ctrlKey: true }],
+		['alt+backspace (delete word)', { key: 'Backspace', altKey: true }],
+	])('leaves the reserved native editing chord %s alone in a textarea', async (_label, init) => {
+		// Bind the plugin to exactly that chord, so only the reserved-chord guard
+		// can stop it from firing.
+		await mountWithChords([
+			{
+				...OVERLAY_CHORD,
+				key: `${init.ctrlKey || init.metaKey ? 'Ctrl+' : ''}${init.altKey ? 'Alt+' : ''}${init.shiftKey ? 'Shift+' : ''}${init.key}`,
+			},
+		]);
+
+		const textarea = document.createElement('textarea');
+		document.body.appendChild(textarea);
+		const event = press({ ...init, target: textarea });
+		textarea.remove();
+
+		expect(pluginBridge.invokeCommand).not.toHaveBeenCalled();
+		expect(event.defaultPrevented).toBe(false);
+	});
+
+	it('still fires a reserved-looking chord when NO text surface has focus', async () => {
+		// The guard is scoped to editable targets. Outside one, Ctrl+Z is fair game.
+		await mountWithChords([{ ...OVERLAY_CHORD, key: 'Ctrl+z' }]);
+
+		press({ key: 'z', ctrlKey: true });
+
+		expect(pluginBridge.invokeCommand).toHaveBeenCalledWith(
+			`${OVERLAY_CHORD.pluginId}/${OVERLAY_CHORD.command}`
+		);
 	});
 
 	it('still fires a modifier-bearing chord while a textarea has focus', async () => {

--- a/src/renderer/hooks/usePluginKeybindings.ts
+++ b/src/renderer/hooks/usePluginKeybindings.ts
@@ -110,6 +110,37 @@ function isEditableTarget(target: EventTarget | null): boolean {
  * keybindings. Call once, near the top of the App tree, after
  * useMainKeyboardHandler().
  */
+/**
+ * Native editing and navigation chords a plugin must never claim while the user
+ * is typing, even though they carry a hard modifier.
+ *
+ * Narrowing the input-focus skip to bare keys (AA1) made contributed chords
+ * usable from the composer, but it also handed plugins every Ctrl/Cmd and Alt
+ * combination the app itself does not bind - including undo, select-all, and
+ * word-wise motion. Since a match calls `preventDefault()`, a plugin binding
+ * `Ctrl+Z` would silently break undo mid-edit. The browser owns these; keep
+ * them off the table.
+ *
+ * Matched on `e.key`, lower-cased, so layout-independent. Shift is ignored:
+ * `Ctrl+Shift+Z` is redo and must be reserved for the same reason as `Ctrl+Z`.
+ */
+function isReservedEditingChord(e: KeyboardEvent): boolean {
+	const key = e.key.toLowerCase();
+	if (e.ctrlKey || e.metaKey) {
+		// Clipboard, undo/redo, select-all, and the common text-entry verbs.
+		if (['a', 'c', 'v', 'x', 'z', 'y', 'backspace', 'delete', 'insert'].includes(key)) return true;
+		// Word-wise and document-wise motion.
+		if (['arrowleft', 'arrowright', 'arrowup', 'arrowdown', 'home', 'end'].includes(key)) {
+			return true;
+		}
+	}
+	if (e.altKey) {
+		// Word-wise motion and delete on macOS, and the Linux/Windows equivalents.
+		if (['arrowleft', 'arrowright', 'backspace', 'delete'].includes(key)) return true;
+	}
+	return false;
+}
+
 export function usePluginKeybindings(): void {
 	const { keybindings } = usePluginContributions();
 
@@ -131,8 +162,10 @@ export function usePluginKeybindings(): void {
 			if (e.defaultPrevented) return;
 			// Never hijack typing: while a text surface has focus only chords that
 			// carry Alt or Ctrl/Cmd may fire. Shift alone is typing, not a chord.
+			// Reserved native editing chords are excluded even then - see
+			// isReservedEditingChord. (AA1 review)
 			const hasHardModifier = e.altKey || e.ctrlKey || e.metaKey;
-			if (!hasHardModifier && isEditableTarget(e.target)) return;
+			if (isEditableTarget(e.target) && (!hasHardModifier || isReservedEditingChord(e))) return;
 			for (const chord of chordsRef.current) {
 				if (!matches(e, chord)) continue;
 				e.preventDefault();

--- a/src/renderer/hooks/usePluginKeybindings.ts
+++ b/src/renderer/hooks/usePluginKeybindings.ts
@@ -165,7 +165,19 @@ export function usePluginKeybindings(): void {
 			// Reserved native editing chords are excluded even then - see
 			// isReservedEditingChord. (AA1 review)
 			const hasHardModifier = e.altKey || e.ctrlKey || e.metaKey;
-			if (isEditableTarget(e.target) && (!hasHardModifier || isReservedEditingChord(e))) return;
+			// AltGr is text entry, not a chord. On the Windows/Linux layouts that
+			// have it (German, Polish, Brazilian and friends) the browser reports
+			// AltGr as ctrlKey AND altKey, so `AltGr+Q` - which types `@` on a
+			// German keyboard - looks exactly like a `Ctrl+Alt+Q` plugin chord and
+			// would be swallowed by the preventDefault below. getModifierState is
+			// the only way to tell the two apart. (Review of PR #1354)
+			const isAltGraph = e.getModifierState?.('AltGraph') === true;
+			if (
+				isEditableTarget(e.target) &&
+				(isAltGraph || !hasHardModifier || isReservedEditingChord(e))
+			) {
+				return;
+			}
 			for (const chord of chordsRef.current) {
 				if (!matches(e, chord)) continue;
 				e.preventDefault();

--- a/src/renderer/hooks/usePluginKeybindings.ts
+++ b/src/renderer/hooks/usePluginKeybindings.ts
@@ -11,8 +11,12 @@
  *
  * Conflict policy - plugin keybindings must never clobber the app's own
  * shortcuts:
- *   - skip while an input/textarea/select/contentEditable element is focused, so
- *     typing is never hijacked;
+ *   - while an input/textarea/select/contentEditable element is focused, skip
+ *     bare (unmodified) chords so typing is never hijacked, but still let
+ *     chords carrying Alt or Ctrl/Cmd through - nobody types with those held,
+ *     and the composer textarea is Maestro's resting focus state, so an
+ *     unconditional skip would leave every contributed chord inert by default.
+ *     Shift alone does NOT count as a modifier here (Shift+letter is typing);
  *   - skip if the event was already handled (`defaultPrevented`), so an app
  *     shortcut that ran first wins. The app's central handler
  *     (useMainKeyboardHandler) binds a bubble-phase `window` keydown too, so
@@ -93,7 +97,7 @@ function matches(e: KeyboardEvent, chord: ParsedChord): boolean {
 	return false;
 }
 
-/** Is focus on a text-entry surface where the chord must not be intercepted? */
+/** Is focus on a text-entry surface where a bare chord must not be intercepted? */
 function isEditableTarget(target: EventTarget | null): boolean {
 	const el = target as HTMLElement | null;
 	if (!el || typeof el.tagName !== 'string') return false;
@@ -125,8 +129,10 @@ export function usePluginKeybindings(): void {
 		const onKeyDown = (e: KeyboardEvent): void => {
 			// An app shortcut that ran first already claimed this event.
 			if (e.defaultPrevented) return;
-			// Never hijack typing.
-			if (isEditableTarget(e.target)) return;
+			// Never hijack typing: while a text surface has focus only chords that
+			// carry Alt or Ctrl/Cmd may fire. Shift alone is typing, not a chord.
+			const hasHardModifier = e.altKey || e.ctrlKey || e.metaKey;
+			if (!hasHardModifier && isEditableTarget(e.target)) return;
 			for (const chord of chordsRef.current) {
 				if (!matches(e, chord)) continue;
 				e.preventDefault();


### PR DESCRIPTION
Closes findings Z1 and AA1.

## Z1 - the overlay opened to a wall of idle dots

`seedFromSessions()` called `getLane()` for every entry returned by `sessions.list()`, so a lane was materialized for every session whether or not it had ever run a tool. On a real install (109 agents here) #1325's full-canvas overlay opened as an unreadable field of near-identical idle nodes. The plugin's own comment already acknowledged the gap: *"the 'focus current agent only' filter itself is Phase 2"*.

Two changes, per the recorded decision:

- **Lazy seeding.** A lane is created when a session first produces a `tool.executed`, not at activate time. This alone turns "109 idle dots" into "the handful actually doing something".
- **Current-agent-only filter**, defaulting OFF with the toggle prominent. `focusedSessionId` was already tracked and shipped in every snapshot, so the data was there - only the filter was missing. Lazy seeding removes the overload, so defaulting to filtered would needlessly hide the global view #1325 built.

## AA1 - the only entry point did not work

`Alt+Shift+F` did nothing. `usePluginKeybindings` skips plugin chords whenever an input/textarea has focus, and Maestro's composer holds focus as its resting state - so pressing the chord the natural way, right after typing, silently did nothing.

Confirmed by the user at the physical display: clicking the transcript area first (moving focus off the composer) made the overlay open. NoMachine was ruled out - the chord reaches the renderer fine.

The skip is now narrowed to **bare chords**. A chord carrying Alt or Ctrl/Cmd cannot be confused with typing, so it passes through while the "never hijack typing" intent is preserved for unmodified keys. The `defaultPrevented` rule and app-wins ordering are untouched.

## Testing

Scoped tests only: 38 pass across the plugin suites and `usePluginKeybindings`. Coverage includes lazy seeding creating no lane for an inactive session, the filter toggle, and a modifier-bearing chord still matching while a textarea has focus while a bare-key chord still does not.

## Note on the bundled signature

This edits `examples/plugins/agent-flow/`, which invalidates the bundled plugin signature until re-signed. That interacts with PR #1298; re-sign after both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Current agent only” filter for focusing the graph on the active agent.
  * Sessions retain title, status, and agent identity metadata.
  * Activating a session highlights it immediately, even before activity occurs.
* **Bug Fixes**
  * Prevented empty activity lanes during session creation and metadata updates.
  * Preserved metadata when clearing the graph and removed it on deactivation.
  * Improved keyboard shortcuts while typing, reserving native editing commands.
* **Documentation**
  * Updated keyboard shortcut guidance.
* **Chores**
  * Updated the agent-flow plugin to version 0.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->