### PR TITLE
perf(tokens): cache parsed Claude transcripts so the Tokens tab only reads what changed

### DIFF
--- a/docs/agent-guides/AGENT-INFRA.md
+++ b/docs/agent-guides/AGENT-INFRA.md
@@ -639,6 +639,43 @@ Subclasses implement:
 | `OpenCodeSessionStorage`     | `opencode-session-storage.ts`      | `~/.local/share/opencode/opencode.db` (v1.2+) or `storage/` (legacy) | SQLite (or legacy JSON) |
 | `FactoryDroidSessionStorage` | `factory-droid-session-storage.ts` | `~/.factory/sessions/`                                               | JSONL + settings.json   |
 
+### Parse Cache (`src/main/storage/session-info-cache.ts`)
+
+`listSessions()` is enumerate-then-parse for every storage, and the parse is the
+expensive half: a heavy Claude user is 5+ GB of JSONL across ~14k transcripts,
+which is why the Cost & Tokens dashboard used to take ~15 seconds to render every
+single time. `SessionInfoCache` caches the parsed `AgentSessionInfo` keyed by a
+`mtimeMs + size` fingerprint, so only new or grown transcripts are re-read.
+Enumerating and stat-ing all 14k files costs under 100ms.
+
+Use it instead of hand-rolling another mtime map (there are already several):
+
+```typescript
+const files = await this.statProjectSessionFiles(projectDir); // readdir + stat
+const sessions = await getSessionInfoCache(this.agentId).resolve(
+	projectDir, // scope: one cache file per project folder
+	files.map((f) => ({ key: f.filePath, fingerprint: fileFingerprint(f.sizeBytes, f.mtimeMs) })),
+	(ref) => parseSessionFile(...), // only called on a miss; null = skip, not cached
+	{ prune: true } // ONLY when refs cover the whole scope (never for one page)
+);
+```
+
+Rules:
+
+- Attach mutable metadata (origin, starred, session name) AFTER `resolve()`. It
+  lives in `originsStore` and changes without the transcript changing, so a
+  fingerprint would never catch it.
+- Returned infos are the cached objects: spread them, never mutate in place.
+- Bump `SESSION_INFO_CACHE_VERSION` when `AgentSessionInfo` gains a field, or
+  cached entries will come back missing it.
+- Tests: `setSessionInfoCacheForTest(agentId, new SessionInfoCache(agentId, tmpDir))`
+  in `beforeEach`, or fixtures that reuse one path + stats while varying content
+  will (correctly) hit the cache.
+
+Wired up for `ClaudeSessionStorage` (local paths). `CodexSessionStorage` predates
+it and still carries its own equivalent cache; the remaining storages parse
+everything on every list and should adopt this when their volume justifies it.
+
 ### Registry Functions
 
 ```typescript

--- a/src/__tests__/main/claude-session-storage.test.ts
+++ b/src/__tests__/main/claude-session-storage.test.ts
@@ -561,10 +561,22 @@ describe('ClaudeSessionStorage', () => {
 		it('should return empty array when project directory does not exist', async () => {
 			// The missing directory surfaces on readdir - listing no longer pays for a
 			// separate existence check before enumerating.
-			vi.mocked(fs.readdir).mockRejectedValue(new Error('ENOENT'));
+			vi.mocked(fs.readdir).mockRejectedValue(
+				Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' })
+			);
 
 			const sessions = await storage.listSessions('/nonexistent/path');
 			expect(sessions).toEqual([]);
+		});
+
+		it('should rethrow when the session directory is unreadable', async () => {
+			// EACCES/EIO are real faults - swallowing them would report a user's
+			// existing transcripts as "no sessions".
+			vi.mocked(fs.readdir).mockRejectedValue(
+				Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' })
+			);
+
+			await expect(storage.listSessions('/test/project')).rejects.toThrow('EACCES');
 		});
 	});
 

--- a/src/__tests__/main/claude-session-storage.test.ts
+++ b/src/__tests__/main/claude-session-storage.test.ts
@@ -78,12 +78,22 @@ vi.mock('fs/promises', () => ({
 	},
 }));
 
+// listSessions now serves unchanged transcripts from the on-disk parse cache,
+// which resolves its location through electron's userData path.
+vi.mock('electron', () => ({
+	app: { getPath: vi.fn().mockReturnValue('/mock/userData') },
+}));
+
 // ============================================================================
 // Imports (after mocks)
 // ============================================================================
 
 import { ClaudeSessionStorage } from '../../main/storage/claude-session-storage';
 import { computeClaudeUsageCost } from '../../main/utils/pricing';
+import {
+	SessionInfoCache,
+	setSessionInfoCacheForTest,
+} from '../../main/storage/session-info-cache';
 import Store from 'electron-store';
 import fs from 'fs/promises';
 
@@ -138,6 +148,10 @@ describe('ClaudeSessionStorage', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		// Fresh parse cache per test: these cases reuse one project path and one
+		// set of file stats while varying the transcript CONTENT, which the real
+		// (mtime + size) fingerprint is entitled to treat as unchanged.
+		setSessionInfoCacheForTest('claude-code', new SessionInfoCache('claude-code', '/mock/cache'));
 		storage = new ClaudeSessionStorage();
 	});
 
@@ -545,7 +559,9 @@ describe('ClaudeSessionStorage', () => {
 		});
 
 		it('should return empty array when project directory does not exist', async () => {
-			vi.mocked(fs.access).mockRejectedValue(new Error('ENOENT'));
+			// The missing directory surfaces on readdir - listing no longer pays for a
+			// separate existence check before enumerating.
+			vi.mocked(fs.readdir).mockRejectedValue(new Error('ENOENT'));
 
 			const sessions = await storage.listSessions('/nonexistent/path');
 			expect(sessions).toEqual([]);

--- a/src/__tests__/main/storage/session-info-cache.test.ts
+++ b/src/__tests__/main/storage/session-info-cache.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for the shared session-info parse cache. Uses real fs against temp
+ * dirs; the "parse" function is a spy so each test can assert exactly which
+ * files were re-read and which were served from cache.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+vi.mock('electron', () => ({
+	app: { getPath: vi.fn().mockReturnValue('/should-be-overridden') },
+}));
+
+vi.mock('../../../main/utils/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../../main/utils/sentry', () => ({
+	captureException: vi.fn(),
+}));
+
+import {
+	SessionInfoCache,
+	fileFingerprint,
+	getSessionInfoCache,
+	setSessionInfoCacheForTest,
+	SESSION_INFO_CACHE_VERSION,
+} from '../../../main/storage/session-info-cache';
+import type { AgentSessionInfo } from '../../../main/agents/session-storage';
+
+const SCOPE = '/projects/-Users-me-thing';
+
+function info(sessionId: string, overrides: Partial<AgentSessionInfo> = {}): AgentSessionInfo {
+	return {
+		sessionId,
+		projectPath: '/Users/me/thing',
+		timestamp: '2026-01-01T00:00:00.000Z',
+		modifiedAt: '2026-01-01T00:00:00.000Z',
+		firstMessage: `preview for ${sessionId}`,
+		messageCount: 2,
+		sizeBytes: 100,
+		inputTokens: 1,
+		outputTokens: 2,
+		cacheReadTokens: 0,
+		cacheCreationTokens: 0,
+		durationSeconds: 5,
+		...overrides,
+	};
+}
+
+describe('SessionInfoCache', () => {
+	let baseDir: string;
+	let cache: SessionInfoCache;
+
+	beforeEach(async () => {
+		baseDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'session-info-cache-'));
+		cache = new SessionInfoCache('claude-code', baseDir);
+	});
+
+	afterEach(async () => {
+		await fsp.rm(baseDir, { recursive: true, force: true });
+		setSessionInfoCacheForTest('claude-code', null);
+	});
+
+	it('parses on a cold cache and serves unchanged files without re-parsing', async () => {
+		const refs = [
+			{ key: '/a.jsonl', fingerprint: fileFingerprint(100, 1000) },
+			{ key: '/b.jsonl', fingerprint: fileFingerprint(200, 2000) },
+		];
+		const parse = vi.fn(async (ref: { key: string }) => info(path.basename(ref.key, '.jsonl')));
+
+		const first = await cache.resolve(SCOPE, refs, parse);
+		expect(first.map((s) => s.sessionId)).toEqual(['a', 'b']);
+		expect(parse).toHaveBeenCalledTimes(2);
+
+		parse.mockClear();
+		const second = await cache.resolve(SCOPE, refs, parse);
+		expect(second.map((s) => s.sessionId)).toEqual(['a', 'b']);
+		expect(parse).not.toHaveBeenCalled();
+	});
+
+	it('re-parses only the file whose fingerprint changed', async () => {
+		const refs = [
+			{ key: '/a.jsonl', fingerprint: fileFingerprint(100, 1000) },
+			{ key: '/b.jsonl', fingerprint: fileFingerprint(200, 2000) },
+		];
+		const parse = vi.fn(async (ref: { key: string }) => info(path.basename(ref.key, '.jsonl')));
+		await cache.resolve(SCOPE, refs, parse);
+
+		parse.mockClear();
+		// b grew - a is byte-for-byte identical.
+		const grown = [refs[0], { key: '/b.jsonl', fingerprint: fileFingerprint(999, 3000) }];
+		await cache.resolve(SCOPE, grown, parse);
+
+		expect(parse).toHaveBeenCalledTimes(1);
+		expect(parse.mock.calls[0][0].key).toBe('/b.jsonl');
+	});
+
+	it('survives a restart: a new instance reads the persisted entries', async () => {
+		const refs = [{ key: '/a.jsonl', fingerprint: fileFingerprint(100, 1000) }];
+		const parse = vi.fn(async () => info('a'));
+		await cache.resolve(SCOPE, refs, parse);
+
+		const restarted = new SessionInfoCache('claude-code', baseDir);
+		const coldParse = vi.fn(async () => info('a'));
+		const sessions = await restarted.resolve(SCOPE, refs, coldParse);
+
+		expect(coldParse).not.toHaveBeenCalled();
+		expect(sessions.map((s) => s.sessionId)).toEqual(['a']);
+	});
+
+	it('discards persisted entries written by an older cache version', async () => {
+		const refs = [{ key: '/a.jsonl', fingerprint: fileFingerprint(100, 1000) }];
+		await cache.resolve(SCOPE, refs, async () => info('a'));
+
+		// Rewrite the scope file as if an older build had produced it.
+		const dir = path.join(baseDir, 'session-info', 'claude-code');
+		const [file] = await fsp.readdir(dir);
+		const stored = JSON.parse(await fsp.readFile(path.join(dir, file), 'utf-8'));
+		stored.version = SESSION_INFO_CACHE_VERSION - 1;
+		await fsp.writeFile(path.join(dir, file), JSON.stringify(stored), 'utf-8');
+
+		const restarted = new SessionInfoCache('claude-code', baseDir);
+		const parse = vi.fn(async () => info('a'));
+		await restarted.resolve(SCOPE, refs, parse);
+		expect(parse).toHaveBeenCalledTimes(1);
+	});
+
+	it('prunes entries for files that disappeared, but only when asked', async () => {
+		const both = [
+			{ key: '/a.jsonl', fingerprint: fileFingerprint(100, 1000) },
+			{ key: '/b.jsonl', fingerprint: fileFingerprint(200, 2000) },
+		];
+		const parse = vi.fn(async (ref: { key: string }) => info(path.basename(ref.key, '.jsonl')));
+		await cache.resolve(SCOPE, both, parse);
+
+		// A paginated caller passes a slice: the other entries must survive.
+		parse.mockClear();
+		await cache.resolve(SCOPE, [both[0]], parse, { prune: false });
+		await cache.resolve(SCOPE, both, parse);
+		expect(parse).not.toHaveBeenCalled();
+
+		// A full enumeration that no longer sees b evicts it.
+		await cache.resolve(SCOPE, [both[0]], parse, { prune: true });
+		await cache.resolve(SCOPE, both, parse);
+		expect(parse).toHaveBeenCalledTimes(1);
+		expect(parse.mock.calls[0][0].key).toBe('/b.jsonl');
+	});
+
+	it('omits unparseable files from the result and retries them next time', async () => {
+		const refs = [
+			{ key: '/a.jsonl', fingerprint: fileFingerprint(100, 1000) },
+			{ key: '/bad.jsonl', fingerprint: fileFingerprint(0, 0) },
+		];
+		const parse = vi.fn(async (ref: { key: string }) =>
+			ref.key === '/bad.jsonl' ? null : info('a')
+		);
+
+		const sessions = await cache.resolve(SCOPE, refs, parse);
+		expect(sessions.map((s) => s.sessionId)).toEqual(['a']);
+
+		parse.mockClear();
+		await cache.resolve(SCOPE, refs, parse);
+		expect(parse).toHaveBeenCalledTimes(1);
+		expect(parse.mock.calls[0][0].key).toBe('/bad.jsonl');
+	});
+
+	it('keeps scopes independent so one project cannot evict another', async () => {
+		const aRef = [{ key: '/a.jsonl', fingerprint: fileFingerprint(100, 1000) }];
+		const bRef = [{ key: '/b.jsonl', fingerprint: fileFingerprint(200, 2000) }];
+		const parse = vi.fn(async (ref: { key: string }) => info(path.basename(ref.key, '.jsonl')));
+
+		await cache.resolve('/projects/one', aRef, parse, { prune: true });
+		await cache.resolve('/projects/two', bRef, parse, { prune: true });
+
+		parse.mockClear();
+		await cache.resolve('/projects/one', aRef, parse);
+		expect(parse).not.toHaveBeenCalled();
+	});
+
+	it('shares one instance per agent and honors the test seam', () => {
+		const injected = new SessionInfoCache('claude-code', baseDir);
+		setSessionInfoCacheForTest('claude-code', injected);
+		expect(getSessionInfoCache('claude-code')).toBe(injected);
+
+		setSessionInfoCacheForTest('claude-code', null);
+		const fresh = getSessionInfoCache('claude-code');
+		expect(fresh).not.toBe(injected);
+		expect(getSessionInfoCache('claude-code')).toBe(fresh);
+	});
+});

--- a/src/main/stats/token-usage/token-usage-accessor.ts
+++ b/src/main/stats/token-usage/token-usage-accessor.ts
@@ -64,16 +64,23 @@ const COVERAGE_BY_AGENT: Record<string, TokenCoverage> = {
 	'copilot-cli': 'partial',
 };
 
-/** How long a computed aggregate stays fresh in memory before a recompute. */
+/** How long collected breakdowns stay fresh in memory before a re-collect. */
 const MEMO_TTL_MS = 30_000;
 
 interface MemoEntry {
-	key: string;
 	computedAt: number;
-	aggregate: TokenUsageAggregate;
+	breakdowns: SessionTokenBreakdown[];
 }
 
+/**
+ * The collected breakdowns, not the aggregate: collection is the expensive step
+ * and is query-independent, while aggregating is pure in-memory math over the
+ * same array. Memoizing here means flipping the dashboard's time range or
+ * granularity re-buckets what we already have instead of re-walking storage.
+ */
 let memo: MemoEntry | null = null;
+/** Shared by concurrent callers so a double mount can't run two collections. */
+let inflight: Promise<SessionTokenBreakdown[]> | null = null;
 
 /** Reset the in-memory memo (call on external stats changes / tests). */
 export function invalidateTokenUsageMemo(): void {
@@ -530,14 +537,36 @@ function projectLabel(projectPath: string): string {
 // Public entry point
 // ---------------------------------------------------------------------------
 
-function memoKey(query: TokenUsageQuery): string {
-	return `${query.sinceMs ?? ''}:${query.untilMs ?? ''}:${query.granularity ?? 'day'}`;
+/**
+ * Collected breakdowns for every known session, served from the memo when it is
+ * still fresh. Concurrent callers share one collection.
+ */
+async function loadBreakdowns(force: boolean): Promise<SessionTokenBreakdown[]> {
+	if (!force && memo && Date.now() - memo.computedAt < MEMO_TTL_MS) {
+		return memo.breakdowns;
+	}
+	if (inflight) return inflight;
+
+	inflight = (async () => {
+		const cache = getTokenUsageCache();
+		await cache.load();
+		const breakdowns = await collectBreakdowns(cache);
+		await cache.persist();
+		memo = { computedAt: Date.now(), breakdowns };
+		return breakdowns;
+	})();
+	try {
+		return await inflight;
+	} finally {
+		inflight = null;
+	}
 }
 
 /**
- * Compute the token-usage aggregate for a query. Served from the in-memory memo
- * within {@link MEMO_TTL_MS}; otherwise recomputes from storage (using the
- * persisted per-session cache to avoid re-deriving unchanged sessions).
+ * Compute the token-usage aggregate for a query. The underlying collection is
+ * served from the in-memory memo within {@link MEMO_TTL_MS}, and each agent's
+ * storage serves unchanged transcripts from its own on-disk parse cache, so a
+ * recompute costs only what changed since the last one.
  *
  * @param force - bypass the memo (e.g. an explicit refresh).
  */
@@ -545,18 +574,8 @@ export async function getTokenUsageAggregate(
 	query: TokenUsageQuery = {},
 	force = false
 ): Promise<TokenUsageAggregate> {
-	const key = memoKey(query);
-	if (!force && memo && memo.key === key && Date.now() - memo.computedAt < MEMO_TTL_MS) {
-		return memo.aggregate;
-	}
-
-	const cache = getTokenUsageCache();
-	await cache.load();
-	const breakdowns = await collectBreakdowns(cache);
-	await cache.persist();
-
+	const breakdowns = await loadBreakdowns(force);
 	const result = aggregate(breakdowns, query);
-	memo = { key, computedAt: Date.now(), aggregate: result };
 	logger.debug(
 		`Computed token usage: ${result.totals.sessionCount} sessions, $${result.totals.costUsd.toFixed(2)}`,
 		LOG_CONTEXT

--- a/src/main/storage/claude-session-storage.ts
+++ b/src/main/storage/claude-session-storage.ts
@@ -23,6 +23,7 @@ import { claudeModelUsage } from '../../shared/modelUsage';
 import { encodeClaudeProjectPath } from '../utils/statsCache';
 import { readFileRemote, listDirWithStatsRemote } from '../utils/remote-fs';
 import { mapWithConcurrency, REMOTE_SESSION_READ_CONCURRENCY } from '../utils/concurrency';
+import { getSessionInfoCache, fileFingerprint, type SessionFileRef } from './session-info-cache';
 import type {
 	AgentSessionInfo,
 	PaginatedSessionsResult,
@@ -360,6 +361,97 @@ export class ClaudeSessionStorage extends BaseSessionStorage {
 	}
 
 	/**
+	 * Enumerate a project's transcript files with the cheap stats the parse cache
+	 * fingerprints on. Newest-first, 0-byte files (created but abandoned before
+	 * any content was written) dropped. Returns empty for a project that has no
+	 * transcript folder yet.
+	 */
+	private async statProjectSessionFiles(
+		projectDir: string
+	): Promise<{ sessionId: string; filePath: string; sizeBytes: number; mtimeMs: number }[]> {
+		let filenames: string[];
+		try {
+			filenames = await fs.readdir(projectDir);
+		} catch {
+			return [];
+		}
+
+		const stats = await Promise.all(
+			filenames
+				.filter((f) => f.endsWith('.jsonl'))
+				.map(async (filename) => {
+					const filePath = path.join(projectDir, filename);
+					try {
+						const stat = await fs.stat(filePath);
+						return {
+							sessionId: filename.replace('.jsonl', ''),
+							filePath,
+							sizeBytes: stat.size,
+							mtimeMs: stat.mtimeMs,
+						};
+					} catch (error) {
+						logger.error(`Error stating session file: ${filename}`, LOG_CONTEXT, error);
+						captureException(error, { operation: 'claudeStorage:statSessionFile', filename });
+						return null;
+					}
+				})
+		);
+
+		return stats
+			.filter((s): s is NonNullable<typeof s> => s !== null)
+			.filter((s) => s.sizeBytes > 0)
+			.sort((a, b) => b.mtimeMs - a.mtimeMs);
+	}
+
+	/**
+	 * Parse the given transcript files, serving unchanged ones from the shared
+	 * {@link getSessionInfoCache} rather than re-reading them. Origin/starred/name
+	 * are attached afterwards on purpose: they live in `originsStore` and change
+	 * without the transcript changing, so they must never be cached.
+	 *
+	 * @param prune - Only when `files` covers the whole project folder; a
+	 *   paginated caller passing one page must leave it off.
+	 */
+	private async parseSessionFilesCached(
+		projectPath: string,
+		projectDir: string,
+		files: { sessionId: string; filePath: string; sizeBytes: number; mtimeMs: number }[],
+		prune: boolean
+	): Promise<AgentSessionInfo[]> {
+		const byPath = new Map(files.map((file) => [file.filePath, file]));
+		const refs: SessionFileRef[] = files.map((file) => ({
+			key: file.filePath,
+			fingerprint: fileFingerprint(file.sizeBytes, file.mtimeMs),
+		}));
+
+		const sessions = await getSessionInfoCache(this.agentId).resolve(
+			projectDir,
+			refs,
+			async (ref) => {
+				const file = byPath.get(ref.key);
+				if (!file) return null;
+				try {
+					return await parseSessionFile(file.filePath, file.sessionId, projectPath, {
+						size: file.sizeBytes,
+						mtimeMs: file.mtimeMs,
+					});
+				} catch (error) {
+					logger.error(`Error processing session file: ${file.filePath}`, LOG_CONTEXT, error);
+					captureException(error, {
+						operation: 'claudeStorage:processSessionFile',
+						filename: file.filePath,
+					});
+					return null;
+				}
+			},
+			{ prune }
+		);
+
+		const projectOrigins = this.getProjectOrigins(projectPath);
+		return sessions.map((session) => this.attachOriginInfo(session, projectOrigins));
+	}
+
+	/**
 	 * @param configDir - Optional `CLAUDE_CONFIG_DIR` selecting which Anthropic
 	 *   account's transcripts to list. Omitted (the default) reads `~/.claude`,
 	 *   preserving existing behavior for every caller that doesn't multi-account.
@@ -377,54 +469,22 @@ export class ClaudeSessionStorage extends BaseSessionStorage {
 		}
 
 		const projectDir = this.getEncodedProjectDir(projectPath, configDir);
+		const files = await this.statProjectSessionFiles(projectDir);
 
-		// Check if the directory exists
-		try {
-			await fs.access(projectDir);
-		} catch {
-			logger.info(`No Claude sessions directory found for project: ${projectPath}`, LOG_CONTEXT);
+		if (files.length === 0) {
+			logger.info(`No Claude sessions found for project: ${projectPath}`, LOG_CONTEXT);
 			return [];
 		}
 
-		// List all .jsonl files in the directory
-		const files = await fs.readdir(projectDir);
-		const sessionFiles = files.filter((f) => f.endsWith('.jsonl'));
-
-		// Get metadata for each session
-		const sessions = await Promise.all(
-			sessionFiles.map(async (filename) => {
-				const sessionId = filename.replace('.jsonl', '');
-				const filePath = path.join(projectDir, filename);
-
-				try {
-					const stats = await fs.stat(filePath);
-					return await parseSessionFile(filePath, sessionId, projectPath, {
-						size: stats.size,
-						mtimeMs: stats.mtimeMs,
-					});
-				} catch (error) {
-					logger.error(`Error processing session file: ${filename}`, LOG_CONTEXT, error);
-					captureException(error, { operation: 'claudeStorage:processSessionFile', filename });
-					return null;
-				}
-			})
-		);
-
-		// Filter out nulls, 0-byte sessions, and sort by modified date
-		const validSessions = sessions
-			.filter((s): s is NonNullable<typeof s> => s !== null)
-			// Filter out 0-byte sessions (created but abandoned before any content was written)
-			.filter((s) => s.sizeBytes > 0)
-			.sort((a, b) => new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime());
-
-		// Attach origin info
-		const projectOrigins = this.getProjectOrigins(projectPath);
-		const sessionsWithOrigins = validSessions.map((session) =>
-			this.attachOriginInfo(session, projectOrigins)
+		const sessionsWithOrigins = await this.parseSessionFilesCached(
+			projectPath,
+			projectDir,
+			files,
+			true
 		);
 
 		logger.info(
-			`Found ${validSessions.length} Claude sessions for project: ${projectPath}`,
+			`Found ${sessionsWithOrigins.length} Claude sessions for project: ${projectPath}`,
 			LOG_CONTEXT
 		);
 		return sessionsWithOrigins;
@@ -508,43 +568,11 @@ export class ClaudeSessionStorage extends BaseSessionStorage {
 		const { cursor, limit = 100 } = options || {};
 		const projectDir = this.getEncodedProjectDir(projectPath);
 
-		// Check if the directory exists
-		try {
-			await fs.access(projectDir);
-		} catch {
+		const sortedFiles = await this.statProjectSessionFiles(projectDir);
+		const totalCount = sortedFiles.length;
+		if (totalCount === 0) {
 			return { sessions: [], hasMore: false, totalCount: 0, nextCursor: null };
 		}
-
-		// List all .jsonl files and get their stats
-		const files = await fs.readdir(projectDir);
-		const sessionFiles = files.filter((f) => f.endsWith('.jsonl'));
-
-		const fileStats = await Promise.all(
-			sessionFiles.map(async (filename) => {
-				const sessionId = filename.replace('.jsonl', '');
-				const filePath = path.join(projectDir, filename);
-				try {
-					const stats = await fs.stat(filePath);
-					return {
-						sessionId,
-						filename,
-						filePath,
-						modifiedAt: stats.mtime.getTime(),
-						sizeBytes: stats.size,
-					};
-				} catch {
-					return null;
-				}
-			})
-		);
-
-		const sortedFiles = fileStats
-			.filter((s): s is NonNullable<typeof s> => s !== null)
-			// Filter out 0-byte sessions (created but abandoned before any content was written)
-			.filter((s) => s.sizeBytes > 0)
-			.sort((a, b) => b.modifiedAt - a.modifiedAt);
-
-		const totalCount = sortedFiles.length;
 
 		// Find cursor position
 		let startIndex = 0;
@@ -557,24 +585,14 @@ export class ClaudeSessionStorage extends BaseSessionStorage {
 		const hasMore = startIndex + limit < totalCount;
 		const nextCursor = hasMore ? pageFiles[pageFiles.length - 1]?.sessionId : null;
 
-		// Get project origins
-		const projectOrigins = this.getProjectOrigins(projectPath);
-
-		// Read full content for sessions in this page
-		const sessions = await Promise.all(
-			pageFiles.map(async (fileInfo) => {
-				const session = await parseSessionFile(fileInfo.filePath, fileInfo.sessionId, projectPath, {
-					size: fileInfo.sizeBytes,
-					mtimeMs: fileInfo.modifiedAt,
-				});
-				if (session) {
-					return this.attachOriginInfo(session, projectOrigins);
-				}
-				return null;
-			})
+		// Read (or serve from cache) the sessions in this page only. Pruning is off:
+		// the page is a slice, not the whole folder.
+		const validSessions = await this.parseSessionFilesCached(
+			projectPath,
+			projectDir,
+			pageFiles,
+			false
 		);
-
-		const validSessions = sessions.filter((s): s is NonNullable<typeof s> => s !== null);
 
 		logger.info(
 			`Paginated Claude sessions - returned ${validSessions.length} of ${totalCount} total (cursor: ${cursor || 'null'}, startIndex: ${startIndex}, hasMore: ${hasMore}, nextCursor: ${nextCursor || 'null'})`,

--- a/src/main/storage/claude-session-storage.ts
+++ b/src/main/storage/claude-session-storage.ts
@@ -372,8 +372,19 @@ export class ClaudeSessionStorage extends BaseSessionStorage {
 		let filenames: string[];
 		try {
 			filenames = await fs.readdir(projectDir);
-		} catch {
-			return [];
+		} catch (error) {
+			// A project that has never been opened in Claude simply has no folder.
+			// Anything else (EACCES, EIO) is a real fault: reporting it as "zero
+			// sessions" would silently hide the user's transcripts.
+			if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+				return [];
+			}
+			logger.error(`Error listing session directory: ${projectDir}`, LOG_CONTEXT, error);
+			captureException(error, {
+				operation: 'claudeStorage:statProjectSessionFiles',
+				projectDir,
+			});
+			throw error;
 		}
 
 		const stats = await Promise.all(
@@ -472,6 +483,10 @@ export class ClaudeSessionStorage extends BaseSessionStorage {
 		const files = await this.statProjectSessionFiles(projectDir);
 
 		if (files.length === 0) {
+			// Still a full listing, so still prune: a project whose transcripts were
+			// all deleted must drop its cache entries too, or a recreated file at the
+			// same path with a matching fingerprint would serve stale metadata.
+			await this.parseSessionFilesCached(projectPath, projectDir, [], true);
 			logger.info(`No Claude sessions found for project: ${projectPath}`, LOG_CONTEXT);
 			return [];
 		}

--- a/src/main/storage/session-info-cache.ts
+++ b/src/main/storage/session-info-cache.ts
@@ -1,0 +1,287 @@
+/**
+ * Session Info Cache
+ *
+ * Disk-backed (with an in-memory hot path) cache of PARSED session metadata,
+ * keyed by a cheap per-file fingerprint. It exists because every agent's
+ * `listSessions()` has the same shape: enumerate a folder of transcripts, then
+ * read and parse each one to recover tokens/cost/preview. The enumeration is
+ * cheap (readdir + stat); the parse is not - a machine with thousands of Claude
+ * sessions is several GB of JSONL, and re-reading all of it on every call is
+ * what made the Cost & Tokens dashboard take many seconds to render, every time.
+ *
+ * The invariant: a transcript file is append-only, so `mtimeMs + size` is a
+ * sufficient change signal. Unchanged files are served from cache and never
+ * touched; only new or grown files are parsed. That makes the steady-state cost
+ * proportional to what actually changed since the last call rather than to the
+ * whole history, mirroring the fingerprint approach already used by
+ * `history-bucket-cache.ts` and `token-usage-cache.ts`.
+ *
+ * Entries are stored per SCOPE (typically one project's transcript folder) so a
+ * write only rewrites the sessions of the folder that changed instead of one
+ * monolithic file.
+ *
+ * Adopting this from a storage implementation is ~10 lines: stat the files you
+ * were about to parse, hand {@link SessionInfoCache.resolve} a ref per file plus
+ * the parse function you already have, and attach your own mutable metadata
+ * (origin, starred, session name) to what comes back. Do NOT cache that mutable
+ * metadata: it changes without the transcript changing, so the fingerprint
+ * would not catch it.
+ */
+
+import * as path from 'path';
+import * as fsp from 'fs/promises';
+import * as crypto from 'crypto';
+import { app } from 'electron';
+import { logger } from '../utils/logger';
+import { captureException } from '../utils/sentry';
+import { atomicWriteFile, createKeyedWriteQueue } from '../utils/atomic-json-store';
+import { mapWithConcurrency, LOCAL_SESSION_READ_CONCURRENCY } from '../utils/concurrency';
+import type { AgentSessionInfo } from '../agents/session-storage';
+
+const LOG_CONTEXT = '[SessionInfoCache]';
+
+/**
+ * Bump to discard every persisted entry (e.g. when `AgentSessionInfo` gains a
+ * field that existing cached entries would be missing).
+ */
+export const SESSION_INFO_CACHE_VERSION = 1;
+
+/** One source file to resolve: its identity within the scope plus its fingerprint. */
+export interface SessionFileRef {
+	/** Stable identity of the file within its scope - normally the absolute path. */
+	key: string;
+	/** Cheap change signal from {@link fileFingerprint}. */
+	fingerprint: string;
+}
+
+interface CachedSessionInfo {
+	fingerprint: string;
+	info: AgentSessionInfo;
+}
+
+/** On-disk shape of one scope's cache file. */
+interface SessionInfoCacheFile {
+	version: number;
+	agentId: string;
+	/** Kept for debuggability - the file name itself is a hash. */
+	scopeKey: string;
+	savedAt: number;
+	entries: Record<string, CachedSessionInfo>;
+}
+
+/** Options for a single {@link SessionInfoCache.resolve} pass. */
+export interface ResolveOptions {
+	/**
+	 * Drop cached entries whose key is absent from `refs`, so deleted transcripts
+	 * don't accumulate. Only safe when `refs` covers the ENTIRE scope - a
+	 * paginated caller passing one page must leave this off or it would evict
+	 * every session outside that page.
+	 */
+	prune?: boolean;
+	/** Parallel parses on a cache miss. Defaults to {@link LOCAL_SESSION_READ_CONCURRENCY}. */
+	concurrency?: number;
+}
+
+/** Fingerprint a source file from the stats an enumeration already returns. */
+export function fileFingerprint(sizeBytes: number, mtimeMs: number): string {
+	return `${mtimeMs}-${sizeBytes}`;
+}
+
+/**
+ * Per-agent cache of parsed {@link AgentSessionInfo}, partitioned into scopes.
+ *
+ * Returned infos are the cached objects themselves, not copies: callers must
+ * treat them as frozen and layer their own fields on with a spread rather than
+ * mutating in place.
+ */
+export class SessionInfoCache {
+	private readonly agentId: string;
+	private readonly dir: string;
+	private readonly scopes = new Map<string, Map<string, CachedSessionInfo>>();
+	/** In-flight scope loads, so concurrent callers share one disk read. */
+	private readonly loading = new Map<string, Promise<Map<string, CachedSessionInfo>>>();
+	/** Serializes writes per scope file so two resolves can't clobber each other. */
+	private readonly writes = createKeyedWriteQueue();
+
+	constructor(agentId: string, baseDir?: string) {
+		this.agentId = agentId;
+		this.dir = path.join(
+			baseDir ?? path.join(app.getPath('userData'), 'stats-cache'),
+			'session-info',
+			agentId
+		);
+	}
+
+	/** Hash the scope key so the file name stays bounded and filesystem-safe. */
+	private filePathFor(scopeKey: string): string {
+		const hash = crypto.createHash('sha256').update(scopeKey).digest('hex').slice(0, 32);
+		return path.join(this.dir, `${hash}.json`);
+	}
+
+	/** Load (once) the entries for a scope. A missing or stale file yields an empty map. */
+	private async loadScope(scopeKey: string): Promise<Map<string, CachedSessionInfo>> {
+		const cached = this.scopes.get(scopeKey);
+		if (cached) return cached;
+
+		const inflight = this.loading.get(scopeKey);
+		if (inflight) return inflight;
+
+		const load = (async (): Promise<Map<string, CachedSessionInfo>> => {
+			const entries = new Map<string, CachedSessionInfo>();
+			try {
+				const raw = await fsp.readFile(this.filePathFor(scopeKey), 'utf-8');
+				const parsed = JSON.parse(raw) as SessionInfoCacheFile;
+				if (parsed.version === SESSION_INFO_CACHE_VERSION && parsed.entries) {
+					for (const [key, entry] of Object.entries(parsed.entries)) {
+						entries.set(key, entry);
+					}
+				}
+			} catch (error) {
+				// A missing file is the expected cold-start case; a corrupt one just
+				// costs a reparse. Neither should break listing, so both degrade to an
+				// empty scope - but anything other than ENOENT is worth a breadcrumb.
+				const code = (error as NodeJS.ErrnoException)?.code;
+				if (code !== 'ENOENT') {
+					logger.warn(`Failed to read cache for scope ${scopeKey}`, LOG_CONTEXT, { error });
+					void captureException(error, { operation: 'sessionInfoCache:read', scopeKey });
+				}
+			}
+			this.scopes.set(scopeKey, entries);
+			return entries;
+		})();
+
+		this.loading.set(scopeKey, load);
+		try {
+			return await load;
+		} finally {
+			this.loading.delete(scopeKey);
+		}
+	}
+
+	/** Persist one scope to disk. Failures are logged, never thrown at the caller. */
+	private async persistScope(scopeKey: string): Promise<void> {
+		const entries = this.scopes.get(scopeKey);
+		if (!entries) return;
+		const payload: SessionInfoCacheFile = {
+			version: SESSION_INFO_CACHE_VERSION,
+			agentId: this.agentId,
+			scopeKey,
+			savedAt: Date.now(),
+			entries: Object.fromEntries(entries),
+		};
+		try {
+			await fsp.mkdir(this.dir, { recursive: true });
+			await atomicWriteFile(this.filePathFor(scopeKey), JSON.stringify(payload));
+		} catch (error) {
+			logger.warn(`Failed to write cache for scope ${scopeKey}`, LOG_CONTEXT, { error });
+			void captureException(error, { operation: 'sessionInfoCache:write', scopeKey });
+		}
+	}
+
+	/**
+	 * Resolve every ref to its parsed info, parsing only the ones whose
+	 * fingerprint changed.
+	 *
+	 * @param scopeKey - Partition key, normally the folder the files live in.
+	 * @param refs - One entry per source file, in the order results should come back.
+	 * @param parse - Parses a single file on a cache miss. `null` means "skip this
+	 *   file" (unreadable, oversized, empty) and is not cached, so a later call
+	 *   retries it.
+	 * @returns The parsed infos in `refs` order, with skipped files omitted.
+	 */
+	async resolve(
+		scopeKey: string,
+		refs: SessionFileRef[],
+		parse: (ref: SessionFileRef) => Promise<AgentSessionInfo | null>,
+		options?: ResolveOptions
+	): Promise<AgentSessionInfo[]> {
+		const entries = await this.loadScope(scopeKey);
+
+		const resolved: (AgentSessionInfo | null)[] = new Array(refs.length).fill(null);
+		const misses: { ref: SessionFileRef; index: number }[] = [];
+
+		refs.forEach((ref, index) => {
+			const hit = entries.get(ref.key);
+			if (hit && hit.fingerprint === ref.fingerprint) {
+				resolved[index] = hit.info;
+			} else {
+				misses.push({ ref, index });
+			}
+		});
+
+		let dirty = false;
+
+		if (misses.length > 0) {
+			const parsed = await mapWithConcurrency(
+				misses,
+				options?.concurrency ?? LOCAL_SESSION_READ_CONCURRENCY,
+				({ ref }) => parse(ref)
+			);
+			parsed.forEach((info, i) => {
+				const { ref, index } = misses[i];
+				if (!info) return;
+				entries.set(ref.key, { fingerprint: ref.fingerprint, info });
+				resolved[index] = info;
+				dirty = true;
+			});
+		}
+
+		if (options?.prune) {
+			const live = new Set(refs.map((ref) => ref.key));
+			for (const key of entries.keys()) {
+				if (!live.has(key)) {
+					entries.delete(key);
+					dirty = true;
+				}
+			}
+		}
+
+		if (dirty) {
+			// Serialized per scope, and awaited so a caller that immediately exits
+			// (CLI, quit) doesn't drop the write.
+			await this.writes.enqueue(scopeKey, () => this.persistScope(scopeKey));
+		}
+
+		if (misses.length > 0) {
+			logger.debug(
+				`Scope ${scopeKey}: ${refs.length - misses.length} cached, ${misses.length} parsed`,
+				LOG_CONTEXT
+			);
+		}
+
+		return resolved.filter((info): info is AgentSessionInfo => info !== null);
+	}
+
+	/** Forget a scope's in-memory entries and delete its file. Primarily for tests/reset. */
+	async invalidate(scopeKey: string): Promise<void> {
+		this.scopes.delete(scopeKey);
+		try {
+			await fsp.unlink(this.filePathFor(scopeKey));
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+				logger.warn(`Failed to delete cache for scope ${scopeKey}`, LOG_CONTEXT, { error });
+			}
+		}
+	}
+}
+
+const instances = new Map<string, SessionInfoCache>();
+
+/** Shared per-agent cache instance. */
+export function getSessionInfoCache(agentId: string): SessionInfoCache {
+	let instance = instances.get(agentId);
+	if (!instance) {
+		instance = new SessionInfoCache(agentId);
+		instances.set(agentId, instance);
+	}
+	return instance;
+}
+
+/** Test seam: swap in a cache with a temp base dir, or reset with `null`. */
+export function setSessionInfoCacheForTest(agentId: string, cache: SessionInfoCache | null): void {
+	if (cache) {
+		instances.set(agentId, cache);
+	} else {
+		instances.delete(agentId);
+	}
+}


### PR DESCRIPTION
## Why

The Cost & Tokens tab rebuilt itself from scratch on every open, and again 30 seconds later.

The per-session `TokenUsageCache` sat **after** the expensive step. `listSessions()` reads and parses every transcript first, then hands the results to a cache that only saved a trivial re-derivation. So the cache never avoided any real work.

Measured on this machine (`~/.claude/projects`, default account only):

| | |
| --- | --- |
| Transcripts | 14,020 files / 5.17 GB |
| Enumerate + stat all of them | **86 ms** |
| Read + parse all of them | **~15 s** |

That 15 s was paid on every open, multiplied by each non-symlinked `.claude-*` account dir.

## What

`src/main/storage/session-info-cache.ts` - a shared, disk-backed cache of parsed `AgentSessionInfo` keyed by an `mtimeMs + size` fingerprint, in the same style as `history-bucket-cache.ts` and `token-usage-cache.ts`. Transcripts are append-only, so an unchanged fingerprint means unchanged content: those files are never re-read. Entries are partitioned per scope (one file per project folder) so a write rewrites only the folder that changed.

- `ClaudeSessionStorage` routes both local list paths through it. History pays the same parse, so it gets the same win.
- Origin / starred / session name stay **outside** the cache: they live in `originsStore` and change without the transcript changing, so a fingerprint would never catch them. They are attached after resolution, as before.
- Cache misses parse with bounded concurrency (`LOCAL_SESSION_READ_CONCURRENCY`) instead of an unbounded `Promise.all` that opened all 14k transcripts at once.
- The token accessor now memoizes the collected breakdowns rather than one query's aggregate, so flipping the dashboard's time range re-buckets in memory instead of re-walking storage. Concurrent callers share one collection.

Steady state after this: ~100 ms of stats plus whatever actually changed.

## Notes

- `CodexSessionStorage` predates this and carries its own equivalent cache; left alone. The remaining storages still parse everything on every list and can adopt this when their volume justifies it. Documented in `docs/agent-guides/AGENT-INFRA.md`.
- Behavior change worth a look: the missing-project-folder check moved from a separate `fs.access` to the `readdir` that follows it. One less syscall, same result.

## Tests

- New `session-info-cache.test.ts` (8 cases): cold parse, warm serve, selective re-parse on fingerprint change, restart persistence, version discard, prune vs paginated slice, unparseable files retried, scope isolation.
- `claude-session-storage.test.ts` updated for the `readdir`-based existence check and given a per-test cache instance (its fixtures reuse one path + stats while varying content, which the real fingerprint is entitled to treat as unchanged).
- Full suite green: 35,950 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved loading speed for local session lists, including paginated views.
  - Reduced repeated processing when viewing token usage and session statistics.

- **Reliability**
  - Improved handling of empty, missing, changed, or temporarily unreadable session files.
  - Preserved accurate results while refreshing updated session data.

- **Documentation**
  - Added guidance covering session metadata caching, maintenance behavior, and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->