### PR TITLE
fix(opencode): narrow session_not_found regex to opencode's real erro…

### DIFF
--- a/src/__tests__/main/group-chat/session-recovery.test.ts
+++ b/src/__tests__/main/group-chat/session-recovery.test.ts
@@ -162,28 +162,28 @@ describe('group-chat/session-recovery', () => {
 			expect(detectSessionNotFoundError(output)).toBe(true);
 		});
 
-		it('should return true for raw pattern "session was not found"', () => {
+		it('should NOT match "session was not found" (words separated by other text)', () => {
 			mockedGetErrorPatterns.mockReturnValue({});
 			mockedMatchErrorPattern.mockReturnValue(null);
 
 			const output = 'The session was not found in the system';
-			expect(detectSessionNotFoundError(output)).toBe(true);
+			expect(detectSessionNotFoundError(output)).toBe(false);
 		});
 
-		it('should return true for raw pattern "invalid session id"', () => {
+		it('should NOT match "invalid session id"', () => {
 			mockedGetErrorPatterns.mockReturnValue({});
 			mockedMatchErrorPattern.mockReturnValue(null);
 
 			const output = 'Error: invalid session id provided';
-			expect(detectSessionNotFoundError(output)).toBe(true);
+			expect(detectSessionNotFoundError(output)).toBe(false);
 		});
 
-		it('should return true for raw pattern "Invalid Session ID" (case insensitive)', () => {
+		it('should NOT match "Invalid Session ID" (case insensitive)', () => {
 			mockedGetErrorPatterns.mockReturnValue({});
 			mockedMatchErrorPattern.mockReturnValue(null);
 
 			const output = 'Invalid Session ID: abc-123';
-			expect(detectSessionNotFoundError(output)).toBe(true);
+			expect(detectSessionNotFoundError(output)).toBe(false);
 		});
 
 		it('should return false when output contains unrelated errors', () => {
@@ -199,7 +199,7 @@ describe('group-chat/session-recovery', () => {
 			mockedMatchErrorPattern.mockReturnValue(null);
 
 			// The raw patterns test against the full output string
-			const output = 'Line 1: some normal output\nLine 2: invalid session id found\nLine 3: done';
+			const output = 'Line 1: some normal output\nLine 2: Session not found\nLine 3: done';
 			expect(detectSessionNotFoundError(output)).toBe(true);
 		});
 

--- a/src/__tests__/main/parsers/error-patterns.test.ts
+++ b/src/__tests__/main/parsers/error-patterns.test.ts
@@ -142,6 +142,38 @@ describe('error-patterns', () => {
 				}
 			});
 		});
+
+		describe('session_not_found patterns', () => {
+			// Verified: opencode-ai v1.18.15, run locally.
+			// `opencode run "hi" --session ses_<bad-id>` -> "Error: Session not found"
+			// `opencode export ses_<bad-id>` -> "Error: Session not found: ses_<bad-id>"
+			it('should match the bare "Error: Session not found"', () => {
+				const result = matchErrorPattern(OPENCODE_ERROR_PATTERNS, 'Error: Session not found');
+				expect(result).not.toBeNull();
+				expect(result?.type).toBe('session_not_found');
+				expect(result?.recoverable).toBe(true);
+			});
+
+			it('should match "Session not found: ses_<id>"', () => {
+				const result = matchErrorPattern(
+					OPENCODE_ERROR_PATTERNS,
+					'Session not found: ses_abc123def456'
+				);
+				expect(result?.type).toBe('session_not_found');
+			});
+
+			it('should NOT match unrelated lines that merely mention "session" and "not found" separately', () => {
+				const falsePositives = [
+					'the session config file was not found',
+					'session store connection lost; retry not found necessary',
+				];
+
+				for (const text of falsePositives) {
+					const result = matchErrorPattern(OPENCODE_ERROR_PATTERNS, text);
+					expect(result).toBeNull();
+				}
+			});
+		});
 	});
 
 	describe('CODEX_ERROR_PATTERNS', () => {

--- a/src/__tests__/renderer/components/TerminalOutput.test.tsx
+++ b/src/__tests__/renderer/components/TerminalOutput.test.tsx
@@ -3000,6 +3000,11 @@ describe('TerminalOutput', () => {
 				tabs: [
 					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showThinking: 'on' },
 				],
+				// TerminalOutput's activeTab memo keys off the real `aiTabs` field (this
+				// suite's `tabs` fixture only feeds the mocked getActiveTab), so a rerender
+				// that only changes `tabs` never busts the memo. Give it a real reference to
+				// depend on; content is irrelevant since getActiveTab still reads `tabs`.
+				aiTabs: [] as any,
 				activeTabId: 'tab-1',
 			});
 
@@ -3059,6 +3064,8 @@ describe('TerminalOutput', () => {
 						isUnread: false,
 					},
 				],
+				// New reference so the activeTab memo (keyed on aiTabs) actually recomputes.
+				aiTabs: [{}] as any,
 			};
 			rerender(<TerminalOutput {...createDefaultProps({ session: newSession })} />);
 			await act(async () => {

--- a/src/main/group-chat/session-recovery.ts
+++ b/src/main/group-chat/session-recovery.ts
@@ -49,11 +49,13 @@ export function detectSessionNotFoundError(output: string, agentId?: string): bo
 		}
 	}
 
-	// Also check for raw error message that might not be in JSON format
+	// Also check for raw error message that might not be in JSON format.
+	// Anchored to the literal phrases each agent actually emits, not broad
+	// `.*` wildcards, which would match any line that merely mentions both
+	// words.
 	const sessionNotFoundPatterns = [
 		/no conversation found with session id/i,
-		/session.*not found/i,
-		/invalid.*session.*id/i,
+		/\bsession not found\b/i,
 	];
 
 	for (const pattern of sessionNotFoundPatterns) {

--- a/src/main/parsers/error-patterns.ts
+++ b/src/main/parsers/error-patterns.ts
@@ -366,13 +366,21 @@ const OPENCODE_ERROR_PATTERNS: AgentErrorPatterns = {
 
 	session_not_found: [
 		{
-			pattern: /session.*not found/i,
+			// Verified: opencode-ai v1.18.15, run locally against a nonexistent
+			// session ID. `opencode run "hi" --session ses_<bad-id>` exits 1 with
+			// stderr "Error: Session not found" (bare). `opencode export
+			// ses_<bad-id>` exits 1 with stderr "Error: Session not found:
+			// ses_<bad-id>" (ID appended after a colon). Anchored to this literal
+			// phrase so unrelated lines that merely mention both words don't
+			// trigger a discard-and-respawn.
+			//
+			// Note: opencode itself surfaces this exact string for causes other
+			// than a truly deleted session (OPENCODE_SERVER_PASSWORD auth
+			// mismatches, corrupted session JSON) - Maestro can't distinguish
+			// those from a real deletion once opencode has collapsed them into
+			// the same message.
+			pattern: /\bsession not found\b/i,
 			message: 'Session not found. Starting fresh conversation.',
-			recoverable: true,
-		},
-		{
-			pattern: /invalid.*session/i,
-			message: 'Invalid session. Starting fresh conversation.',
 			recoverable: true,
 		},
 	],


### PR DESCRIPTION
…r text

fix(opencode): narrow session_not_found regex to opencode's real error text

Both the per-agent pattern and the group-chat recovery fallback used `/session.*not found/i`, a wildcard that matches those two words anywhere on a line regardless of what sits between them. A false match discards a working agentSessionId and silently respawns the agent, losing conversation continuity.

Anchored to opencode's actual literal text instead, verified by running opencode-ai v1.18.15 locally against a nonexistent session ID: "Error: Session not found" (bare, from `run --session`) and "Error: Session not found: ses_<id>" (from `export`).

Also dropped `invalid.*session` / `invalid.*session.*id` from both locations - no real opencode output was found to match either pattern, so they were unverified guesses carrying the same false-positive risk.

Added session_not_found coverage for OPENCODE_ERROR_PATTERNS and updated the three session-recovery tests that had encoded the old broad-match behavior as correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session-recovery detection for missing sessions.
  - Prevented unrelated messages, such as “session was not found” or “invalid session id,” from incorrectly triggering recovery.
  - Added support for recognized “session not found” errors from OpenCode, including messages with session IDs.
  - Improved handling of case variations and multiline error messages.
  - Reduced unnecessary recovery attempts when errors do not indicate a genuinely missing session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->