### PR TITLE
fix(context): rank a provider-resolved window above a materialized default

### DIFF
--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -1059,6 +1059,9 @@ Some text with [x] in it that's not a checkbox
 				cacheCreationInputTokens: 10,
 				totalCostUsd: 0.05,
 				contextWindow: 200000,
+				// Reported by the model, so flagged authoritative even though it
+				// matches the fallback size (review of PR #1356).
+				contextWindowResolved: true,
 			});
 		});
 

--- a/src/__tests__/main/parsers/claude-output-parser.test.ts
+++ b/src/__tests__/main/parsers/claude-output-parser.test.ts
@@ -218,6 +218,30 @@ describe('ClaudeOutputParser', () => {
 			expect(usage?.cacheCreationTokens).toBe(10);
 			expect(usage?.contextWindow).toBe(200000);
 			expect(usage?.costUsd).toBe(0.01);
+			// 200000 here is the aggregator's untouched fallback seed (the model's
+			// own 200000 is not LARGER than it), so it carries no provider authority.
+			expect(usage?.contextWindowReported).toBeUndefined();
+		});
+
+		it('flags a genuinely reported context window as provider-reported', () => {
+			const event = parser.parseJsonLine(
+				JSON.stringify({
+					type: 'result',
+					result: 'test',
+					modelUsage: {
+						'claude-opus-5': {
+							inputTokens: 100,
+							outputTokens: 50,
+							contextWindow: 1000000,
+						},
+					},
+					total_cost_usd: 0.01,
+				})
+			);
+
+			const usage = parser.extractUsage(event!);
+			expect(usage?.contextWindow).toBe(1000000);
+			expect(usage?.contextWindowReported).toBe(true);
 		});
 
 		it('should extract usage with fallback to top-level usage', () => {

--- a/src/__tests__/main/parsers/claude-output-parser.test.ts
+++ b/src/__tests__/main/parsers/claude-output-parser.test.ts
@@ -218,9 +218,12 @@ describe('ClaudeOutputParser', () => {
 			expect(usage?.cacheCreationTokens).toBe(10);
 			expect(usage?.contextWindow).toBe(200000);
 			expect(usage?.costUsd).toBe(0.01);
-			// 200000 here is the aggregator's untouched fallback seed (the model's
-			// own 200000 is not LARGER than it), so it carries no provider authority.
-			expect(usage?.contextWindowReported).toBeUndefined();
+			// The model reported 200000 itself. That it happens to equal the
+			// fallback seed does not make it less of a provider report, so it is
+			// flagged authoritative (review of PR #1356). Before that fix the
+			// "is it LARGER than the fallback" test silently demoted every
+			// 200k-and-under model to unreported.
+			expect(usage?.contextWindowReported).toBe(true);
 		});
 
 		it('flags a genuinely reported context window as provider-reported', () => {

--- a/src/__tests__/main/parsers/codex-output-parser.test.ts
+++ b/src/__tests__/main/parsers/codex-output-parser.test.ts
@@ -711,6 +711,24 @@ describe('CodexOutputParser', () => {
 				})
 			);
 			expect(usageEvent?.usage?.contextWindow).toBe(200000);
+			// The window came from Codex's own turn_context, so it is authoritative
+			// even though it happens to equal the static fallback constant.
+			expect(usageEvent?.usage?.contextWindowReported).toBe(true);
+		});
+
+		it('should not flag the config/static-table seed as provider-reported', () => {
+			const p = new CodexOutputParser();
+
+			// No turn_context and no model_context_window anywhere: the window can
+			// only be the constructor's config / lookup-table seed.
+			const usageEvent = p.parseJsonLine(
+				JSON.stringify({
+					type: 'turn.completed',
+					usage: { input_tokens: 100, output_tokens: 50 },
+				})
+			);
+			expect(usageEvent?.usage?.contextWindow).toBeGreaterThan(0);
+			expect(usageEvent?.usage?.contextWindowReported).toBe(false);
 		});
 
 		it('should handle turn_context without payload', () => {
@@ -811,6 +829,7 @@ describe('CodexOutputParser', () => {
 				expect(event?.usage?.cacheReadTokens).toBe(3000);
 				expect(event?.usage?.cacheCreationTokens).toBe(0);
 				expect(event?.usage?.contextWindow).toBe(400000);
+				expect(event?.usage?.contextWindowReported).toBe(true);
 				expect(event?.usage?.reasoningTokens).toBe(200);
 			});
 
@@ -834,6 +853,8 @@ describe('CodexOutputParser', () => {
 
 				// Should fall back to cached context window (default model)
 				expect(event?.usage?.contextWindow).toBeGreaterThan(0);
+				// ...and that fallback is NOT provider-reported.
+				expect(event?.usage?.contextWindowReported).toBe(false);
 			});
 
 			it('should handle token_count with zero values', () => {

--- a/src/__tests__/main/parsers/codex-output-parser.test.ts
+++ b/src/__tests__/main/parsers/codex-output-parser.test.ts
@@ -731,6 +731,44 @@ describe('CodexOutputParser', () => {
 			expect(usageEvent?.usage?.contextWindowReported).toBe(false);
 		});
 
+		// Review of PR #1356 (item 2). `turn_context` cached the reported window on
+		// the instance but `token_count` did not, so when Codex carried
+		// `model_context_window` in `token_count` only, a single turn produced two
+		// different denominators: token_count reported the real window with the
+		// flag set (renderer rank 2), then turn.completed fell back to the
+		// constructor seed with the flag clear (rank 3, stored override wins). The
+		// gauge changed denominator mid-turn.
+		it('should cache a context window reported by token_count, not just turn_context', () => {
+			const p = new CodexOutputParser();
+
+			// No turn_context at all - the window arrives only on token_count.
+			const tokenCountEvent = p.parseJsonLine(
+				JSON.stringify({
+					type: 'event_msg',
+					payload: {
+						type: 'token_count',
+						info: {
+							model_context_window: 272000,
+							total_token_usage: { input_tokens: 100, output_tokens: 50 },
+						},
+					},
+				})
+			);
+			expect(tokenCountEvent?.usage?.contextWindow).toBe(272000);
+			expect(tokenCountEvent?.usage?.contextWindowReported).toBe(true);
+
+			// The very next event of the same turn must agree. Before the fix this
+			// returned the seed with contextWindowReported false.
+			const completedEvent = p.parseJsonLine(
+				JSON.stringify({
+					type: 'turn.completed',
+					usage: { input_tokens: 100, output_tokens: 50 },
+				})
+			);
+			expect(completedEvent?.usage?.contextWindow).toBe(272000);
+			expect(completedEvent?.usage?.contextWindowReported).toBe(true);
+		});
+
 		it('should handle turn_context without payload', () => {
 			const line = JSON.stringify({ type: 'turn_context' });
 			const event = parser.parseJsonLine(line);

--- a/src/__tests__/main/parsers/qwen-output-parser.test.ts
+++ b/src/__tests__/main/parsers/qwen-output-parser.test.ts
@@ -118,6 +118,8 @@ describe('QwenOutputParser', () => {
 			const usage = parser.extractUsage(event!);
 			expect(usage).not.toBeNull();
 			expect(usage?.contextWindow).toBeUndefined();
+			// Nothing was reported, so nothing may claim provider authority either.
+			expect(usage?.contextWindowReported).toBeUndefined();
 		});
 
 		it('preserves a genuinely larger reported context window', () => {
@@ -139,6 +141,8 @@ describe('QwenOutputParser', () => {
 
 			const usage = parser.extractUsage(event!);
 			expect(usage?.contextWindow).toBe(262144);
+			// Genuinely reported, so it outranks a stored per-session window (P1).
+			expect(usage?.contextWindowReported).toBe(true);
 		});
 		it('preserves a model-reported 200000 context window (not the Claude fallback)', () => {
 			// 200000 equals the injected Claude fallback, but here a model reports it
@@ -160,6 +164,9 @@ describe('QwenOutputParser', () => {
 
 			const usage = parser.extractUsage(event!);
 			expect(usage?.contextWindow).toBe(200000);
+			// Equal to the fallback constant, yet reported: exactly the case a
+			// value-comparison heuristic would get wrong (Decision D4).
+			expect(usage?.contextWindowReported).toBe(true);
 		});
 		it('preserves a model-reported context window below the Claude fallback', () => {
 			// A custom OpenAI-compatible model can report a window < 200000; the aggregator

--- a/src/__tests__/main/parsers/usage-aggregator.test.ts
+++ b/src/__tests__/main/parsers/usage-aggregator.test.ts
@@ -65,6 +65,20 @@ describe('aggregateModelUsage', () => {
 	it('should use default context window of 200000', () => {
 		const result = aggregateModelUsage(undefined, {}, 0);
 		expect(result.contextWindow).toBe(200000);
+		// The default is an injected fallback, never provider truth (finding P1).
+		expect(result.contextWindowResolved).toBeUndefined();
+	});
+
+	it('should not flag a fallback-sized window as resolved', () => {
+		// The model reports a window no larger than the fallback, so the returned
+		// 200000 is still the injected default rather than an aggregated value.
+		const modelUsage: Record<string, ModelStats> = {
+			model1: { inputTokens: 100, contextWindow: 150000 },
+		};
+
+		const result = aggregateModelUsage(modelUsage, {}, 0);
+		expect(result.contextWindow).toBe(200000);
+		expect(result.contextWindowResolved).toBeUndefined();
 	});
 
 	it('should use highest context window from models', () => {
@@ -76,6 +90,8 @@ describe('aggregateModelUsage', () => {
 
 		const result = aggregateModelUsage(modelUsage, {}, 0);
 		expect(result.contextWindow).toBe(300000);
+		// A model actually reported this one, so it is authoritative.
+		expect(result.contextWindowResolved).toBe(true);
 	});
 });
 

--- a/src/__tests__/main/parsers/usage-aggregator.test.ts
+++ b/src/__tests__/main/parsers/usage-aggregator.test.ts
@@ -69,16 +69,34 @@ describe('aggregateModelUsage', () => {
 		expect(result.contextWindowResolved).toBeUndefined();
 	});
 
-	it('should not flag a fallback-sized window as resolved', () => {
-		// The model reports a window no larger than the fallback, so the returned
-		// 200000 is still the injected default rather than an aggregated value.
+	it('should treat a below-fallback provider window as authoritative', () => {
+		// Review of PR #1356: a model reporting a window SMALLER than the 200000
+		// fallback is still provider truth, and must both replace the fallback and
+		// be flagged resolved. Comparing against the fallback instead of against
+		// the other reported windows left a 128k-class model unreported, so the
+		// renderer let a stored customContextWindow outrank the provider and drew
+		// the gauge and timeline against the wrong denominator.
 		const modelUsage: Record<string, ModelStats> = {
 			model1: { inputTokens: 100, contextWindow: 150000 },
 		};
 
 		const result = aggregateModelUsage(modelUsage, {}, 0);
-		expect(result.contextWindow).toBe(200000);
-		expect(result.contextWindowResolved).toBeUndefined();
+		expect(result.contextWindow).toBe(150000);
+		expect(result.contextWindowResolved).toBe(true);
+	});
+
+	it('should keep the highest window when reports straddle the fallback', () => {
+		// The max is taken across REPORTED windows only, so a small model reporting
+		// after a large one cannot drag the window down, and the fallback never
+		// wins over a real report.
+		const modelUsage: Record<string, ModelStats> = {
+			model1: { inputTokens: 100, contextWindow: 150000 },
+			model2: { inputTokens: 100, contextWindow: 180000 },
+		};
+
+		const result = aggregateModelUsage(modelUsage, {}, 0);
+		expect(result.contextWindow).toBe(180000);
+		expect(result.contextWindowResolved).toBe(true);
 	});
 
 	it('should use highest context window from models', () => {

--- a/src/__tests__/main/process-manager.test.ts
+++ b/src/__tests__/main/process-manager.test.ts
@@ -92,6 +92,9 @@ describe('process-manager.ts', () => {
 					cacheCreationInputTokens: 100,
 					totalCostUsd: 0.05,
 					contextWindow: 200000,
+					// The model reported this window itself, so it is provider truth
+					// even though it equals the fallback (review of PR #1356).
+					contextWindowResolved: true,
 				});
 			});
 
@@ -125,6 +128,7 @@ describe('process-manager.ts', () => {
 					cacheCreationInputTokens: 100,
 					totalCostUsd: 0.1,
 					contextWindow: 200000, // Should use the highest context window
+					contextWindowResolved: true,
 				});
 			});
 

--- a/src/__tests__/main/process-manager/handlers/StdoutHandler.test.ts
+++ b/src/__tests__/main/process-manager/handlers/StdoutHandler.test.ts
@@ -1120,6 +1120,7 @@ describe('StdoutHandler', () => {
 				cacheCreationTokens?: number;
 				costUsd?: number;
 				contextWindow?: number;
+				contextWindowReported?: boolean;
 				reasoningTokens?: number;
 				model?: string;
 			} | null
@@ -1311,6 +1312,64 @@ describe('StdoutHandler', () => {
 				cacheCreationInputTokens: 180,
 				reasoningTokens: 0,
 			});
+		});
+
+		it('sets contextWindowResolved when a non-omp parser flags a provider-reported window', () => {
+			// The parser saw the window in the provider's own payload (e.g. codex's
+			// model_context_window), so the value is authoritative and must outrank
+			// the session's stored customContextWindow in the renderer (finding P1).
+			const parser = createOutputParserMock({
+				inputTokens: 1000,
+				outputTokens: 500,
+				costUsd: 0.05,
+				contextWindow: 400000,
+				contextWindowReported: true,
+			});
+
+			const { handler, emitter, sessionId } = createTestContext({
+				isStreamJsonMode: true,
+				toolType: 'codex',
+				// Spawn config carries a different number; the reported one wins.
+				contextWindow: 200000,
+				outputParser: parser as unknown as AgentOutputParser,
+			});
+
+			const usageSpy = vi.fn();
+			emitter.on('usage', usageSpy);
+
+			sendJsonLine(handler, sessionId, { type: 'message', text: 'hi' });
+
+			const stats = usageSpy.mock.calls[0][1];
+			expect(stats.contextWindow).toBe(400000);
+			expect(stats.contextWindowResolved).toBe(true);
+		});
+
+		it('does not set contextWindowResolved for an unflagged usage payload', () => {
+			// Same window value, but the parser injected it from config or a static
+			// table rather than reading it from the provider. Provenance is only
+			// knowable at the parser, so an unflagged window stays a fallback.
+			const parser = createOutputParserMock({
+				inputTokens: 1000,
+				outputTokens: 500,
+				costUsd: 0.05,
+				contextWindow: 400000,
+			});
+
+			const { handler, emitter, sessionId } = createTestContext({
+				isStreamJsonMode: true,
+				toolType: 'codex',
+				contextWindow: 200000,
+				outputParser: parser as unknown as AgentOutputParser,
+			});
+
+			const usageSpy = vi.fn();
+			emitter.on('usage', usageSpy);
+
+			sendJsonLine(handler, sessionId, { type: 'message', text: 'hi' });
+
+			const stats = usageSpy.mock.calls[0][1];
+			expect(stats.contextWindow).toBe(400000);
+			expect(stats.contextWindowResolved).toBeUndefined();
 		});
 
 		it('resolves the omp model window from the local catalog and flags it authoritative', () => {

--- a/src/__tests__/renderer/hooks/agent/internal/useAgentUsageListener.test.tsx
+++ b/src/__tests__/renderer/hooks/agent/internal/useAgentUsageListener.test.tsx
@@ -279,6 +279,94 @@ describe('useAgentUsageListener', () => {
 		expect(last.percentage).toBe(10); // round(100000 / 1000000 * 100)
 	});
 
+	it('lets a resolved window beat a per-session customContextWindow override', () => {
+		// The stored override is a materialized creation-time default (finding P1),
+		// so a genuinely provider-resolved window outranks it.
+		const session = createMockSession({
+			id: 'sess-1',
+			toolType: 'omp',
+			customContextWindow: 200000,
+		});
+		useSessionStore.setState({ sessions: [session] });
+
+		const batched = makeBatched();
+		renderHook(() =>
+			useAgentUsageListener({ batchedUpdater: batched, contextWarningYellowThreshold: 80 })
+		);
+
+		handler!('sess-1', {
+			inputTokens: 100000,
+			outputTokens: 100,
+			cacheReadInputTokens: 0,
+			cacheCreationInputTokens: 0,
+			contextWindow: 1000000,
+			contextWindowResolved: true,
+		});
+
+		const points = useContextTimelineStore.getState().buffers['sess-1']?.points ?? [];
+		const last = points[points.length - 1];
+		expect(last.contextWindow).toBe(1000000);
+		expect(last.percentage).toBe(10); // round(100000 / 1000000 * 100)
+	});
+
+	it('keeps an unresolved reported window below the per-session override', () => {
+		// Without the `contextWindowResolved` flag the reported value may be a
+		// parser-injected static fallback, so the stored override still wins.
+		const session = createMockSession({
+			id: 'sess-1',
+			toolType: 'omp',
+			customContextWindow: 200000,
+		});
+		useSessionStore.setState({ sessions: [session] });
+
+		const batched = makeBatched();
+		renderHook(() =>
+			useAgentUsageListener({ batchedUpdater: batched, contextWarningYellowThreshold: 80 })
+		);
+
+		handler!('sess-1', {
+			inputTokens: 20000,
+			outputTokens: 100,
+			cacheReadInputTokens: 0,
+			cacheCreationInputTokens: 0,
+			contextWindow: 1000000,
+		});
+
+		const points = useContextTimelineStore.getState().buffers['sess-1']?.points ?? [];
+		const last = points[points.length - 1];
+		expect(last.contextWindow).toBe(200000);
+		expect(last.percentage).toBe(10); // round(20000 / 200000 * 100)
+	});
+
+	it('keeps a [1m] custom-model marker above a resolved window', () => {
+		// The marker is an explicit model choice, so it stays at the top of the
+		// precedence list even against a provider-resolved window.
+		const session = createMockSession({
+			id: 'sess-1',
+			toolType: 'claude-code',
+			customModel: 'claude-sonnet-4-5[1m]',
+		});
+		useSessionStore.setState({ sessions: [session] });
+
+		const batched = makeBatched();
+		renderHook(() =>
+			useAgentUsageListener({ batchedUpdater: batched, contextWarningYellowThreshold: 80 })
+		);
+
+		handler!('sess-1', {
+			inputTokens: 100000,
+			outputTokens: 100,
+			cacheReadInputTokens: 0,
+			cacheCreationInputTokens: 0,
+			contextWindow: 200000,
+			contextWindowResolved: true,
+		});
+
+		const points = useContextTimelineStore.getState().buffers['sess-1']?.points ?? [];
+		const last = points[points.length - 1];
+		expect(last.contextWindow).toBe(1_000_000);
+	});
+
 	it('falls back to accumulated growth estimate when contextPercentage is null', () => {
 		const session = createMockSession({
 			id: 'sess-1',

--- a/src/__tests__/renderer/hooks/useContextWindow.test.ts
+++ b/src/__tests__/renderer/hooks/useContextWindow.test.ts
@@ -100,6 +100,41 @@ describe('useContextWindow', () => {
 		await waitFor(() => expect(result.current.activeTabContextWindow).toBe(1_000_000));
 	});
 
+	it('lets a resolved runtime window beat a stored customContextWindow override', async () => {
+		// Finding P1 / D1: the stored value is a materialized creation-time default,
+		// so a provider-resolved window outranks it.
+		const session = makeSession({ toolType: 'omp', customContextWindow: 200000 });
+		const tab = {
+			usageStats: {
+				contextWindow: 1_000_000,
+				contextWindowResolved: true,
+				inputTokens: 1000,
+				outputTokens: 500,
+			},
+		};
+
+		const { result } = renderHook(() => useContextWindow(session, tab));
+
+		await waitFor(() => expect(result.current.activeTabContextWindow).toBe(1_000_000));
+	});
+
+	it('still returns the stored override when the reported window is not flagged resolved', async () => {
+		// Without the authority flag the reported window may be a parser-injected
+		// static fallback, so the stored value stays in charge.
+		const session = makeSession({ toolType: 'omp', customContextWindow: 200000 });
+		const tab = {
+			usageStats: {
+				contextWindow: 1_000_000,
+				inputTokens: 1000,
+				outputTokens: 500,
+			},
+		};
+
+		const { result } = renderHook(() => useContextWindow(session, tab));
+
+		await waitFor(() => expect(result.current.activeTabContextWindow).toBe(200000));
+	});
+
 	it('keeps a [1m] custom-model marker above a resolved window', async () => {
 		mockGetConfig.mockResolvedValue({ contextWindow: 200000 });
 		// An explicit [1m] model choice is authoritative and must outrank a

--- a/src/main/parsers/agent-output-parser.ts
+++ b/src/main/parsers/agent-output-parser.ts
@@ -104,6 +104,18 @@ export interface ParsedEvent {
 		cacheCreationTokens?: number;
 		contextWindow?: number;
 		/**
+		 * Authority marker for `contextWindow`: true only when the window value
+		 * came from the provider's own payload, never from a config value or a
+		 * static-table fallback the parser injected. Parsers routinely seed
+		 * `contextWindow` with a fallback (see `usage-aggregator.ts` and
+		 * `codex-output-parser.ts`), so the presence of a window says nothing
+		 * about its provenance - only this flag does. Downstream,
+		 * `StdoutHandler.buildUsageStats` forwards it into
+		 * `UsageStats.contextWindowResolved`, which the renderer ranks above a
+		 * stored `customContextWindow` (finding P1).
+		 */
+		contextWindowReported?: boolean;
+		/**
 		 * Model identifier the provider reported for this turn (e.g.
 		 * `claude-opus-4-8`). Enables downstream resolution of the model's real
 		 * context window from the provider catalog. Set by providers whose window

--- a/src/main/parsers/claude-output-parser.ts
+++ b/src/main/parsers/claude-output-parser.ts
@@ -514,6 +514,9 @@ export class ClaudeOutputParser implements AgentOutputParser {
 			cacheReadTokens: aggregated.cacheReadInputTokens,
 			cacheCreationTokens: aggregated.cacheCreationInputTokens,
 			contextWindow: aggregated.contextWindow,
+			// The aggregator flags the window as resolved only when a model actually
+			// reported one; the untouched FALLBACK_CONTEXT_WINDOW seed leaves it off.
+			...(aggregated.contextWindowResolved ? { contextWindowReported: true } : {}),
 			costUsd: aggregated.totalCostUsd,
 			// The fields above are the turn's summed SPEND and can exceed the window;
 			// this is the same turn's real occupancy, when the stream gave us one.

--- a/src/main/parsers/codex-output-parser.ts
+++ b/src/main/parsers/codex-output-parser.ts
@@ -513,6 +513,19 @@ export class CodexOutputParser implements AgentOutputParser {
 			const reasoningOutputTokens = tokenUsage.reasoning_output_tokens || 0;
 			const totalOutputTokens = outputTokens + reasoningOutputTokens;
 
+			// Cache the window the same way `turn_context` does. Without this the
+			// denominator flaps inside a single turn whenever Codex carries
+			// `model_context_window` in `token_count` but not in an earlier
+			// `turn_context`: this event reports the real window with the flag set
+			// (renderer rank 2), then `turn.completed` falls back through
+			// `extractUsageFromRaw` to the constructor's config or lookup-table seed
+			// with the flag clear (rank 3, the stored override wins). The value-level
+			// flap predates the flag, but the flag makes it cross a precedence tier.
+			if (payload.info.model_context_window) {
+				this.contextWindow = payload.info.model_context_window;
+				this.contextWindowReported = true;
+			}
+
 			return {
 				type: 'usage',
 				usage: {
@@ -852,8 +865,11 @@ export class CodexOutputParser implements AgentOutputParser {
 			// Note: Codex doesn't report cache creation tokens
 			cacheCreationTokens: 0,
 			// Note: costUsd omitted - Codex doesn't provide cost and pricing varies by model
-			// Context window from Codex config (~/.codex/config.toml) or model lookup table,
-			// unless a turn_context / token_count already replaced it with Codex's own value
+			// Context window from Codex config (~/.codex/config.toml) or model lookup
+			// table, unless a turn_context or token_count already replaced it with
+			// Codex's own value. Both cache it now, so once either has reported a
+			// window this reads the real one for the rest of the session instead of
+			// dropping back to the seed mid-turn.
 			contextWindow: this.contextWindow,
 			contextWindowReported: this.contextWindowReported,
 			// Store reasoning tokens separately for UI display

--- a/src/main/parsers/codex-output-parser.ts
+++ b/src/main/parsers/codex-output-parser.ts
@@ -295,6 +295,15 @@ export class CodexOutputParser implements AgentOutputParser {
 
 	// Cached context window - read once from config
 	private contextWindow: number;
+	/**
+	 * Provenance of `contextWindow`: true only once Codex itself reported a
+	 * `model_context_window` (turn_context or token_count). The constructor seed
+	 * below is a config value or a static-table lookup, never provider truth, so
+	 * it deliberately leaves this false. Emitted as `usage.contextWindowReported`
+	 * so `StdoutHandler.buildUsageStats` can mark the window authoritative
+	 * (finding P1) without guessing from the number alone.
+	 */
+	private contextWindowReported = false;
 	private model: string;
 
 	// Track tool name from tool_call to carry over to tool_result
@@ -379,6 +388,7 @@ export class CodexOutputParser implements AgentOutputParser {
 		if (msg.type === 'turn_context' && msg.payload) {
 			if (msg.payload.model_context_window) {
 				this.contextWindow = msg.payload.model_context_window;
+				this.contextWindowReported = true;
 			}
 			if (msg.payload.model) {
 				this.model = msg.payload.model;
@@ -511,6 +521,12 @@ export class CodexOutputParser implements AgentOutputParser {
 					cacheReadTokens: cachedInputTokens,
 					cacheCreationTokens: 0,
 					contextWindow: payload.info.model_context_window || this.contextWindow,
+					// Authoritative when this payload carried the window itself, or when an
+					// earlier turn_context reported the cached one. A config / static-table
+					// seed leaves the flag off (see `contextWindowReported`).
+					contextWindowReported: payload.info.model_context_window
+						? true
+						: this.contextWindowReported,
 					reasoningTokens: reasoningOutputTokens,
 				},
 				raw: msg,
@@ -836,8 +852,10 @@ export class CodexOutputParser implements AgentOutputParser {
 			// Note: Codex doesn't report cache creation tokens
 			cacheCreationTokens: 0,
 			// Note: costUsd omitted - Codex doesn't provide cost and pricing varies by model
-			// Context window from Codex config (~/.codex/config.toml) or model lookup table
+			// Context window from Codex config (~/.codex/config.toml) or model lookup table,
+			// unless a turn_context / token_count already replaced it with Codex's own value
 			contextWindow: this.contextWindow,
+			contextWindowReported: this.contextWindowReported,
 			// Store reasoning tokens separately for UI display
 			reasoningTokens: reasoningOutputTokens,
 		};

--- a/src/main/parsers/qwen-output-parser.ts
+++ b/src/main/parsers/qwen-output-parser.ts
@@ -75,10 +75,18 @@ export class QwenOutputParser extends ClaudeOutputParser {
 			: 0;
 		if (event.usage) {
 			if (reportedContextWindow > 0) {
-				event.usage = { ...event.usage, contextWindow: reportedContextWindow };
+				// This branch is the only one holding a genuinely provider-reported
+				// window, so it is the only one allowed to mark it authoritative
+				// (finding P1 - see `contextWindowReported` on ParsedEvent.usage).
+				event.usage = {
+					...event.usage,
+					contextWindow: reportedContextWindow,
+					contextWindowReported: true,
+				};
 			} else if (event.usage.contextWindow === FALLBACK_CONTEXT_WINDOW) {
 				const usage = { ...event.usage };
 				delete usage.contextWindow;
+				delete usage.contextWindowReported;
 				event.usage = usage;
 			}
 		}

--- a/src/main/parsers/usage-aggregator.ts
+++ b/src/main/parsers/usage-aggregator.ts
@@ -170,6 +170,10 @@ export function aggregateModelUsage(
 	let maxCacheReadTokens = 0;
 	let maxCacheCreationTokens = 0;
 	let contextWindow = FALLBACK_CONTEXT_WINDOW; // Default for Claude
+	// Provenance of the value above: it starts as an injected fallback, and only a
+	// window that some model actually reported below flips it to authoritative
+	// (finding P1 - the presence of a number says nothing about where it came from).
+	let contextWindowReported = false;
 
 	if (modelUsage) {
 		for (const modelStats of Object.values(modelUsage)) {
@@ -183,6 +187,7 @@ export function aggregateModelUsage(
 			// Use the highest context window from any model
 			if (modelStats.contextWindow && modelStats.contextWindow > contextWindow) {
 				contextWindow = modelStats.contextWindow;
+				contextWindowReported = true;
 			}
 		}
 	}
@@ -203,5 +208,8 @@ export function aggregateModelUsage(
 		cacheCreationInputTokens: maxCacheCreationTokens,
 		totalCostUsd,
 		contextWindow,
+		// Only set when the window above came from the provider's own modelUsage,
+		// so consumers can rank it above a stored per-session fallback.
+		...(contextWindowReported ? { contextWindowResolved: true } : {}),
 	};
 }

--- a/src/main/parsers/usage-aggregator.ts
+++ b/src/main/parsers/usage-aggregator.ts
@@ -217,7 +217,7 @@ export function aggregateModelUsage(
 		totalCostUsd,
 		contextWindow,
 		// Only set when the window above came from the provider's own modelUsage,
-		// so consumers can rank it above a stored per-session fallback.
+		// so consumers can rank it above a stored customContextWindow fallback.
 		...(contextWindowReported ? { contextWindowResolved: true } : {}),
 	};
 }

--- a/src/main/parsers/usage-aggregator.ts
+++ b/src/main/parsers/usage-aggregator.ts
@@ -184,9 +184,17 @@ export function aggregateModelUsage(
 				maxCacheCreationTokens,
 				modelStats.cacheCreationInputTokens || 0
 			);
-			// Use the highest context window from any model
-			if (modelStats.contextWindow && modelStats.contextWindow > contextWindow) {
-				contextWindow = modelStats.contextWindow;
+			// Use the highest context window any model REPORTED. The max is taken
+			// against the other reported windows, never against the injected
+			// fallback: comparing to the fallback made a provider window at or
+			// below it (a 128k model, say) fail the test, leaving the frame marked
+			// unreported so the renderer let a stored customContextWindow outrank
+			// provider truth - the exact inversion P1 exists to fix. The first
+			// reported window therefore replaces the fallback outright.
+			if (modelStats.contextWindow && modelStats.contextWindow > 0) {
+				contextWindow = contextWindowReported
+					? Math.max(contextWindow, modelStats.contextWindow)
+					: modelStats.contextWindow;
 				contextWindowReported = true;
 			}
 		}

--- a/src/main/process-manager/handlers/StdoutHandler.ts
+++ b/src/main/process-manager/handlers/StdoutHandler.ts
@@ -836,6 +836,7 @@ export class StdoutHandler {
 			cacheCreationTokens?: number;
 			costUsd?: number;
 			contextWindow?: number;
+			contextWindowReported?: boolean;
 			reasoningTokens?: number;
 			model?: string;
 			absoluteUsage?: UsageStats['absoluteUsage'];
@@ -856,6 +857,15 @@ export class StdoutHandler {
 			contextWindow: usage.contextWindow || managedProcess.contextWindow || FALLBACK_CONTEXT_WINDOW,
 			reasoningTokens: usage.reasoningTokens,
 		};
+		// A window is only AUTHORITATIVE when the parser saw it in the provider's
+		// own payload; parsers seed the same field with config values and static
+		// fallbacks, so the flag - not the presence of a number - is the signal.
+		// The renderer ranks a resolved window above the session's stored
+		// customContextWindow, which is usually a materialized creation-time
+		// default rather than a value the user chose (finding P1).
+		if (usage.contextWindowReported && (usage.contextWindow || 0) > 0) {
+			stats.contextWindowResolved = true;
+		}
 		// Oh My Pi's window is model-dependent and reported per turn, so resolve the
 		// per-turn model against the catalog primed for THIS process's binary + env
 		// (ompModelCatalogKey) and let that authoritative value win over the static

--- a/src/renderer/hooks/agent/internal/useAgentUsageListener.ts
+++ b/src/renderer/hooks/agent/internal/useAgentUsageListener.ts
@@ -81,50 +81,66 @@ export function useAgentUsageListener(deps: UseAgentUsageListenerDeps): void {
 				? { ...usageStats.absoluteUsage, contextWindow: usageStats.contextWindow }
 				: usageStats;
 
-			// Resolve the effective context window ONCE, matching the header gauge's
-			// precedence (resolveConfiguredContextWindow): a per-agent custom window,
-			// a `[1m]` model marker, or the provider's configured window wins over the
-			// reported/static window, so a session configured for e.g. 1M isn't sized
-			// against a 200k denominator. Shared by the timeline point and the
-			// accumulated-growth fallback so they can never disagree.
+			// Resolve the effective context window ONCE, shared by the timeline point
+			// and the accumulated-growth fallback so they can never disagree.
+			//
+			// Precedence (finding P1). Ranks 1-3 and 5 are POSITIONALLY IDENTICAL to
+			// useContextWindow's, or the header gauge and the Context Timeline
+			// disagree again (the bug PR #1221 fixed). Ranks 4 and 6 are
+			// timeline-only extras and sit below the shared ranks:
+			//   1. `[1m]` model marker
+			//   2. resolved reported window
+			//   3. `customContextWindow` override
+			//   4. cached provider-configured window (timeline-only)
+			//   5. raw reported window
+			//   6. static per-agent table (timeline-only)
 			//
 			// The provider-config source lives behind an async `getConfig` call that
 			// must NOT run on this hot per-turn path, so we read it from a synchronous
-			// cache and prime that cache off-path for the next turn. The two sync
-			// sources (per-session window, model marker) take precedence and cover the
-			// common cases immediately; the cached provider window closes the gap for
-			// agents (e.g. OpenCode) whose window is configured at the provider level
-			// only and would otherwise plot against the static table.
+			// cache and prime that cache off-path for the next turn. It closes the gap
+			// for agents (e.g. OpenCode) whose window is configured at the provider
+			// level only and would otherwise plot against the static table.
 			ensureConfiguredContextWindowCached(sessionForUsage);
-			const syncConfiguredWindow =
-				typeof sessionForUsage.customContextWindow === 'number' &&
-				sessionForUsage.customContextWindow > 0
-					? sessionForUsage.customContextWindow
-					: getModelContextWindowOverride(sessionForUsage.customModel) || 0;
-			const cachedConfiguredWindow = getCachedConfiguredContextWindow(sessionForUsage);
-			// A genuinely provider/model-resolved window (currently Oh My Pi's per-turn
-			// model catalog, flagged via `contextWindowResolved`) is the ACTUAL window
-			// and must beat the agent-level configured FALLBACK - but never an explicit
-			// per-session override or a `[1m]` model marker, both of which rank above it.
+			// A `[1m]` marker on the session's custom model is an explicit model choice
+			// the user made per-session, so it stays at the top.
+			const modelMarker = getModelContextWindowOverride(sessionForUsage.customModel) || 0;
+			// A genuinely provider-resolved window (flagged via `contextWindowResolved`,
+			// set only where the value came from the provider's own payload) is runtime
+			// truth, so it outranks the stored override below.
 			const resolvedReportedWindow =
 				usageStats.contextWindowResolved && usageStats.contextWindow > 0
 					? usageStats.contextWindow
 					: 0;
+			// `customContextWindow` is NOT reliably something the user chose: the agent
+			// definition's `contextWindow` default is materialized into every new session
+			// at creation time (see P1), which is how a fresh omp agent plotted against
+			// 200k instead of the provider's real 1M. Treat it as a fallback that applies
+			// until the provider reports an authoritative window.
+			const sessionOverride =
+				typeof sessionForUsage.customContextWindow === 'number' &&
+				sessionForUsage.customContextWindow > 0
+					? sessionForUsage.customContextWindow
+					: 0;
+			const cachedConfiguredWindow = getCachedConfiguredContextWindow(sessionForUsage);
 			const resolvedWindow =
-				syncConfiguredWindow > 0
-					? syncConfiguredWindow
+				modelMarker > 0
+					? modelMarker
 					: resolvedReportedWindow > 0
 						? resolvedReportedWindow
-						: cachedConfiguredWindow > 0
-							? cachedConfiguredWindow
-							: usageStats.contextWindow > 0
-								? usageStats.contextWindow
-								: agentToolType && agentToolType !== 'terminal'
-									? getContextWindowForAgent(
-											agentToolType,
-											useAgentStore.getState().getCapabilitySnapshot(agentToolType, sessionRemoteId)
-										)
-									: 0;
+						: sessionOverride > 0
+							? sessionOverride
+							: cachedConfiguredWindow > 0
+								? cachedConfiguredWindow
+								: usageStats.contextWindow > 0
+									? usageStats.contextWindow
+									: agentToolType && agentToolType !== 'terminal'
+										? getContextWindowForAgent(
+												agentToolType,
+												useAgentStore
+													.getState()
+													.getCapabilitySnapshot(agentToolType, sessionRemoteId)
+											)
+										: 0;
 
 			// Gauge percentage, computed AFTER `resolvedWindow` so it divides by the
 			// same denominator the timeline point stores. Computing it earlier used

--- a/src/renderer/hooks/mainPanel/useContextWindow.ts
+++ b/src/renderer/hooks/mainPanel/useContextWindow.ts
@@ -34,19 +34,30 @@ export function useContextWindow(activeSession: Session | null, activeTab: AITab
 	}, [activeSession?.toolType, activeSession?.customContextWindow]);
 
 	const activeTabContextWindow = useMemo(() => {
-		// Explicit per-session override always wins.
-		const sessionOverride = activeSession?.customContextWindow ?? 0;
-		if (sessionOverride > 0) return sessionOverride;
+		// Precedence (finding P1). Keep this list POSITIONALLY IDENTICAL to
+		// useAgentUsageListener's, or the header gauge and the Context Timeline
+		// disagree again (the bug PR #1221 fixed):
+		//   1. `[1m]` model marker
+		//   2. resolved reported window
+		//   3. `customContextWindow` override
+		//   4. async configured window
+		//   5. raw reported window
 		// A `[1m]` marker on the session's custom model is an explicit model choice
-		// and outranks a runtime-resolved window, matching useAgentUsageListener's
-		// precedence so the header gauge and the timeline never disagree.
+		// the user made per-session, so it stays at the top.
 		const modelMarker = getModelContextWindowOverride(activeSession?.customModel) ?? 0;
 		if (modelMarker > 0) return modelMarker;
 		const reported = activeTab?.usageStats?.contextWindow ?? 0;
-		// A genuinely provider/model-resolved window (omp's per-turn model catalog,
-		// flagged via `contextWindowResolved`) is the ACTUAL window, so it beats the
-		// agent-level configured fallback (e.g. opus's 1M vs the 200k default).
+		// A genuinely provider-resolved window (flagged via `contextWindowResolved`,
+		// set only where the value came from the provider's own payload) is runtime
+		// truth, so it outranks the stored override below.
 		if (activeTab?.usageStats?.contextWindowResolved && reported > 0) return reported;
+		// `customContextWindow` is NOT reliably something the user chose: the agent
+		// definition's `contextWindow` default is materialized into every new session
+		// at creation time (see P1), which is how a fresh omp agent displayed 200k
+		// instead of the provider's real 1M. Treat it as a fallback that applies
+		// until the provider reports an authoritative window.
+		const sessionOverride = activeSession?.customContextWindow ?? 0;
+		if (sessionOverride > 0) return sessionOverride;
 		return configuredContextWindow > 0 ? configuredContextWindow : reported;
 	}, [
 		configuredContextWindow,


### PR DESCRIPTION
Closes finding P1. Second of four in the context-cluster queue - #1351 (Q1) merged first; R1 and S1 follow.

## Problem

The main process already treats a provider-reported context window as authoritative and says so in comments. The renderer then discards it.

`StdoutHandler` resolves omp's per-turn model against the primed catalog and sets `contextWindowResolved: true`, explicitly so "opus's 1M isn't masked by the 200k default". But `useContextWindow.ts` returned `customContextWindow` first, and the `contextWindowResolved` check below it was never reached.

The value that won is not one the user chose. `agents:getConfig` merges every configOption `default` into the returned config, `NewInstanceModal` persists that onto the new session as `customContextWindow`, and the gauge then treats it as an explicit override forever.

Evidence from a live session store: **every** omp agent carried `customContextWindow: 200000` with `customModel: None`, and 25 codex agents still carried `400000` even though codex has no `contextWindow` configOption today - orphaned snapshots from when it did, which nothing in the current code could have written.

The omp option documents itself as a *"Fallback context window size in tokens until Oh My Pi reports a runtime-specific value"* - and was then promoted to a hard override that runtime truth could never beat.

## Fix

- Move the `contextWindowResolved` check above `customContextWindow` in the gauge, and mirror it in the Context Timeline **in lockstep**. A gauge/timeline disagreement is the exact bug #1221 fixed, so the two surfaces change together.
- Extend the authority signal beyond omp: parsers now flag a provider-reported window, so any provider reporting one can outrank a stored default.

Resulting precedence: provider-reported wins, user/agent config is the fallback until a provider reports, the static table is last resort. This **reinterprets** the stored value rather than migrating it, so it fixes existing agents with no data change.

Deliberately unchanged: the spawn-time resolution in `agent-args.ts`. Session-override-first is arguably correct there, since it runs before any provider report exists.

## Behaviour change (review of #1356, item 1)

Authority was originally inferred by comparing each model's reported window against the injected 200000 fallback seed, so a provider reporting **at or below** 200k lost its authority and the stored `customContextWindow` won again - the same failure this PR exists to fix, just below the seed instead of above it. The max is now taken across *reported* windows only.

**This moves the returned `contextWindow`, not just the flag.** A model reporting `150000` now yields `150000` instead of `200000`, so `getContextPercentage` shifts for that path. That is a fix rather than a regression - the denominator becomes the real one - but it is a real behaviour change and is called out here rather than slipped in.

## Codex mid-turn denominator flap (review of #1356, item 2)

`turn_context` cached the reported window on the parser instance but `token_count` did not. With `model_context_window` present in `token_count` only, one turn produced two denominators: `token_count` -> real window / resolved / rank 2, then `turn.completed` -> config seed / unresolved / rank 3 and the stored override. The `token_count` branch now caches both fields.

## Follow-up, deliberately not in this PR

Rank 3 means a genuinely deliberate `customContextWindow` is silently outranked once the provider reports. Distinguishing "materialized at creation" from "user edited" needs a provenance flag plus a migration decision for every value already stored without one, so it is recorded as finding AD1 for a follow-up alongside R1/S1 rather than folded in here.

## Testing

Scoped only, no full-suite run. Item 1 widened the blast radius beyond the original 7 files, so every test touching the aggregated usage shape was swept: **1993** passing across main + CLI (parsers, process-manager, process-listeners, CLI) and **8306** across renderer hooks/utils/stores. Three exhaustive `toEqual` assertions (`process-manager.test.ts` x2, `agent-spawner.test.ts`) and two tests that had encoded the old value-comparison behaviour were updated to the corrected contract rather than worked around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context-window selection for usage displays and session calculations.
  * Provider-reported values now take precedence over session overrides and fallback values.
  * Explicit model context limits, including `[1m]`, are prioritized correctly.
  * Fallback and configured values are no longer presented as provider-confirmed limits.
  * Context-window handling is now consistent across supported providers.

* **Tests**
  * Added coverage for provider-reported values, fallback handling, and precedence rules across usage tracking and context-window displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
