### PR TITLE
fix(context): record whether a customContextWindow was deliberately set (AD1)

### DIFF
--- a/src/__tests__/cli/commands/create-agent.test.ts
+++ b/src/__tests__/cli/commands/create-agent.test.ts
@@ -52,6 +52,30 @@ describe('create-agent command', () => {
 			expect(processExitSpy).not.toHaveBeenCalled();
 		});
 
+		it('does not record provenance when --context-window is not passed', async () => {
+			let sentPayload: Record<string, unknown> = {};
+			vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+				const mockClient = {
+					sendCommand: vi.fn().mockImplementation((payload) => {
+						sentPayload = payload;
+						return Promise.resolve({
+							type: 'create_session_result',
+							success: true,
+							sessionId: 'id-1',
+						});
+					}),
+				};
+				return action(mockClient as never);
+			});
+
+			await createAgent('Agent', { cwd: '/tmp', type: 'codex', model: 'gpt-4' });
+
+			// No window, so nothing to describe. A provenance marker with no value
+			// would outrank the provider's report on whatever gets set later.
+			expect(sentPayload.customContextWindow).toBeUndefined();
+			expect(sentPayload.contextWindowSource).toBeUndefined();
+		});
+
 		it('should send config fields when provided', async () => {
 			let sentPayload: Record<string, unknown> = {};
 			vi.mocked(withMaestroClient).mockImplementation(async (action) => {
@@ -89,6 +113,11 @@ describe('create-agent command', () => {
 			expect(sentPayload.customPath).toBe('/usr/local/bin/codex');
 			expect(sentPayload.customArgs).toBe('--verbose');
 			expect(sentPayload.customContextWindow).toBe(128000);
+			// Typing the flag is a deliberate choice, so it must carry provenance or
+			// the provider's reported window silently overrides it and the user has
+			// to re-apply the same number with `update-agent` (finding AD1, review
+			// of PR #1362). `update-agent` already did this; `create-agent` did not.
+			expect(sentPayload.contextWindowSource).toBe('user-edited');
 			expect(sentPayload.customProviderPath).toBe('/custom/path');
 			expect(sentPayload.customEnvVars).toEqual({ FOO: 'bar', BAZ: 'qux' });
 		});

--- a/src/__tests__/main/web-server/handlers/createSessionProvenance.test.ts
+++ b/src/__tests__/main/web-server/handlers/createSessionProvenance.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @file createSessionProvenance.test.ts
+ * @description `handleCreateSession` builds its `CreateSessionConfig` from an
+ * explicit allowlist, so a field the CLI sends is silently dropped unless it is
+ * named there. Finding AD1's `contextWindowSource` is exactly that shape - the
+ * same failure mode as the `EDITABLE_KEYS` allowlist in the remote patch
+ * applier (review of PR #1362).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleCreateSession } from '../../../../main/web-server/handlers/messageHandlers/sessions';
+import type {
+	WebClient,
+	WebClientMessage,
+	MessageHandlerContext,
+} from '../../../../main/web-server/handlers/messageHandlers/types';
+import type { CreateSessionConfig } from '../../../../main/web-server/types';
+
+let createSession: ReturnType<typeof vi.fn>;
+
+/** Minimal context: only the createSession callback and the send/error sinks. */
+function makeCtx(): MessageHandlerContext {
+	return {
+		send: vi.fn(),
+		sendError: vi.fn(),
+		callbacks: { createSession },
+	} as unknown as MessageHandlerContext;
+}
+
+/** Dispatch a create_session message and return the config the callback saw. */
+function created(message: Partial<WebClientMessage>): CreateSessionConfig | undefined {
+	handleCreateSession(
+		makeCtx(),
+		{} as WebClient,
+		{
+			name: 'Agent',
+			toolType: 'codex',
+			cwd: '/tmp',
+			...message,
+		} as WebClientMessage
+	);
+	expect(createSession).toHaveBeenCalled();
+	return createSession.mock.calls[0][4] as CreateSessionConfig | undefined;
+}
+
+beforeEach(() => {
+	createSession = vi.fn().mockResolvedValue({ sessionId: 'new-1' });
+});
+
+describe('handleCreateSession - context window provenance (finding AD1)', () => {
+	it('passes contextWindowSource through the config allowlist', () => {
+		const config = created({
+			customContextWindow: 120000,
+			contextWindowSource: 'user-edited',
+		});
+
+		expect(config?.customContextWindow).toBe(120000);
+		// Without the allowlist entry the number arrives but its provenance does
+		// not, so `maestro-cli create-agent --context-window` is silently
+		// overridden by the provider's report - the harm AD1 exists to remove.
+		expect(config?.contextWindowSource).toBe('user-edited');
+	});
+
+	it('leaves provenance unset when the CLI did not send it', () => {
+		const config = created({ customContextWindow: 200000 });
+
+		expect(config?.customContextWindow).toBe(200000);
+		// Absence is the materialized signal, so it must stay absent rather than
+		// being defaulted to anything.
+		expect(config?.contextWindowSource).toBeUndefined();
+	});
+
+	it('ignores a provenance value it does not recognise', () => {
+		// The field crosses a process boundary from an untrusted client, so only
+		// the one supported value is accepted.
+		const config = created({
+			customContextWindow: 200000,
+			contextWindowSource: 'something-else',
+		});
+
+		expect(config?.contextWindowSource).toBeUndefined();
+	});
+});

--- a/src/__tests__/main/web-server/handlers/createSessionProvenance.test.ts
+++ b/src/__tests__/main/web-server/handlers/createSessionProvenance.test.ts
@@ -70,6 +70,16 @@ describe('handleCreateSession - context window provenance (finding AD1)', () => 
 		expect(config?.contextWindowSource).toBeUndefined();
 	});
 
+	it('ignores provenance sent without a context window', () => {
+		// Provenance describes a value. A source-only payload would leave a marker
+		// with nothing to describe, and that orphan would then outrank a provider
+		// report for whatever window is set later (review of PR #1362).
+		const config = created({ contextWindowSource: 'user-edited' });
+
+		expect(config?.customContextWindow).toBeUndefined();
+		expect(config?.contextWindowSource).toBeUndefined();
+	});
+
 	it('ignores a provenance value it does not recognise', () => {
 		// The field crosses a process boundary from an untrusted client, so only
 		// the one supported value is accepted.

--- a/src/__tests__/renderer/components/NewInstanceModal/EditAgentModal.test.tsx
+++ b/src/__tests__/renderer/components/NewInstanceModal/EditAgentModal.test.tsx
@@ -916,6 +916,32 @@ describe('EditAgentModal', () => {
 			expect(args[18]).toBeUndefined();
 		});
 
+		it('clears provenance when the user clears the context window', async () => {
+			// Review of PR #1362 (CodeRabbit). Clearing the control makes the value
+			// undefined, which differs from the numeric seed and so used to be
+			// recorded as a deliberate edit. Provenance must die with the value it
+			// describes, or the NEXT window set inherits precedence nobody asked for.
+			render(
+				<EditAgentModal
+					isOpen={true}
+					onClose={onClose}
+					onSave={onSave}
+					theme={theme}
+					session={createSession({ contextWindowSource: 'user-edited' })}
+					existingSessions={[]}
+				/>
+			);
+
+			const input = await screen.findByDisplayValue('100000');
+			fireEvent.change(input, { target: { value: '' } });
+
+			fireEvent.click(screen.getByText('Save Changes'));
+
+			const args = onSave.mock.calls[0];
+			expect(args[10]).toBeUndefined();
+			expect(args[18]).toBeUndefined();
+		});
+
 		it('marks a context window the user actually changed as user-edited', async () => {
 			render(
 				<EditAgentModal

--- a/src/__tests__/renderer/components/NewInstanceModal/EditAgentModal.test.tsx
+++ b/src/__tests__/renderer/components/NewInstanceModal/EditAgentModal.test.tsx
@@ -330,7 +330,9 @@ describe('EditAgentModal', () => {
 				undefined,
 				true,
 				true,
-				undefined // additionalDirectories
+				undefined, // additionalDirectories
+				undefined // contextWindowSource: the window was not touched, so no
+				// provenance is recorded and P1 precedence stands (finding AD1)
 			);
 		});
 
@@ -425,7 +427,9 @@ describe('EditAgentModal', () => {
 			undefined, // maestroPMode
 			true, // retryOnAvailabilityErrors
 			true, // retryOnTokenExhaustion
-			undefined // additionalDirectories
+			undefined, // additionalDirectories
+			undefined // contextWindowSource: the window was not touched, so no
+			// provenance is recorded and P1 precedence stands (finding AD1)
 		);
 		expect(onClose).toHaveBeenCalled();
 	});
@@ -657,7 +661,9 @@ describe('EditAgentModal', () => {
 			undefined, // maestroPMode
 			true, // retryOnAvailabilityErrors
 			true, // retryOnTokenExhaustion
-			undefined // additionalDirectories
+			undefined, // additionalDirectories
+			undefined // contextWindowSource: the window was not touched, so no
+			// provenance is recorded and P1 precedence stands (finding AD1)
 		);
 	});
 
@@ -729,7 +735,9 @@ describe('EditAgentModal', () => {
 			undefined, // maestroPMode
 			true, // retryOnAvailabilityErrors
 			true, // retryOnTokenExhaustion
-			undefined // additionalDirectories
+			undefined, // additionalDirectories
+			undefined // contextWindowSource: the window was not touched, so no
+			// provenance is recorded and P1 precedence stands (finding AD1)
 		);
 	});
 
@@ -807,7 +815,9 @@ describe('EditAgentModal', () => {
 			undefined, // maestroPMode
 			true, // retryOnAvailabilityErrors
 			true, // retryOnTokenExhaustion
-			undefined // additionalDirectories
+			undefined, // additionalDirectories
+			undefined // contextWindowSource: the window was not touched, so no
+			// provenance is recorded and P1 precedence stands (finding AD1)
 		);
 	});
 
@@ -839,6 +849,93 @@ describe('EditAgentModal', () => {
 		// SSH selector should appear after SSH configs load
 		await waitFor(() => {
 			expect(screen.getByText('SSH Remote Execution')).toBeInTheDocument();
+		});
+	});
+
+	// Finding AD1: provenance for `customContextWindow`.
+	describe('context window provenance (finding AD1)', () => {
+		const agentWithWindow = {
+			id: 'claude-code',
+			name: 'Claude Code',
+			available: true,
+			path: '/usr/local/bin/claude',
+			binaryName: 'claude',
+			hidden: false,
+			configOptions: [
+				{ key: 'model', type: 'text', label: 'Model', default: '' },
+				{
+					key: 'contextWindow',
+					type: 'number',
+					label: 'Context Window Size',
+					default: 200000,
+				},
+			],
+		} as unknown as AgentConfig;
+
+		beforeEach(() => {
+			vi.mocked(window.maestro.agents.detect).mockResolvedValue([agentWithWindow]);
+			vi.mocked(window.maestro.agents.getConfig).mockResolvedValue({
+				model: 'claude-sonnet',
+				contextWindow: 200000,
+			});
+		});
+
+		// Finding AD1. This modal is HOW the agent-level default gets materialized
+		// into a per-session override (finding P1): with no stored value the panel
+		// seeds from `globalConfig.contextWindow`, and pressing Save writes that
+		// number to the session. If that write were recorded as 'user-edited' it
+		// would outrank the provider's own report and reinstate the exact bug P1
+		// removed - so the seed comparison, not the presence of a value, is what
+		// decides provenance.
+		it('does not mark an untouched seeded context window as user-edited', async () => {
+			const { customContextWindow: _drop, ...withoutWindow } = createSession() as Record<
+				string,
+				unknown
+			>;
+
+			render(
+				<EditAgentModal
+					isOpen={true}
+					onClose={onClose}
+					onSave={onSave}
+					theme={theme}
+					session={withoutWindow as unknown as Session}
+					existingSessions={[]}
+				/>
+			);
+
+			// Seeded from the agent-level config because the session has none.
+			expect(await screen.findByDisplayValue('200000')).toBeInTheDocument();
+
+			fireEvent.click(screen.getByText('Save Changes'));
+
+			const args = onSave.mock.calls[0];
+			// The value still materializes onto the session, exactly as before...
+			expect(args[10]).toBe(200000);
+			// ...but carries no provenance, so P1's precedence still applies to it.
+			expect(args[18]).toBeUndefined();
+		});
+
+		it('marks a context window the user actually changed as user-edited', async () => {
+			render(
+				<EditAgentModal
+					isOpen={true}
+					onClose={onClose}
+					onSave={onSave}
+					theme={theme}
+					session={createSession()}
+					existingSessions={[]}
+				/>
+			);
+
+			const input = await screen.findByDisplayValue('100000');
+			fireEvent.change(input, { target: { value: '120000' } });
+
+			fireEvent.click(screen.getByText('Save Changes'));
+
+			const args = onSave.mock.calls[0];
+			expect(args[10]).toBe(120000);
+			expect(args[18]).toBe('user-edited');
 		});
 	});
 });

--- a/src/__tests__/renderer/hooks/agent/internal/useAgentUsageListener.test.tsx
+++ b/src/__tests__/renderer/hooks/agent/internal/useAgentUsageListener.test.tsx
@@ -309,6 +309,39 @@ describe('useAgentUsageListener', () => {
 		expect(last.percentage).toBe(10); // round(100000 / 1000000 * 100)
 	});
 
+	// Finding AD1, and the timeline half of the pair. useContextWindow has the
+	// positionally identical case; if only one of the two learns about
+	// provenance the header gauge and the Context Timeline disagree again, which
+	// is exactly the bug PR #1221 fixed.
+	it('keeps a user-edited window above a resolved reported window', () => {
+		const session = createMockSession({
+			id: 'sess-1',
+			toolType: 'omp',
+			customContextWindow: 120000,
+			contextWindowSource: 'user-edited',
+		});
+		useSessionStore.setState({ sessions: [session] });
+
+		const batched = makeBatched();
+		renderHook(() =>
+			useAgentUsageListener({ batchedUpdater: batched, contextWarningYellowThreshold: 80 })
+		);
+
+		handler!('sess-1', {
+			inputTokens: 60000,
+			outputTokens: 0,
+			cacheReadInputTokens: 0,
+			cacheCreationInputTokens: 0,
+			contextWindow: 1000000,
+			contextWindowResolved: true,
+		});
+
+		const points = useContextTimelineStore.getState().buffers['sess-1']?.points ?? [];
+		const last = points[points.length - 1];
+		expect(last.contextWindow).toBe(120000);
+		expect(last.percentage).toBe(50); // round(60000 / 120000 * 100)
+	});
+
 	it('keeps an unresolved reported window below the per-session override', () => {
 		// Without the `contextWindowResolved` flag the reported value may be a
 		// parser-injected static fallback, so the stored override still wins.

--- a/src/__tests__/renderer/hooks/useAppRemoteEventListeners.configPatch.test.ts
+++ b/src/__tests__/renderer/hooks/useAppRemoteEventListeners.configPatch.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @file useAppRemoteEventListeners.configPatch.test.ts
+ * @description Covers the `maestro:remoteUpdateSessionConfig` branch, which
+ * applies `maestro-cli update-agent` patches to a session. Scoped to the
+ * context-window provenance rules from finding AD1: the allowlist has to carry
+ * `contextWindowSource`, and clearing the window has to clear its provenance.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, cleanup } from '@testing-library/react';
+import { useAppRemoteEventListeners } from '../../../renderer/hooks/remote/useAppRemoteEventListeners';
+import type { Session } from '../../../renderer/types';
+
+const RESPONSE_CHANNEL = 'remote:updateSessionConfig:response:test';
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+	return {
+		id: 'session-1',
+		name: 'Agent',
+		toolType: 'claude-code',
+		projectRoot: '/project',
+		cwd: '/project',
+		aiTabs: [],
+		activeTabId: null,
+		...overrides,
+	} as unknown as Session;
+}
+
+/** Only the deps this branch actually touches; the rest are inert spies. */
+function makeDeps(session: Session) {
+	return {
+		sessionsRef: { current: [session] },
+		setActiveSessionId: vi.fn(),
+		setSessions: vi.fn(),
+		setGroups: vi.fn(),
+		handleOpenFileTab: vi.fn(),
+		refreshFileTree: vi.fn(),
+		handleAutoRunRefresh: vi.fn(),
+		startBatchRun: vi.fn().mockResolvedValue(undefined),
+		stopBatchRun: vi.fn(),
+		resumeAfterError: vi.fn(),
+		skipCurrentDocument: vi.fn(),
+		abortBatchOnError: vi.fn(),
+	} as unknown as Parameters<typeof useAppRemoteEventListeners>[0];
+}
+
+/** Dispatch a config patch and return what was written onto the session. */
+async function applyPatch(
+	session: Session,
+	configPatch: Record<string, unknown>
+): Promise<Partial<Session>> {
+	const deps = makeDeps(session);
+	renderHook(() => useAppRemoteEventListeners(deps));
+
+	await act(async () => {
+		window.dispatchEvent(
+			new CustomEvent('maestro:remoteUpdateSessionConfig', {
+				detail: { sessionId: session.id, configPatch, responseChannel: RESPONSE_CHANNEL },
+			})
+		);
+		// Let the handler's awaited persist call settle.
+		await Promise.resolve();
+	});
+
+	const setSessions = (deps as unknown as { setSessions: ReturnType<typeof vi.fn> }).setSessions;
+	expect(setSessions).toHaveBeenCalled();
+	const updater = setSessions.mock.calls[0][0] as (prev: Session[]) => Session[];
+	return updater([session])[0];
+}
+
+beforeEach(() => {
+	vi.mocked(window.maestro.sessions.setMany).mockResolvedValue(undefined as never);
+	// Not part of the shared preload mock in setup.ts, so stub it here rather
+	// than widening the global surface for one branch.
+	(
+		window.maestro.process as unknown as Record<string, unknown>
+	).sendRemoteUpdateSessionConfigResponse = vi.fn();
+});
+
+afterEach(() => cleanup());
+
+describe('remoteUpdateSessionConfig - context window provenance (finding AD1)', () => {
+	it('writes contextWindowSource through the editable-key allowlist', async () => {
+		// Without the allowlist entry the CLI writes the number but not its
+		// provenance, so the deliberate edit stays outranked by the provider's
+		// report and silently does not apply.
+		const updated = await applyPatch(makeSession(), {
+			customContextWindow: 120000,
+			contextWindowSource: 'user-edited',
+		});
+
+		expect(updated.customContextWindow).toBe(120000);
+		expect(updated.contextWindowSource).toBe('user-edited');
+	});
+
+	it('clears provenance when a patch clears the window, even alone', async () => {
+		// Review of PR #1362. A patch carrying only `customContextWindow: null`
+		// left a stale 'user-edited' behind, so the next window set without
+		// provenance inherited precedence nobody asked for.
+		const updated = await applyPatch(
+			makeSession({ customContextWindow: 120000, contextWindowSource: 'user-edited' }),
+			{ customContextWindow: null }
+		);
+
+		expect(updated.customContextWindow).toBeUndefined();
+		expect(updated.contextWindowSource).toBeUndefined();
+	});
+
+	it('leaves provenance alone when the patch does not touch the window', async () => {
+		const updated = await applyPatch(
+			makeSession({ customContextWindow: 120000, contextWindowSource: 'user-edited' }),
+			{ customModel: 'opus' }
+		);
+
+		expect(updated.customModel).toBe('opus');
+		expect(updated.contextWindowSource).toBe('user-edited');
+	});
+});

--- a/src/__tests__/renderer/hooks/useContextWindow.test.ts
+++ b/src/__tests__/renderer/hooks/useContextWindow.test.ts
@@ -135,6 +135,69 @@ describe('useContextWindow', () => {
 		await waitFor(() => expect(result.current.activeTabContextWindow).toBe(200000));
 	});
 
+	// Finding AD1. P1 ranks a provider report above every stored value, which is
+	// right for the materialized defaults that dominate the store but silently
+	// discards the intent of someone who deliberately lowered their window to
+	// force earlier compaction. Provenance is what tells the two apart.
+	it('keeps a user-edited window above a resolved runtime window', async () => {
+		const session = makeSession({
+			toolType: 'omp',
+			customContextWindow: 120000,
+			contextWindowSource: 'user-edited',
+		});
+		const tab = {
+			usageStats: {
+				contextWindow: 1_000_000,
+				contextWindowResolved: true,
+				inputTokens: 1000,
+				outputTokens: 500,
+			},
+		};
+
+		const { result } = renderHook(() => useContextWindow(session, tab));
+
+		await waitFor(() => expect(result.current.activeTabContextWindow).toBe(120000));
+	});
+
+	it('lets a resolved window beat a stored value explicitly marked materialized', async () => {
+		// The explicit counterpart of the legacy case below: provenance recorded,
+		// and it says this number was never a choice.
+		const session = makeSession({
+			toolType: 'omp',
+			customContextWindow: 200000,
+			contextWindowSource: 'materialized',
+		});
+		const tab = {
+			usageStats: {
+				contextWindow: 1_000_000,
+				contextWindowResolved: true,
+				inputTokens: 1000,
+				outputTokens: 500,
+			},
+		};
+
+		const { result } = renderHook(() => useContextWindow(session, tab));
+
+		await waitFor(() => expect(result.current.activeTabContextWindow).toBe(1_000_000));
+	});
+
+	it('keeps a [1m] custom-model marker above a user-edited window', async () => {
+		mockGetConfig.mockResolvedValue({ contextWindow: 200000 });
+		// Both are deliberate choices, but the model marker is the more specific
+		// one: picking `[1m]` selects a model variant, and a stale window typed
+		// before that switch must not shrink it back.
+		const session = makeSession({
+			customModel: 'opus[1m]',
+			customContextWindow: 120000,
+			contextWindowSource: 'user-edited',
+		});
+		const tab = { usageStats: { contextWindow: 200000, inputTokens: 10, outputTokens: 5 } };
+
+		const { result } = renderHook(() => useContextWindow(session, tab));
+
+		await waitFor(() => expect(result.current.activeTabContextWindow).toBe(1_000_000));
+	});
+
 	it('keeps a [1m] custom-model marker above a resolved window', async () => {
 		mockGetConfig.mockResolvedValue({ contextWindow: 200000 });
 		// An explicit [1m] model choice is authoritative and must outrank a

--- a/src/__tests__/renderer/hooks/useContextWindow.test.ts
+++ b/src/__tests__/renderer/hooks/useContextWindow.test.ts
@@ -102,7 +102,9 @@ describe('useContextWindow', () => {
 
 	it('lets a resolved runtime window beat a stored customContextWindow override', async () => {
 		// Finding P1 / D1: the stored value is a materialized creation-time default,
-		// so a provider-resolved window outranks it.
+		// so a provider-resolved window outranks it. Note the ABSENCE of
+		// `contextWindowSource` is what marks it materialized - there is no
+		// `'materialized'` value to assign, by design (review of PR #1362).
 		const session = makeSession({ toolType: 'omp', customContextWindow: 200000 });
 		const tab = {
 			usageStats: {
@@ -157,28 +159,6 @@ describe('useContextWindow', () => {
 		const { result } = renderHook(() => useContextWindow(session, tab));
 
 		await waitFor(() => expect(result.current.activeTabContextWindow).toBe(120000));
-	});
-
-	it('lets a resolved window beat a stored value explicitly marked materialized', async () => {
-		// The explicit counterpart of the legacy case below: provenance recorded,
-		// and it says this number was never a choice.
-		const session = makeSession({
-			toolType: 'omp',
-			customContextWindow: 200000,
-			contextWindowSource: 'materialized',
-		});
-		const tab = {
-			usageStats: {
-				contextWindow: 1_000_000,
-				contextWindowResolved: true,
-				inputTokens: 1000,
-				outputTokens: 500,
-			},
-		};
-
-		const { result } = renderHook(() => useContextWindow(session, tab));
-
-		await waitFor(() => expect(result.current.activeTabContextWindow).toBe(1_000_000));
 	});
 
 	it('keeps a [1m] custom-model marker above a user-edited window', async () => {

--- a/src/__tests__/renderer/utils/worktreeSession.test.ts
+++ b/src/__tests__/renderer/utils/worktreeSession.test.ts
@@ -29,6 +29,7 @@ const createMockParentSession = (overrides: Partial<Session> = {}): Session =>
 		customEnvVars: { KEY: 'val' },
 		customModel: 'opus',
 		customContextWindow: 200000,
+		contextWindowSource: 'user-edited' as const,
 		nudgeMessage: 'Keep going',
 		newSessionMessage: 'Init context',
 		autoRunFolderPath: '/autorun/docs',
@@ -71,6 +72,11 @@ describe('buildWorktreeSession', () => {
 		expect(session.customEnvVars).toEqual({ KEY: 'val' });
 		expect(session.customModel).toBe('opus');
 		expect(session.customContextWindow).toBe(200000);
+		// Provenance travels with the value (finding AD1): inheriting the number
+		// alone would demote the parent's deliberate budget to unknown provenance
+		// here, so a provider report would override it in the worktree while still
+		// being outranked in the parent.
+		expect(session.contextWindowSource).toBe('user-edited');
 		expect(session.nudgeMessage).toBe('Keep going');
 		expect(session.newSessionMessage).toBe('Init context');
 		expect(session.autoRunFolderPath).toBe('/autorun/docs');
@@ -93,6 +99,7 @@ describe('buildWorktreeSession', () => {
 		expect(session.worktreeParentPath).toBe('/projects');
 		expect(session.inputMode).toBe('terminal'); // inherited directly
 		expect(session.customContextWindow).toBeUndefined();
+		expect(session.contextWindowSource).toBeUndefined();
 		expect(session.nudgeMessage).toBeUndefined();
 		expect(session.newSessionMessage).toBeUndefined();
 		expect(session.autoRunFolderPath).toBeUndefined();

--- a/src/cli/commands/create-agent.ts
+++ b/src/cli/commands/create-agent.ts
@@ -144,7 +144,15 @@ export async function createAgent(name: string, options: CreateAgentOptions): Pr
 	if (customEnvVars) payload.customEnvVars = customEnvVars;
 	if (options.model) payload.customModel = options.model;
 	if (options.effort) payload.customEffort = options.effort;
-	if (customContextWindow !== undefined) payload.customContextWindow = customContextWindow;
+	if (customContextWindow !== undefined) {
+		payload.customContextWindow = customContextWindow;
+		// Typing `--context-window` is unambiguously a deliberate choice, exactly as
+		// it is on `update-agent` (finding AD1, review of PR #1362). Without this the
+		// same flag on the same CLI produced two different outcomes: a scripted
+		// create with a lowered budget was silently overridden by the provider's
+		// report and had to be re-applied with `update-agent` to stick.
+		payload.contextWindowSource = 'user-edited';
+	}
 	if (options.providerPath) payload.customProviderPath = options.providerPath;
 	if (sessionSshRemoteConfig) payload.sessionSshRemoteConfig = sessionSshRemoteConfig;
 	if (options.autoRunFolder) payload.autoRunFolderPath = path.resolve(options.autoRunFolder);

--- a/src/cli/commands/update-agent.ts
+++ b/src/cli/commands/update-agent.ts
@@ -106,6 +106,8 @@ function buildConfigPatch(options: UpdateAgentOptions): Record<string, unknown> 
 		const raw = options.contextWindow.trim().toLowerCase();
 		if (raw === '' || raw === 'none' || raw === '0') {
 			patch.customContextWindow = null;
+			// Clearing the value clears its provenance with it.
+			patch.contextWindowSource = null;
 		} else {
 			const n = Number(raw);
 			if (!Number.isFinite(n) || n < 0) {
@@ -114,6 +116,10 @@ function buildConfigPatch(options: UpdateAgentOptions): Record<string, unknown> 
 				);
 			}
 			patch.customContextWindow = Math.floor(n);
+			// Typing `--context-window` is unambiguously a deliberate choice, so it
+			// outranks a provider-reported window (finding AD1). No seed to compare
+			// against here, unlike the edit modal.
+			patch.contextWindowSource = 'user-edited';
 		}
 	}
 
@@ -426,6 +432,9 @@ export async function updateAgent(agentId: string, options: UpdateAgentOptions):
 			maestroPPath: 'maestro-p path',
 		};
 		for (const [key, value] of Object.entries(applied.config)) {
+			// Derived marker, not something the caller typed - it is implied by
+			// `--context-window` and printing it just adds noise (finding AD1).
+			if (key === 'contextWindowSource') continue;
 			const label = labels[key] ?? key;
 			if (value === null) {
 				console.log(`  ${label}: (cleared)`);

--- a/src/main/web-server/handlers/messageHandlers/sessions.ts
+++ b/src/main/web-server/handlers/messageHandlers/sessions.ts
@@ -85,7 +85,13 @@ export function handleCreateSession(
 	// Provenance for the key above. This allowlist is explicit, so omitting it
 	// would silently drop the CLI's `--context-window` intent - the same failure
 	// mode as the EDITABLE_KEYS allowlist in the remote patch applier (AD1).
-	if (message.contextWindowSource === 'user-edited') config.contextWindowSource = 'user-edited';
+	// Gated on the window actually being accepted: provenance describes a value,
+	// so a source-only payload would leave a marker with nothing to describe, and
+	// that orphan would then outrank a provider report for whatever window is set
+	// later (review of PR #1362).
+	if (config.customContextWindow !== undefined && message.contextWindowSource === 'user-edited') {
+		config.contextWindowSource = 'user-edited';
+	}
 	if (message.customProviderPath) config.customProviderPath = message.customProviderPath as string;
 	if (message.sessionSshRemoteConfig) {
 		config.sessionSshRemoteConfig =

--- a/src/main/web-server/handlers/messageHandlers/sessions.ts
+++ b/src/main/web-server/handlers/messageHandlers/sessions.ts
@@ -82,6 +82,10 @@ export function handleCreateSession(
 	if (message.customEffort) config.customEffort = message.customEffort as string;
 	if (message.customContextWindow)
 		config.customContextWindow = message.customContextWindow as number;
+	// Provenance for the key above. This allowlist is explicit, so omitting it
+	// would silently drop the CLI's `--context-window` intent - the same failure
+	// mode as the EDITABLE_KEYS allowlist in the remote patch applier (AD1).
+	if (message.contextWindowSource === 'user-edited') config.contextWindowSource = 'user-edited';
 	if (message.customProviderPath) config.customProviderPath = message.customProviderPath as string;
 	if (message.sessionSshRemoteConfig) {
 		config.sessionSshRemoteConfig =

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -883,6 +883,14 @@ export interface CreateSessionConfig {
 	customModel?: string;
 	customEffort?: string;
 	customContextWindow?: number;
+	/**
+	 * Provenance of {@link customContextWindow} (finding AD1). `'user-edited'`
+	 * only when a human deliberately chose the number - typing
+	 * `--context-window` on the CLI qualifies. The desktop New Agent modal does
+	 * NOT set it: its control is seeded from the agent-level config, so that
+	 * write is a materialization of the default rather than a choice.
+	 */
+	contextWindowSource?: 'user-edited';
 	customProviderPath?: string;
 	sessionSshRemoteConfig?: {
 		enabled: boolean;

--- a/src/renderer/components/AppModals/AppModals.tsx
+++ b/src/renderer/components/AppModals/AppModals.tsx
@@ -147,7 +147,7 @@ export interface AppModalsProps {
 		retryOnTokenExhaustion?: boolean,
 		additionalDirectories?: AdditionalDirectory[],
 		/** Provenance of `customContextWindow` (finding AD1). */
-		contextWindowSource?: 'user-edited' | 'materialized'
+		contextWindowSource?: 'user-edited'
 	) => void;
 	editAgentSession: Session | null;
 	renameSessionValue: string;

--- a/src/renderer/components/AppModals/AppModals.tsx
+++ b/src/renderer/components/AppModals/AppModals.tsx
@@ -22,6 +22,7 @@ import type {
 	ToolType,
 	LeaderboardRegistration,
 	ThinkingMode,
+	AdditionalDirectory,
 } from '../../types';
 import type { FileNode } from '../../types/fileTree';
 import type { WizardStep } from '../Wizard/WizardContext';
@@ -141,7 +142,12 @@ export interface AppModalsProps {
 		},
 		enableMaestroP?: boolean,
 		maestroPPath?: string,
-		maestroPMode?: 'interactive' | 'dynamic'
+		maestroPMode?: 'interactive' | 'dynamic',
+		retryOnAvailabilityErrors?: boolean,
+		retryOnTokenExhaustion?: boolean,
+		additionalDirectories?: AdditionalDirectory[],
+		/** Provenance of `customContextWindow` (finding AD1). */
+		contextWindowSource?: 'user-edited' | 'materialized'
 	) => void;
 	editAgentSession: Session | null;
 	renameSessionValue: string;

--- a/src/renderer/components/AppModals/AppSessionModals.tsx
+++ b/src/renderer/components/AppModals/AppSessionModals.tsx
@@ -80,7 +80,9 @@ export interface AppSessionModalsProps {
 		maestroPMode?: 'interactive' | 'dynamic',
 		retryOnAvailabilityErrors?: boolean,
 		retryOnTokenExhaustion?: boolean,
-		additionalDirectories?: AdditionalDirectory[]
+		additionalDirectories?: AdditionalDirectory[],
+		/** Provenance of `customContextWindow` (finding AD1). */
+		contextWindowSource?: 'user-edited' | 'materialized'
 	) => void;
 	editAgentSession: Session | null;
 

--- a/src/renderer/components/AppModals/AppSessionModals.tsx
+++ b/src/renderer/components/AppModals/AppSessionModals.tsx
@@ -82,7 +82,7 @@ export interface AppSessionModalsProps {
 		retryOnTokenExhaustion?: boolean,
 		additionalDirectories?: AdditionalDirectory[],
 		/** Provenance of `customContextWindow` (finding AD1). */
-		contextWindowSource?: 'user-edited' | 'materialized'
+		contextWindowSource?: 'user-edited'
 	) => void;
 	editAgentSession: Session | null;
 

--- a/src/renderer/components/NewInstanceModal/EditAgentModal.tsx
+++ b/src/renderer/components/NewInstanceModal/EditAgentModal.tsx
@@ -50,6 +50,13 @@ export function EditAgentModal({
 	const homeDir = useHomeDir();
 	const [agent, setAgent] = useState<AgentConfig | null>(null);
 	const [agentConfig, setAgentConfig] = useState<Record<string, any>>({});
+	/**
+	 * The context window the config panel was SEEDED with, so save can tell a
+	 * deliberate edit from an untouched round-trip (finding AD1). A ref, not
+	 * state: nothing renders from it and it must not retrigger the seeding
+	 * effect that writes it.
+	 */
+	const seededContextWindowRef = useRef<number | undefined>(undefined);
 	const [availableModels, setAvailableModels] = useState<string[]>([]);
 	const [loadingModels, setLoadingModels] = useState(false);
 	const [customPath, setCustomPath] = useState('');
@@ -204,12 +211,23 @@ export function EditAgentModal({
 				if (isProviderSwitch) {
 					// When provider changed, use agent-level defaults for the new provider
 					setAgentConfig(globalConfig);
+					// The new provider's default is the seed, so leaving it alone is not
+					// an edit. The provider switch clears the old override anyway.
+					seededContextWindowRef.current = globalConfig.contextWindow;
 				} else {
 					// Empty string means explicitly cleared, undefined means never set (use agent-level default)
 					const effortKey = getEffortConfigKey(foundAgent);
 					const modelValue =
 						session.customModel !== undefined ? session.customModel : (globalConfig.model ?? '');
 					const contextWindowValue = session.customContextWindow ?? globalConfig.contextWindow;
+					// Remember what the control was SEEDED with so save can tell an
+					// actual edit from an untouched round-trip. Seeding from
+					// `globalConfig.contextWindow` when the session has no override is
+					// exactly how the agent-level default gets materialized into a
+					// per-session value just by opening this modal and pressing Save
+					// (finding P1); without this the write would be indistinguishable
+					// from a deliberate choice (finding AD1).
+					seededContextWindowRef.current = contextWindowValue;
 					const effortValue =
 						session.customEffort !== undefined
 							? session.customEffort
@@ -356,6 +374,14 @@ export function EditAgentModal({
 			typeof agentConfig.contextWindow === 'number' && agentConfig.contextWindow > 0
 				? agentConfig.contextWindow
 				: undefined;
+		// Provenance for that number (finding AD1). Only a value the user actually
+		// moved off the seed counts as intent; an untouched round-trip keeps
+		// whatever provenance the session already had, which for everything stored
+		// before AD1 is none - so P1's "provider report wins" stands for it.
+		const contextWindowSource =
+			contextWindowValue !== seededContextWindowRef.current
+				? ('user-edited' as const)
+				: session.contextWindowSource;
 		const effortValue = agentConfig[getEffortConfigKey(agent)]?.trim() ?? undefined;
 
 		// Build per-session SSH remote config: ALWAYS pass explicitly to override any agent-level config.
@@ -401,7 +427,8 @@ export function EditAgentModal({
 			enableMaestroP ? maestroPMode : undefined,
 			retryOnAvailabilityErrors,
 			retryOnTokenExhaustion,
-			normalizeAdditionalDirectories(additionalDirectories, homeDir)
+			normalizeAdditionalDirectories(additionalDirectories, homeDir),
+			contextWindowSource
 		);
 		onClose();
 	}, [

--- a/src/renderer/components/NewInstanceModal/EditAgentModal.tsx
+++ b/src/renderer/components/NewInstanceModal/EditAgentModal.tsx
@@ -379,9 +379,14 @@ export function EditAgentModal({
 		// whatever provenance the session already had, which for everything stored
 		// before AD1 is none - so P1's "provider report wins" stands for it.
 		const contextWindowSource =
-			contextWindowValue !== seededContextWindowRef.current
-				? ('user-edited' as const)
-				: session.contextWindowSource;
+			contextWindowValue === undefined
+				? // Clearing the control clears the value, so its provenance goes with
+					// it - keeping a stale 'user-edited' would let the NEXT value
+					// inherit precedence nobody asked for.
+					undefined
+				: contextWindowValue !== seededContextWindowRef.current
+					? ('user-edited' as const)
+					: session.contextWindowSource;
 		const effortValue = agentConfig[getEffortConfigKey(agent)]?.trim() ?? undefined;
 
 		// Build per-session SSH remote config: ALWAYS pass explicitly to override any agent-level config.

--- a/src/renderer/components/NewInstanceModal/types.ts
+++ b/src/renderer/components/NewInstanceModal/types.ts
@@ -91,7 +91,9 @@ export interface EditAgentModalProps {
 		maestroPMode?: 'interactive' | 'dynamic',
 		retryOnAvailabilityErrors?: boolean,
 		retryOnTokenExhaustion?: boolean,
-		additionalDirectories?: AdditionalDirectory[]
+		additionalDirectories?: AdditionalDirectory[],
+		/** Provenance of `customContextWindow` (finding AD1). */
+		contextWindowSource?: 'user-edited' | 'materialized'
 	) => void;
 	theme: Theme;
 	session: Session | null;

--- a/src/renderer/components/NewInstanceModal/types.ts
+++ b/src/renderer/components/NewInstanceModal/types.ts
@@ -93,7 +93,7 @@ export interface EditAgentModalProps {
 		retryOnTokenExhaustion?: boolean,
 		additionalDirectories?: AdditionalDirectory[],
 		/** Provenance of `customContextWindow` (finding AD1). */
-		contextWindowSource?: 'user-edited' | 'materialized'
+		contextWindowSource?: 'user-edited'
 	) => void;
 	theme: Theme;
 	session: Session | null;

--- a/src/renderer/hooks/agent/internal/contextTimelinePoint.ts
+++ b/src/renderer/hooks/agent/internal/contextTimelinePoint.ts
@@ -106,6 +106,13 @@ export function buildContextTimelinePoint(
 	//   6. raw reported window
 	//   7. static per-agent table (timeline-only)
 	//
+	// A THIRD precedence list exists in `utils/contextWindowResolver.ts`
+	// (`resolveConfiguredContextWindow`), which ranks `customContextWindow`
+	// first unconditionally and feeds Auto Run's fresh-context picker. It
+	// predates P1/AD1 and serves a different purpose, so it is deliberately
+	// NOT kept in sync - but it is the site a future reader will miss when
+	// changing this order (review of PR #1362).
+	//
 	// The provider-config source lives behind an async `getConfig` call that must
 	// NOT run on this hot per-turn path, so we read it from a synchronous cache
 	// and prime that cache off-path for the next turn. It closes the gap for

--- a/src/renderer/hooks/agent/internal/contextTimelinePoint.ts
+++ b/src/renderer/hooks/agent/internal/contextTimelinePoint.ts
@@ -94,16 +94,17 @@ export function buildContextTimelinePoint(
 	// Resolve the effective context window ONCE, shared by the timeline point and
 	// the caller's accumulated-growth fallback so they can never disagree.
 	//
-	// Precedence (finding P1). Ranks 1-3 and 5 are POSITIONALLY IDENTICAL to
-	// useContextWindow's, or the header gauge and the Context Timeline disagree
-	// again (the bug PR #1221 fixed). Ranks 4 and 6 are timeline-only extras and
-	// sit below the shared ranks:
+	// Precedence (findings P1 and AD1). Ranks 1-4 and 6 are POSITIONALLY
+	// IDENTICAL to useContextWindow's, or the header gauge and the Context
+	// Timeline disagree again (the bug PR #1221 fixed). Ranks 5 and 7 are
+	// timeline-only extras and sit below the shared ranks:
 	//   1. `[1m]` model marker
-	//   2. resolved reported window
-	//   3. `customContextWindow` override
-	//   4. cached provider-configured window (timeline-only)
-	//   5. raw reported window
-	//   6. static per-agent table (timeline-only)
+	//   2. user-edited `customContextWindow`
+	//   3. resolved reported window
+	//   4. `customContextWindow` of unknown/materialized provenance
+	//   5. cached provider-configured window (timeline-only)
+	//   6. raw reported window
+	//   7. static per-agent table (timeline-only)
 	//
 	// The provider-config source lives behind an async `getConfig` call that must
 	// NOT run on this hot per-turn path, so we read it from a synchronous cache
@@ -119,33 +120,39 @@ export function buildContextTimelinePoint(
 	// truth, so it outranks the stored override below.
 	const resolvedReportedWindow =
 		usageStats.contextWindowResolved && usageStats.contextWindow > 0 ? usageStats.contextWindow : 0;
-	// `customContextWindow` is NOT reliably something the user chose: the agent
-	// definition's `contextWindow` default is materialized into every new session
-	// at creation time (see P1), which is how a fresh omp agent plotted against
-	// 200k instead of the provider's real 1M. Treat it as a fallback that applies
-	// until the provider reports an authoritative window.
+	// Without recorded provenance `customContextWindow` is NOT reliably something
+	// the user chose: the agent definition's `contextWindow` default is
+	// materialized into every new session at creation time (see P1), which is how
+	// a fresh omp agent plotted against 200k instead of the provider's real 1M.
+	// Treat it as a fallback that applies until the provider reports an
+	// authoritative window.
 	const sessionOverride =
 		typeof session.customContextWindow === 'number' && session.customContextWindow > 0
 			? session.customContextWindow
 			: 0;
+	// ...unless the user deliberately set it, which is intent rather than a stale
+	// default and outranks even the provider's report (finding AD1).
+	const userEditedWindow = session.contextWindowSource === 'user-edited' ? sessionOverride : 0;
 	const cachedConfiguredWindow = getCachedConfiguredContextWindow(session);
 	const resolvedWindow =
 		modelMarker > 0
 			? modelMarker
-			: resolvedReportedWindow > 0
-				? resolvedReportedWindow
-				: sessionOverride > 0
-					? sessionOverride
-					: cachedConfiguredWindow > 0
-						? cachedConfiguredWindow
-						: usageStats.contextWindow > 0
-							? usageStats.contextWindow
-							: agentToolType && agentToolType !== 'terminal'
-								? getContextWindowForAgent(
-										agentToolType,
-										useAgentStore.getState().getCapabilitySnapshot(agentToolType, sessionRemoteId)
-									)
-								: 0;
+			: userEditedWindow > 0
+				? userEditedWindow
+				: resolvedReportedWindow > 0
+					? resolvedReportedWindow
+					: sessionOverride > 0
+						? sessionOverride
+						: cachedConfiguredWindow > 0
+							? cachedConfiguredWindow
+							: usageStats.contextWindow > 0
+								? usageStats.contextWindow
+								: agentToolType && agentToolType !== 'terminal'
+									? getContextWindowForAgent(
+											agentToolType,
+											useAgentStore.getState().getCapabilitySnapshot(agentToolType, sessionRemoteId)
+										)
+									: 0;
 
 	// A context-window correction (omp's catalog primed after the first turn's
 	// fallback usage already emitted) replays an already-counted turn purely to

--- a/src/renderer/hooks/mainPanel/useContextWindow.ts
+++ b/src/renderer/hooks/mainPanel/useContextWindow.ts
@@ -43,6 +43,12 @@ export function useContextWindow(activeSession: Session | null, activeTab: AITab
 		//   4. `customContextWindow` of unknown/materialized provenance
 		//   5. async configured window
 		//   6. raw reported window
+		// A THIRD precedence list exists in `utils/contextWindowResolver.ts`
+		// (`resolveConfiguredContextWindow`), which ranks `customContextWindow`
+		// first unconditionally and feeds Auto Run's fresh-context picker. It
+		// predates P1/AD1 and serves a different purpose, so it is deliberately
+		// NOT kept in sync - but it is the site a future reader will miss when
+		// changing this order (review of PR #1362).
 		// A `[1m]` marker on the session's custom model is an explicit model choice
 		// the user made per-session, so it stays at the top.
 		const modelMarker = getModelContextWindowOverride(activeSession?.customModel) ?? 0;

--- a/src/renderer/hooks/mainPanel/useContextWindow.ts
+++ b/src/renderer/hooks/mainPanel/useContextWindow.ts
@@ -34,29 +34,37 @@ export function useContextWindow(activeSession: Session | null, activeTab: AITab
 	}, [activeSession?.toolType, activeSession?.customContextWindow]);
 
 	const activeTabContextWindow = useMemo(() => {
-		// Precedence (finding P1). Keep this list POSITIONALLY IDENTICAL to
-		// useAgentUsageListener's, or the header gauge and the Context Timeline
+		// Precedence (findings P1 and AD1). Keep this list POSITIONALLY IDENTICAL
+		// to useAgentUsageListener's, or the header gauge and the Context Timeline
 		// disagree again (the bug PR #1221 fixed):
 		//   1. `[1m]` model marker
-		//   2. resolved reported window
-		//   3. `customContextWindow` override
-		//   4. async configured window
-		//   5. raw reported window
+		//   2. user-edited `customContextWindow`
+		//   3. resolved reported window
+		//   4. `customContextWindow` of unknown/materialized provenance
+		//   5. async configured window
+		//   6. raw reported window
 		// A `[1m]` marker on the session's custom model is an explicit model choice
 		// the user made per-session, so it stays at the top.
 		const modelMarker = getModelContextWindowOverride(activeSession?.customModel) ?? 0;
 		if (modelMarker > 0) return modelMarker;
+		const sessionOverride = activeSession?.customContextWindow ?? 0;
+		// A window the user deliberately set is intent, not a stale default, so it
+		// outranks even the provider's own report (finding AD1). Someone who lowers
+		// their window to force earlier compaction means it; P1 alone silently
+		// discarded that the moment the provider reported.
+		if (activeSession?.contextWindowSource === 'user-edited' && sessionOverride > 0) {
+			return sessionOverride;
+		}
 		const reported = activeTab?.usageStats?.contextWindow ?? 0;
 		// A genuinely provider-resolved window (flagged via `contextWindowResolved`,
 		// set only where the value came from the provider's own payload) is runtime
 		// truth, so it outranks the stored override below.
 		if (activeTab?.usageStats?.contextWindowResolved && reported > 0) return reported;
-		// `customContextWindow` is NOT reliably something the user chose: the agent
-		// definition's `contextWindow` default is materialized into every new session
-		// at creation time (see P1), which is how a fresh omp agent displayed 200k
-		// instead of the provider's real 1M. Treat it as a fallback that applies
-		// until the provider reports an authoritative window.
-		const sessionOverride = activeSession?.customContextWindow ?? 0;
+		// Reaching here means the stored value has NO recorded provenance, so it
+		// cannot be told apart from the agent definition's `contextWindow` default
+		// materialized into every new session at creation time (see P1) - which is
+		// how a fresh omp agent displayed 200k instead of the provider's real 1M.
+		// Treat it as a fallback that applies until the provider reports.
 		if (sessionOverride > 0) return sessionOverride;
 		return configuredContextWindow > 0 ? configuredContextWindow : reported;
 	}, [
@@ -64,6 +72,7 @@ export function useContextWindow(activeSession: Session | null, activeTab: AITab
 		activeTab?.usageStats?.contextWindow,
 		activeTab?.usageStats?.contextWindowResolved,
 		activeSession?.customContextWindow,
+		activeSession?.contextWindowSource,
 		activeSession?.customModel,
 	]);
 

--- a/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
+++ b/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
@@ -1072,6 +1072,9 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 				...(config?.customContextWindow && {
 					customContextWindow: config.customContextWindow as number,
 				}),
+				...(config?.contextWindowSource === 'user-edited' && {
+					contextWindowSource: 'user-edited' as const,
+				}),
 				...(config?.customProviderPath && {
 					customProviderPath: config.customProviderPath as string,
 				}),

--- a/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
+++ b/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
@@ -1365,6 +1365,14 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 			(updated as Record<string, unknown>)[key] = value === null ? undefined : value;
 		}
 
+		// Clearing the window clears its provenance too, even when the caller sent
+		// only `customContextWindow: null`. Otherwise a stale 'user-edited' outlives
+		// the value it described and the next window set without provenance
+		// inherits precedence nobody asked for (finding AD1).
+		if (patch.customContextWindow === null) {
+			updated.contextWindowSource = undefined;
+		}
+
 		if (Object.keys(updated).length === 0) {
 			window.maestro.process.sendRemoteUpdateSessionConfigResponse(responseChannel, {
 				success: false,

--- a/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
+++ b/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
@@ -1300,6 +1300,9 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 				customEnvVars: undefined,
 				customModel: undefined,
 				customContextWindow: undefined,
+				// Provenance describes the value cleared above and must not outlive
+				// it (finding AD1); mirrors the Edit Agent modal's switch branch.
+				contextWindowSource: undefined,
 				enableMaestroP: undefined,
 				maestroPPath: undefined,
 				maestroPMode: undefined,
@@ -1342,6 +1345,11 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 			'customModel',
 			'customEffort',
 			'customContextWindow',
+			// Provenance for the key above (finding AD1). Must be allowlisted or
+			// `maestro-cli update-agent --context-window` writes the number without
+			// its provenance, and the value it just set stays outranked by the
+			// provider's report - the deliberate edit would silently not apply.
+			'contextWindowSource',
 			'enableMaestroP',
 			'maestroPMode',
 			'maestroPPath',

--- a/src/renderer/hooks/session/useSessionLifecycle.ts
+++ b/src/renderer/hooks/session/useSessionLifecycle.ts
@@ -102,7 +102,7 @@ export interface SessionLifecycleReturn {
 		retryOnTokenExhaustion?: boolean,
 		additionalDirectories?: AdditionalDirectory[],
 		/** Provenance of `customContextWindow` (finding AD1). */
-		contextWindowSource?: 'user-edited' | 'materialized'
+		contextWindowSource?: 'user-edited'
 	) => void;
 	/** Rename the currently-selected tab (persists to agent session storage + history) */
 	handleRenameTab: (newName: string) => void;
@@ -185,7 +185,7 @@ export function useSessionLifecycle(deps: SessionLifecycleDeps): SessionLifecycl
 			retryOnTokenExhaustion?: boolean,
 			additionalDirectories?: AdditionalDirectory[],
 			/** Provenance of `customContextWindow` (finding AD1). */
-			contextWindowSource?: 'user-edited' | 'materialized'
+			contextWindowSource?: 'user-edited'
 		) => {
 			useSessionStore.getState().setSessions((prev) =>
 				prev.map((s) => {

--- a/src/renderer/hooks/session/useSessionLifecycle.ts
+++ b/src/renderer/hooks/session/useSessionLifecycle.ts
@@ -181,7 +181,9 @@ export function useSessionLifecycle(deps: SessionLifecycleDeps): SessionLifecycl
 			maestroPMode?: 'interactive' | 'dynamic',
 			retryOnAvailabilityErrors?: boolean,
 			retryOnTokenExhaustion?: boolean,
-			additionalDirectories?: AdditionalDirectory[]
+			additionalDirectories?: AdditionalDirectory[],
+			/** Provenance of `customContextWindow` (finding AD1). */
+			contextWindowSource?: 'user-edited' | 'materialized'
 		) => {
 			useSessionStore.getState().setSessions((prev) =>
 				prev.map((s) => {
@@ -200,6 +202,7 @@ export function useSessionLifecycle(deps: SessionLifecycleDeps): SessionLifecycl
 						customModel,
 						customEffort,
 						customContextWindow,
+						contextWindowSource,
 						sessionSshRemoteConfig,
 						enableMaestroP,
 						maestroPPath,
@@ -238,6 +241,10 @@ export function useSessionLifecycle(deps: SessionLifecycleDeps): SessionLifecycl
 							customModel: undefined,
 							customEffort: undefined,
 							customContextWindow: undefined,
+							// Provenance describes the value cleared above, so it must not
+							// outlive it: a stale 'user-edited' would make the new
+							// provider's window look deliberate (finding AD1).
+							contextWindowSource: undefined,
 							enableMaestroP: undefined,
 							maestroPPath: undefined,
 							maestroPMode: undefined,

--- a/src/renderer/hooks/session/useSessionLifecycle.ts
+++ b/src/renderer/hooks/session/useSessionLifecycle.ts
@@ -100,7 +100,9 @@ export interface SessionLifecycleReturn {
 		maestroPMode?: 'interactive' | 'dynamic',
 		retryOnAvailabilityErrors?: boolean,
 		retryOnTokenExhaustion?: boolean,
-		additionalDirectories?: AdditionalDirectory[]
+		additionalDirectories?: AdditionalDirectory[],
+		/** Provenance of `customContextWindow` (finding AD1). */
+		contextWindowSource?: 'user-edited' | 'materialized'
 	) => void;
 	/** Rename the currently-selected tab (persists to agent session storage + history) */
 	handleRenameTab: (newName: string) => void;

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -1186,7 +1186,7 @@ export interface Session {
 	 * nothing like an agent default yet is not a choice either, so any
 	 * value-comparison heuristic gets exactly the codex case wrong.
 	 */
-	contextWindowSource?: 'user-edited' | 'materialized';
+	contextWindowSource?: 'user-edited';
 	documentGraphLayout?: 'mindmap' | 'radial' | 'hierarchical' | 'force'; // Document Graph layout algorithm preference (overrides global default)
 	// Per-session SSH remote configuration (overrides agent-level SSH config)
 	// When set, this session uses the specified SSH remote; when not set, runs locally

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -1173,6 +1173,20 @@ export interface Session {
 	customEffort?: string; // Custom effort/reasoning level (overrides agent-level)
 	customProviderPath?: string; // Custom provider path (overrides agent-level)
 	customContextWindow?: number; // Custom context window size (overrides agent-level)
+	/**
+	 * Provenance of `customContextWindow` (finding AD1).
+	 *
+	 * `'user-edited'` means a human deliberately set this number and it outranks
+	 * a provider-reported window. Anything else - including ABSENT, which is
+	 * every value stored before AD1 shipped - means the value cannot be
+	 * distinguished from a materialized creation-time default, so P1's
+	 * precedence stands and the provider's own report wins.
+	 *
+	 * Deliberately NOT inferred from the value: an orphaned `400000` looks
+	 * nothing like an agent default yet is not a choice either, so any
+	 * value-comparison heuristic gets exactly the codex case wrong.
+	 */
+	contextWindowSource?: 'user-edited' | 'materialized';
 	documentGraphLayout?: 'mindmap' | 'radial' | 'hierarchical' | 'force'; // Document Graph layout algorithm preference (overrides global default)
 	// Per-session SSH remote configuration (overrides agent-level SSH config)
 	// When set, this session uses the specified SSH remote; when not set, runs locally

--- a/src/renderer/utils/worktreeSession.ts
+++ b/src/renderer/utils/worktreeSession.ts
@@ -124,6 +124,12 @@ export function buildWorktreeSession(params: BuildWorktreeSessionParams): Sessio
 		customModel: params.parentSession.customModel,
 		// New model inherits these; legacy does not
 		customContextWindow: isLegacy ? undefined : params.parentSession.customContextWindow,
+		// Provenance travels WITH the value it describes (finding AD1). Copying
+		// the number alone would demote a parent's deliberate budget to unknown
+		// provenance in the worktree, so a provider report would override it there
+		// while still being outranked in the parent - the same agent's gauge,
+		// timeline and compaction threshold disagreeing across a worktree split.
+		contextWindowSource: isLegacy ? undefined : params.parentSession.contextWindowSource,
 		nudgeMessage: isLegacy ? undefined : params.parentSession.nudgeMessage,
 		newSessionMessage: isLegacy ? undefined : params.parentSession.newSessionMessage,
 		autoRunFolderPath: isLegacy ? undefined : params.parentSession.autoRunFolderPath,


### PR DESCRIPTION
Follow-up to #1356, and **stacked on it** - base is `fix/p1-context-window-precedence`, so this diff shows only the AD1 commit. Retarget to `rc` once #1356 merges.

Raised by @pedramamini as the open question at the end of the #1356 review:

> Rank 3 now means a genuinely deliberate `customContextWindow` gets overridden as soon as the provider reports. [...] Do you think it is worth distinguishing "materialized at creation" from "user edited"?

Recorded as finding AD1. This is the answer.

## Problem

P1 ranks a provider-reported window above every stored `customContextWindow`. That is correct for the values that dominate the store - every omp agent carrying a materialized `200000`, the 25 codex agents holding orphaned `400000` snapshots - but a user who deliberately **lowers** their window to force earlier compaction loses that the moment the provider reports. The control still shows their number; it just stops driving the gauge, the timeline, and compaction timing. Nothing tells them.

## Why not infer it from the value

Because that is the same mistake #1356's first review round rejected. An orphaned `400000` looks nothing like an agent default yet is not a choice either, so "does this value resemble a default" gets exactly the codex case wrong and would reinstate the masking P1 removed. Provenance has to be recorded, not guessed.

## Fix

`Session.contextWindowSource` is set to `'user-edited'` only when a human actually moved the number. Precedence becomes:

1. `[1m]` model marker
2. **user-edited `customContextWindow`**
3. provider-resolved window
4. `customContextWindow` of unknown/materialized provenance
5. configured window
6. raw reported window

Ranks 2 and 4 are the same stored field, split by provenance. The two surfaces stay **positionally identical**, or the header gauge and the Context Timeline disagree again - the bug #1221 fixed.

**No migration.** Absence means materialized, so every value stored before this ships keeps P1's behaviour exactly. That is the migration default recommended in the finding: defaulting legacy values to `user-edited` instead would reinstate the masking for precisely the agents P1 was written for.

### The seed comparison is the load-bearing part

The Edit Agent modal is *how* the agent-level default gets materialized in the first place: with no stored value the panel seeds from `globalConfig.contextWindow`, and pressing Save writes that number onto the session. Recording that write as `'user-edited'` would outrank the provider and reinstate the P1 bug one layer up. So save compares the value against **what the control was seeded with**, not against presence-of-a-value.

`maestro-cli update-agent --context-window` has no seed to compare against and is unambiguous, so it marks user-edited directly. Clearing the value clears its provenance, and a provider switch clears both in all three switch paths (modal, lifecycle handler, remote patch applier).

Also allowlists the new key in the remote config-patch applier. Without that the CLI writes the number without its provenance and the deliberate edit silently does not apply.

## Testing

Scoped only, no full-suite run. **6259** passing across renderer hooks / NewInstanceModal / AppModals / CLI, plus **3857** across renderer utils, stores and main parsers. Three tsc configs, ESLint and prettier clean.

New coverage pins the header rank, the timeline rank, the materialization case and the genuine-edit case. Verified the naive implementation - "a value is present, so it must be user-edited" - **fails 6 of them**, including the materialization test.

Five existing assertions enumerate the full `onSave` argument list and gained the new trailing argument; they assert `undefined`, which documents that an untouched round-trip records no provenance.

## Still open for you

The finding lists two decisions I did **not** take here, both easy to add if you want them in this PR:

1. **Surface the demotion in the UI.** Right now a stored value being outranked is still invisible - the settings control could say "overridden by provider (1M reported)". My recommendation in the finding was to do this, since the invisibility is most of the harm, but it is a UI change with its own review surface so I left it out of a precedence PR.
2. **Should a user-edited window LARGER than the provider's report be treated differently?** A larger one is arguably always wrong (the model cannot hold it); a smaller one is a deliberate budget. Currently both win at rank 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom context-window settings now preserve whether they were user-edited or automatically generated.
  * User-edited context windows take precedence over provider-reported values in the Context Timeline.
  * Provenance is preserved across remote updates and new-model worktree sessions.
  * CLI commands support setting, clearing, and creating sessions with custom context-window values.

* **Bug Fixes**
  * Provider switching clears outdated custom context-window settings and provenance.
  * Context-window resolution now follows the expected precedence rules across sessions and providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->