### PR TITLE
fix(process-manager): never hand node-pty a signal on Windows (MAESTRO-XZ)

### DIFF
--- a/src/__tests__/main/process-manager/ProcessManager.ptyKill.test.ts
+++ b/src/__tests__/main/process-manager/ProcessManager.ptyKill.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { mockPtySpawn, mockChildSpawn, mockExecFile, mockExecFileSync, mockIsWindows } = vi.hoisted(
+	() => ({
+		mockPtySpawn: vi.fn(),
+		mockChildSpawn: vi.fn(),
+		mockExecFile: vi.fn(),
+		mockExecFileSync: vi.fn(),
+		mockIsWindows: vi.fn(() => true),
+	})
+);
+
+vi.mock('node-pty', () => ({
+	spawn: mockPtySpawn,
+}));
+
+vi.mock('child_process', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('child_process')>();
+	const overrides = {
+		spawn: mockChildSpawn,
+		execFile: mockExecFile,
+		execFileSync: mockExecFileSync,
+	};
+	return {
+		...actual,
+		...overrides,
+		default: { ...actual, ...overrides },
+	};
+});
+
+vi.mock('../../../main/utils/logger', () => ({
+	logger: {
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+vi.mock('../../../shared/platformDetection', () => ({
+	isWindows: () => mockIsWindows(),
+}));
+
+vi.mock('../../../main/coworking/coworking-socket-path', () => ({
+	getBridgeSocketPath: () => '/tmp/maestro-test-coworking.sock',
+}));
+
+import { ProcessManager } from '../../../main/process-manager';
+
+/**
+ * A node-pty `IPty` that reproduces the Windows backend's two defining
+ * behaviours, because both are load-bearing for this regression:
+ *
+ *  1. Any signal argument throws `Signals not supported on windows.`
+ *  2. The call is QUEUED as a deferred until the ConPTY agent reports ready,
+ *     and the queue is later flushed from a socket `data` handler.
+ *
+ * (2) is why a try/catch at the call site does not contain the throw: it
+ * surfaces on an unrelated stack as an uncaught exception. `flushDeferreds()`
+ * stands in for that socket event.
+ */
+class FakeWindowsPty {
+	/** ConPTY reports pid 0 when the shell fails to launch - the field case. */
+	pid = 0;
+	kill = vi.fn((signal?: string) => {
+		const run = () => {
+			if (signal) throw new Error('Signals not supported on windows.');
+		};
+		if (this.isReady) {
+			run();
+			return;
+		}
+		this.deferreds.push(run);
+	});
+	onData = vi.fn();
+	onExit = vi.fn();
+	write = vi.fn();
+	resize = vi.fn();
+
+	private isReady = false;
+	private deferreds: Array<() => void> = [];
+
+	flushDeferreds(): void {
+		this.isReady = true;
+		const queued = this.deferreds;
+		this.deferreds = [];
+		for (const fn of queued) fn();
+	}
+}
+
+function spawnTerminal(pm: ProcessManager, sessionId: string) {
+	return pm.spawn({
+		sessionId,
+		toolType: 'terminal',
+		cwd: '/tmp/project',
+		command: 'bash',
+		args: [],
+	});
+}
+
+describe('ProcessManager PTY kill on Windows (MAESTRO-XZ)', () => {
+	let fakePty: FakeWindowsPty;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockIsWindows.mockReturnValue(true);
+		fakePty = new FakeWindowsPty();
+		mockPtySpawn.mockReturnValue(fakePty);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('never hands node-pty a signal when the ConPTY pid is unavailable', () => {
+		const pm = new ProcessManager();
+		spawnTerminal(pm, 'win-no-pid');
+
+		pm.kill('win-no-pid');
+
+		expect(fakePty.kill).toHaveBeenCalledTimes(1);
+		// The argument itself is the bug: any truthy signal throws on Windows.
+		expect(fakePty.kill).toHaveBeenCalledWith(undefined);
+	});
+
+	it('does not raise a deferred exception once the ConPTY agent becomes ready', () => {
+		const pm = new ProcessManager();
+		spawnTerminal(pm, 'win-deferred');
+
+		pm.kill('win-deferred');
+
+		// Before the fix this threw `Signals not supported on windows.` from the
+		// socket data handler, escaping the caller's try/catch as a fatal.
+		expect(() => fakePty.flushDeferreds()).not.toThrow();
+	});
+
+	it('sends no signal on the shutdown path either', () => {
+		const pm = new ProcessManager();
+		spawnTerminal(pm, 'win-shutdown');
+
+		pm.killAll({ shutdown: true });
+
+		expect(fakePty.kill).toHaveBeenCalledWith(undefined);
+		expect(() => fakePty.flushDeferreds()).not.toThrow();
+	});
+
+	it('sends no signal when the SIGTERM escalation timer fires', () => {
+		vi.useFakeTimers();
+		const pm = new ProcessManager();
+		spawnTerminal(pm, 'win-escalation');
+
+		pm.kill('win-escalation');
+		vi.advanceTimersByTime(5000);
+
+		expect(fakePty.kill).toHaveBeenCalledTimes(2);
+		for (const call of fakePty.kill.mock.calls) {
+			expect(call[0]).toBeUndefined();
+		}
+		expect(() => fakePty.flushDeferreds()).not.toThrow();
+	});
+
+	it('still kills the whole tree via taskkill when a real pid is known', () => {
+		fakePty.pid = 4242;
+		const pm = new ProcessManager();
+		spawnTerminal(pm, 'win-with-pid');
+
+		pm.kill('win-with-pid');
+
+		expect(mockExecFile).toHaveBeenCalledWith(
+			'taskkill',
+			['/pid', '4242', '/t', '/f'],
+			expect.any(Function)
+		);
+		expect(fakePty.kill).not.toHaveBeenCalled();
+	});
+
+	it('still delivers real POSIX signals off Windows', () => {
+		mockIsWindows.mockReturnValue(false);
+		const pm = new ProcessManager();
+		spawnTerminal(pm, 'posix-kill');
+
+		pm.kill('posix-kill');
+
+		expect(fakePty.kill).toHaveBeenCalledWith('SIGTERM');
+	});
+});

--- a/src/main/process-manager/ProcessManager.ts
+++ b/src/main/process-manager/ProcessManager.ts
@@ -21,6 +21,7 @@ import { expandTilde } from '../../shared/pathUtils';
 import type { SshRemoteConfig } from '../../shared/types';
 import { getDefaultShell } from '../stores/defaults';
 import { captureException } from '../utils/sentry';
+import { killPty } from './utils/commandKill';
 
 /** Time (ms) to wait for a PTY process to exit after SIGTERM before sending SIGKILL. */
 const PTY_KILL_ESCALATION_MS = 2000;
@@ -271,7 +272,7 @@ export class ProcessManager extends EventEmitter {
 					// reaches EOF, node-pty's worker thread exits, and its TSFN releases
 					// before Electron's environment teardown runs CleanupHandles.
 					try {
-						proc.ptyProcess.kill('SIGKILL');
+						killPty(proc.ptyProcess, 'SIGKILL');
 					} catch {
 						// Process may already be dead
 					}
@@ -281,7 +282,7 @@ export class ProcessManager extends EventEmitter {
 
 					// Use SIGTERM (not the default SIGHUP which shells may survive on macOS)
 					try {
-						ptyProc.kill('SIGTERM');
+						killPty(ptyProc, 'SIGTERM');
 					} catch {
 						// Process may already be dead
 					}
@@ -289,7 +290,7 @@ export class ProcessManager extends EventEmitter {
 					// Escalate to SIGKILL if the process doesn't exit promptly.
 					const escalationTimer = setTimeout(() => {
 						try {
-							ptyProc.kill('SIGKILL');
+							killPty(ptyProc, 'SIGKILL');
 							logger.warn(
 								'[ProcessManager] PTY did not exit after SIGTERM, escalated to SIGKILL',
 								'ProcessManager',

--- a/src/main/process-manager/utils/commandKill.ts
+++ b/src/main/process-manager/utils/commandKill.ts
@@ -1,5 +1,7 @@
 // src/main/process-manager/utils/commandKill.ts
 
+import type * as pty from 'node-pty';
+
 import { execFileNoThrow, execFileSyncNoThrow } from '../../utils/execFile';
 import { logger } from '../../utils/logger';
 import { isWindows } from '../../../shared/platformDetection';
@@ -111,6 +113,31 @@ export function killProcessTreeNow(pid: number, context: { sessionId: string }):
 		pid,
 		descendants: descendants.length,
 	});
+}
+
+/**
+ * Kill a PTY, dropping the POSIX signal on Windows.
+ *
+ * node-pty's Windows backend throws `Signals not supported on windows.` for any
+ * signal argument at all - it only implements the no-argument form, which closes
+ * the pty and kills the ConPTY/winpty agent. On POSIX the signal is honoured, so
+ * it is passed straight through.
+ *
+ * A plain try/catch around `ptyProcess.kill(signal)` does NOT contain that throw.
+ * node-pty queues the call as a *deferred* whenever the agent has not signalled
+ * ready yet, and later runs the queue from a socket `data` handler - so the throw
+ * surfaces on a completely different stack, escapes as an uncaught exception, and
+ * takes the main process down (Sentry MAESTRO-XZ: 822 fatal events from a single
+ * Windows install). Callers must therefore never hand node-pty a signal on
+ * Windows, rather than trying to catch what it throws.
+ *
+ * Windows PTYs are normally torn down by pid with `taskkill /t /f`, which also
+ * gets grandchildren. This path is what remains when the pid is unavailable -
+ * ConPTY reports pid 0 when the shell fails to launch - and a signal-less kill()
+ * is then the only correct call.
+ */
+export function killPty(ptyProcess: pty.IPty, signal: NodeJS.Signals): void {
+	ptyProcess.kill(isWindows() ? undefined : signal);
 }
 
 /**


### PR DESCRIPTION
## Sentry triage: `main` / `channel:stable`

Fixes **[MAESTRO-XZ](https://smash-labs.sentry.io/issues/MAESTRO-XZ)** - `Error: Signals not supported on windows.`
822 fatal events, `handled: no`, 100% `channel:stable` on release **0.17.4** (main's current `package.json`; `rc` is on `0.18.5-RC`).

### Root cause

node-pty's Windows backend implements only the **no-argument** form of `kill()`:

```js
WindowsTerminal.prototype.kill = function (signal) {
    this._deferNoArgs(function () {
        if (signal) { throw new Error('Signals not supported on windows.'); }
        this._close(); this._agent.kill();
    });
};
```

Two things combine to make this fatal rather than merely wrong:

1. **Any** signal argument throws - there is no supported signal on Windows.
2. `_deferNoArgs` **queues** the call whenever the ConPTY agent has not signalled ready, and the queue is later flushed from a socket `data` handler.

Because of (2) the throw surfaces on a completely unrelated stack, so the `try/catch` already wrapped around every call site never sees it and the exception escapes uncaught. The reported stack is exactly that flush:

```
Socket.emit -> onceWrapper -> windowsTerminal.js:70 _deferreds.forEach
  -> fn.run() -> throw new Error('Signals not supported on windows.')
```

### Why it stayed hidden

`ProcessManager.kill()` normally tears a Windows PTY down by pid with `taskkill /t /f`. The signal-passing branches are reached only when `proc.pid` is falsy - and ConPTY reports **pid 0** when the shell fails to launch. A failing shell then gets retried, and each attempt queues another throwing deferred, which is how one install produced 822 events in a 16-minute window.

### The fix

A `killPty()` helper in `commandKill.ts` (which already owns kill semantics and `isWindows`) drops the signal on Windows and passes it through untouched on POSIX. The three reachable `ProcessManager` sites route through it: the shutdown SIGKILL, the SIGTERM, and the SIGKILL escalation.

Signal-less `kill()` is the *correct* Windows teardown - it runs `_close()` + `_agent.kill()`, which is the ConPTY/winpty native kill.

Out of scope, deliberately: `LocalCommandRunner`'s PTY kill is already behind `!isWindows()`, so it cannot fire.

### Tests

`ProcessManager.ptyKill.test.ts` uses a node-pty-faithful fake reproducing **both** the throw-on-signal rule and the ready/deferred queue, so the regression is proved where it actually fired rather than at the call site. All 6 confirmed red against unfixed source (4 fail with the literal field message; the taskkill and POSIX control cases stay green, showing those paths are unchanged).

### Validation

- `npx tsc --noEmit` - 112 errors, byte-identical to the clean-`main` baseline, none in changed files
- ESLint + Prettier clean on changed files
- `process-manager` suites: 309 passed. `ChildProcessSpawner.test.ts` fails identically on clean `main` (pre-existing `promisify(execFile)` mock gap), verified by stashing.

### Also triaged, no change warranted

- `MAESTRO-1G` (`write EPIPE`), `MAESTRO-JS` (grooming spawn) - already fixed on `main` by #1311, but post-`v0.17.3`, so the field events are pre-fix. Verified with `git merge-base --is-ancestor`.
- `MAESTRO-RS` (better-sqlite3 GLIBC_2.38, 453 occ) - Linux build/CI glibc target, still needs a human.
- `MAESTRO-62`, `SG`/`QG`/`1F`/`RB`/`XM` - native/GPU crashes with no app frames.

### Follow-up (not in this PR)

`src/maestro-p/tui-driver.ts:404` calls `this.ptyProcess.kill('SIGKILL')` with no platform guard - the identical bug class, now a one-line `killPty()` swap. There is no field evidence for it, so I left it out to keep this PR scoped; happy to fold it in if you'd like.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows process termination to avoid delayed errors when stopping terminal sessions.
  * Ensured immediate, graceful, and forced shutdowns work reliably across Windows and POSIX systems.
  * Preserved signal-based termination behavior on POSIX systems.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->