### PR TITLE
fix(context): show true over-limit percentages in the Context Timeline (R1)

### DIFF
--- a/src/__tests__/renderer/components/ContextTimelinePanel.test.tsx
+++ b/src/__tests__/renderer/components/ContextTimelinePanel.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * Tests for ContextTimelinePanel
+ *
+ * Focus: the over-limit rendering contract (finding R1). Every row's label, bar
+ * width and color derive from ONE value - computeOverLimitDisplay over that
+ * row's stored contextTokens/contextWindow - so a row that breached the window
+ * still reads its true percentage instead of collapsing to "~" or a clamped
+ * full-width 100% bar.
+ *
+ * Deliberately provider-agnostic: rows are seeded from explicit token/window
+ * pairs, never from "provider X produces over-limit rows".
+ */
+
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ContextTimelinePanel } from '../../../renderer/components/ContextTimelinePanel';
+import { LayerStackProvider } from '../../../renderer/contexts/LayerStackContext';
+import {
+	useContextTimelineStore,
+	type ContextTimelinePointInput,
+} from '../../../renderer/stores/contextTimelineStore';
+import { computeOverLimitDisplay } from '../../../renderer/utils/contextUsage';
+import type { Theme } from '../../../renderer/types';
+
+vi.mock('lucide-react', () => ({
+	Gauge: () => <svg data-testid="gauge-icon" />,
+	Minus: () => <svg data-testid="minus-icon" />,
+	X: () => <svg data-testid="x-icon" />,
+	Trash2: () => <svg data-testid="trash-icon" />,
+}));
+
+const testTheme: Theme = {
+	id: 'test-theme',
+	name: 'Test Theme',
+	mode: 'dark',
+	colors: {
+		bgMain: '#1e1e1e',
+		bgSidebar: '#252526',
+		bgActivity: '#333333',
+		textMain: '#d4d4d4',
+		textDim: '#808080',
+		accent: '#007acc',
+		accentForeground: '#ffffff',
+		border: '#404040',
+		error: '#f14c4c',
+		warning: '#cca700',
+		success: '#89d185',
+	},
+};
+
+const SID = 'session-timeline';
+const WINDOW = 200_000;
+
+function pt(overrides: Partial<ContextTimelinePointInput> = {}): ContextTimelinePointInput {
+	return {
+		tabId: 'tab-a',
+		inputTokens: 100,
+		outputTokens: 20,
+		cacheReadInputTokens: 0,
+		cacheCreationInputTokens: 0,
+		reasoningTokens: 0,
+		totalCostUsd: 0,
+		contextTokens: 100_000,
+		contextWindow: WINDOW,
+		percentage: 50,
+		...overrides,
+	};
+}
+
+function reset() {
+	useContextTimelineStore.setState({
+		panelSessionId: null,
+		minimized: false,
+		anchorRect: null,
+		buffers: {},
+	});
+}
+
+/** Seed points (oldest first) and open the panel for them. */
+function seed(points: ContextTimelinePointInput[]) {
+	const store = useContextTimelineStore.getState();
+	store.openPanel(SID);
+	for (const p of points) store.appendPoint(SID, p);
+}
+
+function renderPanel() {
+	return render(
+		<LayerStackProvider>
+			<ContextTimelinePanel theme={testTheme} />
+		</LayerStackProvider>
+	);
+}
+
+/** Fill-bar widths in render order (newest first, as the panel displays them). */
+function fillWidths(): string[] {
+	return screen.getAllByTestId('timeline-bar-fill').map((el) => (el as HTMLElement).style.width);
+}
+
+/**
+ * Row labels in render order. The label is assembled from several JSX text
+ * nodes, so it is read off the element rather than matched with getByText.
+ */
+function rowLabels(): HTMLElement[] {
+	return screen.getAllByTestId('timeline-row-label') as HTMLElement[];
+}
+
+function labelTexts(): string[] {
+	return rowLabels().map((el) => el.textContent ?? '');
+}
+
+/** The single row whose label contains `needle`. */
+function rowLabel(needle: string): HTMLElement {
+	const match = rowLabels().filter((el) => (el.textContent ?? '').includes(needle));
+	expect(match).toHaveLength(1);
+	return match[0];
+}
+
+describe('ContextTimelinePanel over-limit rendering', () => {
+	beforeEach(reset);
+
+	// Under, exactly at, and over the window. The store's own `percentage` is
+	// null for the over-limit point, exactly as useAgentUsageListener records it.
+	const UNDER = pt({ contextTokens: 100_000, percentage: 50 });
+	const AT = pt({ contextTokens: WINDOW, percentage: 100 });
+	const OVER = pt({ contextTokens: 310_000, percentage: null });
+
+	it('labels each row with its true percentage, including past 100%', () => {
+		seed([UNDER, AT, OVER]);
+		renderPanel();
+
+		// Newest first. The 155% row used to render "~" beside a capped "200k+".
+		expect(labelTexts()).toEqual([
+			'155% · 310.0K / 200.0K',
+			'100% · 200.0K / 200.0K',
+			'50% · 100.0K / 200.0K',
+		]);
+	});
+
+	it('sizes every fill bar from computeOverLimitDisplay against the shared scale', () => {
+		seed([UNDER, AT, OVER]);
+		renderPanel();
+
+		// Per-panel headroom scale: max(window, peak tokens) = 310k.
+		const scaleMax = 310_000;
+		// Newest first.
+		const expected = [OVER, AT, UNDER].map((p) => {
+			const d = computeOverLimitDisplay(p.contextTokens, p.contextWindow, scaleMax);
+			return `${Math.max(d.fillFraction * 100, 2)}%`;
+		});
+
+		expect(fillWidths()).toEqual(expected);
+		// The point of the headroom scale: the bars are no longer all full width.
+		expect(fillWidths()[0]).toBe('100%');
+		expect(fillWidths()[1]).not.toBe('100%');
+		expect(fillWidths()[2]).not.toBe('100%');
+	});
+
+	it('renders the 100% tick only when a turn exceeded the window', () => {
+		seed([UNDER, AT]);
+		const { unmount } = renderPanel();
+		expect(screen.queryAllByTestId('timeline-limit-tick')).toHaveLength(0);
+		unmount();
+
+		reset();
+		seed([UNDER, AT, OVER]);
+		renderPanel();
+		const ticks = screen.getAllByTestId('timeline-limit-tick');
+		expect(ticks).toHaveLength(3);
+		// window / scaleMax = 200k / 310k.
+		expect((ticks[0] as HTMLElement).style.left).toBe(`${(200_000 / 310_000) * 100}%`);
+	});
+
+	it('colors an over-limit row with the error color and an under-limit row with success', () => {
+		seed([UNDER, OVER]);
+		renderPanel();
+
+		expect(rowLabel('155%')).toHaveStyle({ color: testTheme.colors.error });
+		expect(rowLabel('50%')).toHaveStyle({ color: testTheme.colors.success });
+	});
+
+	it('explains an over-limit row without claiming what the tokens measure', () => {
+		seed([OVER]);
+		const { unmount } = renderPanel();
+
+		expect(rowLabel('155%')).toHaveAttribute(
+			'title',
+			'Over the context limit: 310.0K against a 200.0K window'
+		);
+		unmount();
+
+		// An in-window row carries no such note.
+		reset();
+		seed([UNDER]);
+		renderPanel();
+		expect(rowLabel('50%')).not.toHaveAttribute('title');
+	});
+
+	it('keeps "~" only when a point has no window to divide by', () => {
+		seed([pt({ contextTokens: 12_000, contextWindow: 0, percentage: null })]);
+		renderPanel();
+
+		expect(labelTexts()).toEqual(['~ · 12.0K']);
+	});
+
+	it('shows the newest turn true percentage in the panel header past 100%', () => {
+		seed([UNDER, OVER]);
+		renderPanel();
+
+		expect(screen.getByTitle('Latest context fill')).toHaveTextContent('155%');
+	});
+});

--- a/src/__tests__/renderer/components/ContextTimelinePanel.test.tsx
+++ b/src/__tests__/renderer/components/ContextTimelinePanel.test.tsx
@@ -171,6 +171,42 @@ describe('ContextTimelinePanel over-limit rendering', () => {
 		expect((ticks[0] as HTMLElement).style.left).toBe(`${(200_000 / 310_000) * 100}%`);
 	});
 
+	// Review of PR #1364, flagged independently by both bots. The scale was
+	// seeded from the LATEST window only, and one shared tick was drawn from it,
+	// while each row divides by its OWN stored window. A mid-session window
+	// change therefore contradicted the labels - exactly what Decision 3 says
+	// must not happen.
+	describe('mixed windows across turns', () => {
+		// An older, roomier turn (800k of 1M) followed by a turn recorded after
+		// the window shrank to 200k.
+		const OLD_BIG = pt({ id: 'old', contextTokens: 800_000, contextWindow: 1_000_000 });
+		const NEW_SMALL = pt({ id: 'new', contextTokens: 100_000, contextWindow: 200_000 });
+
+		it('does not draw an under-limit row at full width', () => {
+			seed([OLD_BIG, NEW_SMALL]);
+			renderPanel();
+
+			// Scale is max over tokens AND windows = 1M, so the 800k row fills 80%.
+			// Seeding from the latest window alone made the scale 800k and drew this
+			// 80% row as a full bar.
+			expect(labelTexts()).toEqual(['50% · 100.0K / 200.0K', '80% · 800.0K / 1.0M']);
+			expect(fillWidths()).toEqual(['10%', '80%']);
+		});
+
+		it('places each row 100% tick at that row own window', () => {
+			seed([OLD_BIG, NEW_SMALL]);
+			renderPanel();
+
+			// Only ONE tick: the 1M row's limit IS the scale maximum, so it has no
+			// headroom beyond it and correctly draws none. The 200k row does.
+			const ticks = screen.getAllByTestId('timeline-limit-tick');
+			expect(ticks).toHaveLength(1);
+			// 200k/1M = 20%. The old shared tick used the latest window over a
+			// latest-seeded scale and would have put it at 100%.
+			expect((ticks[0] as HTMLElement).style.left).toBe(`${(200_000 / 1_000_000) * 100}%`);
+		});
+	});
+
 	it('colors an over-limit row with the error color and an under-limit row with success', () => {
 		seed([UNDER, OVER]);
 		renderPanel();

--- a/src/__tests__/renderer/components/MainPanel/MainPanelHeader.test.tsx
+++ b/src/__tests__/renderer/components/MainPanel/MainPanelHeader.test.tsx
@@ -429,6 +429,19 @@ describe('MainPanelHeader', () => {
 		expect(screen.getByText('25%')).toBeInTheDocument();
 	});
 
+	it('renders an over-limit context percentage past 100 without clamping', () => {
+		// Finding R1, Decision 2: the pill shows the true percentage whenever it
+		// has an over-limit measurement, so the header cannot silently disagree
+		// with the Context Timeline. The readout renders whatever number arrives;
+		// this pins that it is not clamped on the way out.
+		render(<MainPanelHeader {...defaultProps} activeTabContextUsage={147} />);
+		const readout = screen.getByText('147%');
+		expect(readout).toBeInTheDocument();
+		// A 4-character value must not wrap in the fixed-width mono pill.
+		expect(readout).toHaveClass('whitespace-nowrap');
+		expect(readout).toHaveClass('tabular-nums');
+	});
+
 	it('renders GitStatusWidget', () => {
 		render(<MainPanelHeader {...defaultProps} />);
 		expect(screen.getByTestId('git-status-widget')).toBeInTheDocument();

--- a/src/__tests__/renderer/utils/contextUsage.test.ts
+++ b/src/__tests__/renderer/utils/contextUsage.test.ts
@@ -490,6 +490,49 @@ describe('calculateContextDisplay', () => {
 		expect(result.tokens).toBe(200000);
 		expect(result.percentage).toBe(100);
 	});
+
+	describe('over-limit percentages (finding R1, Decision 2)', () => {
+		it('reads exactly 100 at the window boundary with the clamp removed', () => {
+			const result = calculateContextDisplay(
+				{ inputTokens: 150000, cacheReadInputTokens: 50000 },
+				200000,
+				'claude-code'
+			);
+			expect(result.tokens).toBe(200000);
+			expect(result.percentage).toBe(100);
+			expect(result.trustworthy).toBe(true);
+		});
+
+		it('still bounds a fallback-derived reading at 100', () => {
+			// The bound that stays (Task 5): a stored `contextUsage` fallback is
+			// 0-100 by construction, so a percentage recovered from it is NOT an
+			// over-limit measurement and must not be presented as one.
+			const result = calculateContextDisplay(
+				{ inputTokens: 400000, cacheReadInputTokens: 100000 },
+				200000,
+				'claude-code',
+				150
+			);
+			expect(result.percentage).toBe(100);
+			expect(result.trustworthy).toBe(true);
+		});
+
+		it('documents that a raw over-limit frame is still untrustworthy, not a >100 reading', () => {
+			// KNOWN GAP, deliberate: removing the clamp does not by itself make the
+			// header pill read `147%`. A raw frame above the window with no
+			// fallback hits the #762 branch first and returns untrustworthy zeros,
+			// so the header holds its last good value instead. Changing that branch
+			// is explicitly out of scope for this playbook; this test pins the
+			// current contract so the asymmetry with the timeline stays deliberate.
+			const result = calculateContextDisplay(
+				{ inputTokens: 250000, cacheReadInputTokens: 44000 },
+				200000,
+				'claude-code'
+			);
+			expect(result.percentage).toBe(0);
+			expect(result.trustworthy).toBe(false);
+		});
+	});
 });
 
 describe('computeOverLimitDisplay', () => {
@@ -656,5 +699,80 @@ describe('calculateDisplayInputTokens', () => {
 			cacheCreationInputTokens: 50,
 		};
 		expect(calculateDisplayInputTokens(stats, 'brand-new-agent')).toBe(2_053);
+	});
+});
+
+describe('header and timeline cross-surface agreement (finding R1)', () => {
+	const WINDOW = 200000;
+
+	/**
+	 * Feed one tokens/window pair through BOTH display paths: the header's
+	 * `calculateContextDisplay` and the Context Timeline's
+	 * `computeOverLimitDisplay`. The two surfaces sitting side by side must not
+	 * report different numbers for the same turn - that disagreement is the class
+	 * of bug PR #1221 fixed, and R1 re-opened it by rendering the over-limit case
+	 * differently on each surface.
+	 */
+	const bothSurfaces = (contextTokens: number) => ({
+		header: calculateContextDisplay(
+			{ inputTokens: contextTokens, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 },
+			WINDOW,
+			'claude-code'
+		),
+		timeline: computeOverLimitDisplay(contextTokens, WINDOW),
+	});
+
+	it('agrees on an under-limit turn', () => {
+		const { header, timeline } = bothSurfaces(90000);
+		expect(header.trustworthy).toBe(true);
+		expect(header.percentage).toBe(45);
+		expect(timeline.truePercentage).toBe(45);
+		expect(header.percentage).toBe(timeline.truePercentage);
+		expect(timeline.overLimit).toBe(false);
+	});
+
+	it('agrees on a turn exactly at the limit', () => {
+		const { header, timeline } = bothSurfaces(WINDOW);
+		expect(header.trustworthy).toBe(true);
+		expect(header.percentage).toBe(100);
+		expect(timeline.truePercentage).toBe(100);
+		expect(header.percentage).toBe(timeline.truePercentage);
+		// Exactly at the window is not over it.
+		expect(timeline.overLimit).toBe(false);
+	});
+
+	it('documents the over-limit asymmetry so future drift is deliberate', () => {
+		// The timeline reports the true magnitude of an over-limit turn, which is
+		// the whole point of R1. The header does NOT match it on this input, and
+		// that is by construction rather than by a clamp: a raw frame above the
+		// window with no preserved fallback is the #762 untrustworthy branch, so
+		// the header holds its previous good value instead of rendering anything.
+		// `calculateContextDisplay`'s own clamp is gone (Decision 2), so the day a
+		// trustworthy over-limit numerator reaches it, it will agree with the
+		// timeline automatically. Pinned here so any change to that contract has
+		// to update this expectation on purpose.
+		const { header, timeline } = bothSurfaces(294000);
+		expect(timeline.truePercentage).toBe(147);
+		expect(timeline.overLimit).toBe(true);
+		expect(header.trustworthy).toBe(false);
+		expect(header.percentage).toBe(0);
+	});
+
+	it('agrees when the over-limit turn arrives with a preserved fallback', () => {
+		// The reachable over-limit path today: the accumulated-turn fallback. It is
+		// bounded at 100 on purpose (a stored contextUsage is 0-100 by
+		// construction), so the header reads 100 while the timeline, which plots
+		// the real measured tokens, reads the true figure. Same documented
+		// asymmetry, different entry point.
+		const header = calculateContextDisplay(
+			{ inputTokens: 294000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 },
+			WINDOW,
+			'claude-code',
+			100
+		);
+		const timeline = computeOverLimitDisplay(294000, WINDOW);
+		expect(header.trustworthy).toBe(true);
+		expect(header.percentage).toBe(100);
+		expect(timeline.truePercentage).toBe(147);
 	});
 });

--- a/src/__tests__/renderer/utils/contextUsage.test.ts
+++ b/src/__tests__/renderer/utils/contextUsage.test.ts
@@ -7,6 +7,7 @@ import {
 	estimateContextUsage,
 	calculateContextTokens,
 	calculateContextDisplay,
+	computeOverLimitDisplay,
 	calculateDisplayInputTokens,
 	estimateAccumulatedGrowth,
 	DEFAULT_CONTEXT_WINDOWS,
@@ -488,6 +489,103 @@ describe('calculateContextDisplay', () => {
 		// Falls back to: round(100/100 * 200000) = 200000
 		expect(result.tokens).toBe(200000);
 		expect(result.percentage).toBe(100);
+	});
+});
+
+describe('computeOverLimitDisplay', () => {
+	const WINDOW = 200000;
+
+	it('reports an under-limit point with its true percentage and proportional fill', () => {
+		const result = computeOverLimitDisplay(100000, WINDOW);
+
+		expect(result.truePercentage).toBe(50);
+		expect(result.overLimit).toBe(false);
+		expect(result.fillFraction).toBe(0.5);
+	});
+
+	it('treats a point exactly at the window as 100% but NOT over limit', () => {
+		const result = computeOverLimitDisplay(WINDOW, WINDOW);
+
+		expect(result.truePercentage).toBe(100);
+		expect(result.overLimit).toBe(false);
+		expect(result.fillFraction).toBe(1);
+	});
+
+	it('reports the true unclamped percentage for an over-limit point', () => {
+		// 294000 / 200000 = 147%
+		const result = computeOverLimitDisplay(294000, WINDOW);
+
+		expect(result.truePercentage).toBe(147);
+		expect(result.overLimit).toBe(true);
+		// Without a headroom scale the bar saturates at the track end.
+		expect(result.fillFraction).toBe(1);
+	});
+
+	it('fills proportionally against a shared headroom scale', () => {
+		const result = computeOverLimitDisplay(294000, WINDOW, WINDOW * 2);
+
+		expect(result.truePercentage).toBe(147);
+		expect(result.overLimit).toBe(true);
+		// 294000 / 400000 = 0.735, so the bar sits past the 100% tick at 0.5.
+		expect(result.fillFraction).toBeCloseTo(0.735, 5);
+	});
+
+	it('keeps an under-limit point below the tick when a headroom scale applies', () => {
+		const result = computeOverLimitDisplay(100000, WINDOW, WINDOW * 2);
+
+		expect(result.truePercentage).toBe(50);
+		expect(result.overLimit).toBe(false);
+		expect(result.fillFraction).toBeCloseTo(0.25, 5);
+	});
+
+	it('uses each point OWN window for the percentage, not the shared scale', () => {
+		// A mid-session window change must not retroactively distort old rows.
+		const older = computeOverLimitDisplay(90000, 100000, 400000);
+
+		expect(older.truePercentage).toBe(90);
+		expect(older.overLimit).toBe(false);
+		expect(older.fillFraction).toBeCloseTo(0.225, 5);
+	});
+
+	it('returns zeros (not NaN) for a degenerate zero window', () => {
+		const result = computeOverLimitDisplay(50000, 0);
+
+		expect(result.truePercentage).toBe(0);
+		expect(result.fillFraction).toBe(0);
+		expect(result.overLimit).toBe(false);
+		expect(Number.isNaN(result.truePercentage)).toBe(false);
+		expect(Number.isNaN(result.fillFraction)).toBe(false);
+	});
+
+	it('returns zeros for a negative or non-finite window', () => {
+		expect(computeOverLimitDisplay(50000, -1)).toEqual({
+			truePercentage: 0,
+			fillFraction: 0,
+			overLimit: false,
+		});
+		expect(computeOverLimitDisplay(50000, Number.NaN)).toEqual({
+			truePercentage: 0,
+			fillFraction: 0,
+			overLimit: false,
+		});
+	});
+
+	it('floors negative or non-finite token counts at zero', () => {
+		expect(computeOverLimitDisplay(-500, WINDOW)).toEqual({
+			truePercentage: 0,
+			fillFraction: 0,
+			overLimit: false,
+		});
+		expect(computeOverLimitDisplay(Number.NaN, WINDOW)).toEqual({
+			truePercentage: 0,
+			fillFraction: 0,
+			overLimit: false,
+		});
+	});
+
+	it('ignores an unusable scaleMax and falls back to the window', () => {
+		expect(computeOverLimitDisplay(100000, WINDOW, 0).fillFraction).toBe(0.5);
+		expect(computeOverLimitDisplay(100000, WINDOW, Number.NaN).fillFraction).toBe(0.5);
 	});
 });
 

--- a/src/__tests__/renderer/utils/contextUsage.test.ts
+++ b/src/__tests__/renderer/utils/contextUsage.test.ts
@@ -536,6 +536,20 @@ describe('calculateContextDisplay', () => {
 });
 
 describe('computeOverLimitDisplay', () => {
+	// Review of PR #1364 (CodeRabbit). The guard checked `scaleMax > 0`, so a
+	// positive-but-too-small scale slipped through and pushed an in-window point
+	// past the track - the exact case the code comment warned about.
+	it('ignores a scaleMax smaller than the window', () => {
+		const result = computeOverLimitDisplay(100_000, 200_000, 100_000);
+		expect(result.fillFraction).toBe(0.5);
+		expect(result.truePercentage).toBe(50);
+		expect(result.overLimit).toBe(false);
+	});
+
+	it('uses a scaleMax equal to the window unchanged', () => {
+		expect(computeOverLimitDisplay(100_000, 200_000, 200_000).fillFraction).toBe(0.5);
+	});
+
 	const WINDOW = 200000;
 
 	it('reports an under-limit point with its true percentage and proportional fill', () => {

--- a/src/__tests__/renderer/utils/theme.test.tsx
+++ b/src/__tests__/renderer/utils/theme.test.tsx
@@ -102,6 +102,15 @@ describe('theme utilities', () => {
 			it('returns error color at boundary 80.01%', () => {
 				expect(getContextColor(80.01, mockTheme)).toBe(mockTheme.colors.error);
 			});
+
+			it('saturates at error for over-limit usage above 100%', () => {
+				// Finding R1, Decision 4: no fourth "over" state is added to the ramp.
+				// Magnitude past the limit is conveyed by the timeline's geometry (the
+				// 100% tick plus the overflow extension), never by a new hue. Pinned
+				// here so the contract is written down rather than implied.
+				expect(getContextColor(147, mockTheme)).toBe(mockTheme.colors.error);
+				expect(getContextColor(1000, mockTheme)).toBe(mockTheme.colors.error);
+			});
 		});
 
 		describe('uses correct theme colors', () => {

--- a/src/renderer/components/ContextTimelinePanel.tsx
+++ b/src/renderer/components/ContextTimelinePanel.tsx
@@ -33,6 +33,7 @@ import { useSessionStore } from '../stores/sessionStore';
 // creates a fresh private stack). This one reads the app's shared layer stack.
 import { useLayerStack } from '../contexts/LayerStackContext';
 import { getContextColor } from '../utils/theme';
+import { computeOverLimitDisplay } from '../utils/contextUsage';
 import { formatTokensCompact, formatCost } from '../../shared/formatters';
 import { useEventListener } from '../hooks/utils/useEventListener';
 
@@ -128,7 +129,28 @@ export function ContextTimelinePanel({ theme }: ContextTimelinePanelProps) {
 
 	const latest: ContextTimelinePoint | undefined = points[points.length - 1];
 	const latestWindow = latest?.contextWindow ?? 0;
-	const latestPercent = latest?.percentage ?? null;
+	// True (unclamped) fill for the newest turn. Reading the stored
+	// tokens/window rather than the point's `percentage` is what keeps this
+	// readout alive past 100%: the stored percentage is null once a turn breaches
+	// the window, which used to blank the number exactly when it mattered most.
+	const latestPercent =
+		latest && latest.contextWindow > 0
+			? computeOverLimitDisplay(latest.contextTokens, latest.contextWindow).truePercentage
+			: (latest?.percentage ?? null);
+
+	// Per-panel headroom scale (option A, Decision 3): every rendered row shares
+	// ONE track maximum so bar lengths stay comparable across turns, while each
+	// row's percentage still divides by its OWN stored window - a mid-session
+	// window change must not retroactively distort older rows. When nothing
+	// exceeds the window this equals the window and the track behaves as before.
+	const scaleMax = useMemo(
+		() => points.reduce((max, p) => Math.max(max, p.contextTokens), latestWindow),
+		[points, latestWindow]
+	);
+	// The 100% boundary inside the track, drawn only when there IS headroom
+	// beyond it (i.e. some turn went over the limit).
+	const tickPercent =
+		scaleMax > latestWindow && latestWindow > 0 ? (latestWindow / scaleMax) * 100 : null;
 
 	// This is a PASSIVE inspector, so it deliberately does NOT register a layer:
 	// any layer (modal or overlay) trips hasOpenLayers()/hasOpenModal() and
@@ -248,25 +270,14 @@ export function ContextTimelinePanel({ theme }: ContextTimelinePanelProps) {
 				) : (
 					<div className="flex flex-col gap-2.5">
 						{ordered.map((p) => {
-							const pct = p.percentage;
-							// Drive the bar width from the SAME value as the % label and color:
-							// the provider-reported percentage when available, else the raw
-							// tokens/window ratio. Otherwise a "50%" label could sit beside a
-							// 30%-filled bar when the two sources disagree.
-							const fillFraction =
-								pct !== null
-									? Math.min(1, Math.max(0, pct / 100))
-									: p.contextWindow > 0
-										? Math.min(1, Math.max(0, p.contextTokens / p.contextWindow))
-										: 0;
-							const barColor = getContextColor(pct ?? Math.round(fillFraction * 100), theme);
-							// When the percentage is indeterminate (an accumulated multi-tool
-							// turn whose raw tokens exceed the window), contextTokens can read
-							// higher than the window - "310k / 200k" would imply an impossible
-							// breach. Cap the shown figure to the window and flag it instead.
-							const overflow =
-								pct === null && p.contextWindow > 0 && p.contextTokens > p.contextWindow;
-							const displayTokens = overflow ? p.contextWindow : p.contextTokens;
+							// ONE value drives the label, the bar width and the color, so they
+							// cannot disagree: the true (unclamped) ratio of this row's stored
+							// tokens to this row's stored window, with the bar measured against
+							// the shared headroom scale. A row with no window at all still has
+							// no denominator to divide by and stays "~".
+							const hasWindow = p.contextWindow > 0;
+							const display = computeOverLimitDisplay(p.contextTokens, p.contextWindow, scaleMax);
+							const barColor = getContextColor(display.truePercentage, theme);
 							return (
 								<div key={p.id} className="flex flex-col gap-1">
 									<div className="flex items-center justify-between gap-2">
@@ -279,31 +290,43 @@ export function ContextTimelinePanel({ theme }: ContextTimelinePanelProps) {
 										</span>
 										<span
 											className="text-[10px] font-mono tabular-nums"
+											data-testid="timeline-row-label"
 											style={{ color: barColor }}
 											title={
-												overflow
-													? 'Accumulated across multiple internal calls in one turn'
+												display.overLimit
+													? `Over the context limit: ${formatTokensCompact(p.contextTokens)} against a ${formatTokensCompact(p.contextWindow)} window`
 													: undefined
 											}
 										>
-											{pct !== null ? `${Math.round(pct)}%` : '~'} ·{' '}
-											{formatTokensCompact(displayTokens)}
-											{overflow ? '+' : ''}
-											{p.contextWindow > 0 ? ` / ${formatTokensCompact(p.contextWindow)}` : ''}
+											{hasWindow ? `${display.truePercentage}%` : '~'} ·{' '}
+											{formatTokensCompact(p.contextTokens)}
+											{hasWindow ? ` / ${formatTokensCompact(p.contextWindow)}` : ''}
 										</span>
 									</div>
 									{/* Fill bar */}
 									<div
-										className="h-2 rounded-full overflow-hidden"
+										className="h-2 rounded-full overflow-hidden relative"
 										style={{ backgroundColor: theme.colors.bgActivity }}
+										data-testid="timeline-bar-track"
 									>
 										<div
 											className="h-full rounded-full transition-all"
+											data-testid="timeline-bar-fill"
 											style={{
-												width: `${Math.max(fillFraction * 100, p.contextTokens > 0 ? 2 : 0)}%`,
+												width: `${Math.max(display.fillFraction * 100, p.contextTokens > 0 ? 2 : 0)}%`,
 												backgroundColor: barColor,
 											}}
 										/>
+										{/* The persistent 100% boundary; only drawn once some turn
+											    has pushed the track past the window. */}
+										{tickPercent !== null && (
+											<div
+												className="absolute top-0 bottom-0 w-px pointer-events-none"
+												data-testid="timeline-limit-tick"
+												style={{ left: `${tickPercent}%`, backgroundColor: theme.colors.textMain }}
+												title="100% of the context window"
+											/>
+										)}
 									</div>
 									{/* Per-turn token breakdown */}
 									<div className="flex flex-wrap gap-x-3 gap-y-0.5 text-[10px]">

--- a/src/renderer/components/ContextTimelinePanel.tsx
+++ b/src/renderer/components/ContextTimelinePanel.tsx
@@ -143,14 +143,15 @@ export function ContextTimelinePanel({ theme }: ContextTimelinePanelProps) {
 	// row's percentage still divides by its OWN stored window - a mid-session
 	// window change must not retroactively distort older rows. When nothing
 	// exceeds the window this equals the window and the track behaves as before.
+	// Every row's OWN window counts toward the track maximum, not just the latest
+	// one. Seeding from `latestWindow` alone broke the geometry the moment the
+	// window changed mid-session: an older 800k/1M row against a latest 200k
+	// window made `scaleMax` 800k, so that row filled the whole track while its
+	// label read 80% - an under-limit row drawn as if it were at the limit.
 	const scaleMax = useMemo(
-		() => points.reduce((max, p) => Math.max(max, p.contextTokens), latestWindow),
-		[points, latestWindow]
+		() => points.reduce((max, p) => Math.max(max, p.contextTokens, p.contextWindow), 0),
+		[points]
 	);
-	// The 100% boundary inside the track, drawn only when there IS headroom
-	// beyond it (i.e. some turn went over the limit).
-	const tickPercent =
-		scaleMax > latestWindow && latestWindow > 0 ? (latestWindow / scaleMax) * 100 : null;
 
 	// This is a PASSIVE inspector, so it deliberately does NOT register a layer:
 	// any layer (modal or overlay) trips hasOpenLayers()/hasOpenModal() and
@@ -278,6 +279,13 @@ export function ContextTimelinePanel({ theme }: ContextTimelinePanelProps) {
 							const hasWindow = p.contextWindow > 0;
 							const display = computeOverLimitDisplay(p.contextTokens, p.contextWindow, scaleMax);
 							const barColor = getContextColor(display.truePercentage, theme);
+							// The 100% boundary is per row, because each row's limit is its
+							// OWN stored window. A single shared tick drawn from the latest
+							// window would sit at the wrong place on every row recorded
+							// under a different one. Drawn only when there is headroom
+							// beyond that row's limit within the shared track.
+							const tickPercent =
+								hasWindow && scaleMax > p.contextWindow ? (p.contextWindow / scaleMax) * 100 : null;
 							return (
 								<div key={p.id} className="flex flex-col gap-1">
 									<div className="flex items-center justify-between gap-2">

--- a/src/renderer/components/TabSwitcherModal.tsx
+++ b/src/renderer/components/TabSwitcherModal.tsx
@@ -152,7 +152,11 @@ function ContextGauge({
 	const strokeWidth = 3;
 	const radius = (size - strokeWidth) / 2;
 	const circumference = 2 * Math.PI * radius;
-	const strokeDashoffset = circumference - (percentage / 100) * circumference;
+	// The arc fill clamps at a full circle while the readout below stays true:
+	// `calculateContextDisplay` can now return a percentage above 100 (finding
+	// R1), and an unclamped fraction would drive `strokeDashoffset` negative,
+	// wrapping the dash pattern instead of reading as "full".
+	const strokeDashoffset = circumference - Math.min(1, percentage / 100) * circumference;
 	const color = getContextColor(percentage, theme);
 
 	return (

--- a/src/renderer/utils/contextUsage.ts
+++ b/src/renderer/utils/contextUsage.ts
@@ -273,6 +273,71 @@ export function calculateContextDisplay(
 }
 
 /**
+ * Result of an over-limit display calculation.
+ *
+ * The finding-R1 invariant: the label, the bar width and the color of a context
+ * row must ALL derive from this one return value, so they cannot disagree.
+ */
+export interface OverLimitDisplayResult {
+	/**
+	 * The UNCLAMPED usage percentage of this measurement against its OWN window.
+	 * An over-limit point reads e.g. `147`. 0 when the window is unknown.
+	 */
+	truePercentage: number;
+	/**
+	 * How much of the rendered track this point fills, 0-1. Measured against
+	 * `scaleMax` (the shared per-panel headroom scale) when one is supplied,
+	 * otherwise against the point's own window.
+	 */
+	fillFraction: number;
+	/** True when this measurement exceeds its own context window. */
+	overLimit: boolean;
+}
+
+/**
+ * Compute the display math for one context measurement, including the
+ * over-limit case (finding R1).
+ *
+ * Before this helper, an over-limit point was rendered as a full-width bar
+ * labelled `100%` or `~`, so the panel stopped conveying information exactly
+ * when the context story got interesting. `truePercentage` is deliberately
+ * NOT clamped: showing `147%` is the numeric floor of the fix.
+ *
+ * The per-panel headroom scale (Decision 3) is expressed through `scaleMax`:
+ * callers pass `max(window, observedPeakTokens)` across the rendered points so
+ * over-limit bars extend proportionally past the 100% tick, which sits at
+ * `window / scaleMax`. Only the SCALE maximum is shared - `truePercentage` uses
+ * each point's own `contextWindow`, so a mid-session window change cannot
+ * retroactively distort older rows.
+ *
+ * @param contextTokens - Tokens measured for this point
+ * @param contextWindow - The window this point was measured against (0 = unknown)
+ * @param scaleMax - Optional shared track maximum; defaults to `contextWindow`
+ * @returns True percentage, fill fraction (0-1) and the over-limit flag
+ */
+export function computeOverLimitDisplay(
+	contextTokens: number,
+	contextWindow: number,
+	scaleMax?: number
+): OverLimitDisplayResult {
+	if (!contextWindow || contextWindow <= 0 || !Number.isFinite(contextWindow)) {
+		return { truePercentage: 0, fillFraction: 0, overLimit: false };
+	}
+
+	const tokens = Number.isFinite(contextTokens) && contextTokens > 0 ? contextTokens : 0;
+	const truePercentage = Math.round((tokens / contextWindow) * 100);
+	const overLimit = tokens > contextWindow;
+
+	// A scaleMax below the window would push in-window points past the track,
+	// so an unusable value falls back to the window itself.
+	const effectiveScale =
+		scaleMax != null && Number.isFinite(scaleMax) && scaleMax > 0 ? scaleMax : contextWindow;
+	const fillFraction = Math.min(1, Math.max(0, tokens / effectiveScale));
+
+	return { truePercentage, fillFraction, overLimit };
+}
+
+/**
  * Estimate context growth during accumulated (multi-tool) turns.
  *
  * When estimateContextUsage returns null (accumulated values), the percentage

--- a/src/renderer/utils/contextUsage.ts
+++ b/src/renderer/utils/contextUsage.ts
@@ -267,7 +267,22 @@ export function calculateContextDisplay(
 		}
 	}
 
-	const percentage = tokens <= 0 ? 0 : Math.min(100, Math.round((tokens / contextWindow) * 100));
+	// NOT clamped to 100 (finding R1, Decision 2). A `Math.min(100, ...)` here
+	// laundered a genuine over-limit measurement into a flat, indistinguishable
+	// `100%` on the header pill and the Context Window popover, which is the same
+	// symptom the Context Timeline had. The header now reports whatever it
+	// actually measured, matching `computeOverLimitDisplay`'s `truePercentage`
+	// for the same tokens/window pair.
+	//
+	// The two paths above keep their own bounds and are deliberately unchanged:
+	// the untrustworthy-zeros branch (#762) still returns zeros, and the
+	// accumulated-turn fallback is still bounded by `Math.min(100, ...)` at the
+	// FALLBACK, because a stored `contextUsage` is 0-100 by construction and a
+	// percentage recovered from it is not an over-limit measurement. So today
+	// this expression only exceeds 100 if a caller supplies a numerator above
+	// its own window directly; it is the laundering that is removed, not a new
+	// number that is invented.
+	const percentage = tokens <= 0 ? 0 : Math.round((tokens / contextWindow) * 100);
 
 	return { tokens, percentage, contextWindow, trustworthy };
 }

--- a/src/renderer/utils/contextUsage.ts
+++ b/src/renderer/utils/contextUsage.ts
@@ -343,10 +343,15 @@ export function computeOverLimitDisplay(
 	const truePercentage = Math.round((tokens / contextWindow) * 100);
 	const overLimit = tokens > contextWindow;
 
-	// A scaleMax below the window would push in-window points past the track,
-	// so an unusable value falls back to the window itself.
+	// A scaleMax below the window would push in-window points past the track, so
+	// an unusable value falls back to the window itself. The bound is
+	// `>= contextWindow`, not `> 0`: a positive-but-too-small scale is exactly
+	// the case the comment warns about, and merely checking positivity let it
+	// through - `(100k, 200k, 100k)` returned a full bar for a half-full window.
 	const effectiveScale =
-		scaleMax != null && Number.isFinite(scaleMax) && scaleMax > 0 ? scaleMax : contextWindow;
+		scaleMax != null && Number.isFinite(scaleMax) && scaleMax >= contextWindow
+			? scaleMax
+			: contextWindow;
 	const fillFraction = Math.min(1, Math.max(0, tokens / effectiveScale));
 
 	return { truePercentage, fillFraction, overLimit };


### PR DESCRIPTION
Finding R1. Bottom of a 2-PR stack (#1364 -> #1365); #1365 builds the Context Timeline persistence on top of the shared helper this PR adds.

## Problem

The Context Timeline could not distinguish "at the limit" from "well past it". Every over-limit row rendered as a full red bar reading 100%, so a turn at 105% and one at 300% looked identical, and the header pill laundered the same figure through a `Math.min(100, ...)` before display.

## Fix

- **Shared helper (option C floor).** `computeOverLimitDisplay(contextTokens, contextWindow, scaleMax?)` in `contextUsage.ts` returns `{ truePercentage, fillFraction, overLimit }`. `truePercentage` is unclamped; `fillFraction` is clamped 0-1 against a per-panel scale so rows stay comparable. Both surfaces consume the one helper rather than each deriving percentages.
- **Timeline rendering (options C+A).** Over-limit rows show the true percentage with a tick mark at the 100% boundary and an overflow extension. Scale is per-panel (`max(window, observedPeak)` across rendered points) because cross-row comparability is the point of a timeline, but each row keeps its OWN stored `contextWindow` for its ratio, so a mid-session window change does not retroactively distort earlier rows.
- **Header unclamped.** The `Math.min(100, ...)` on the returned percentage is gone.

Colour deliberately saturates at the existing red instead of adding a fourth `getContextColor` state - that function is used by many surfaces and its three-state ramp is pinned by tests, so magnitude is conveyed by geometry instead.

## Honest caveat

Removing the clamp does **not**, by itself, make the header pill read `147%`. `calculateContextDisplay` cannot currently produce a value above 100 by construction: `tokens` is bounded on every path reaching the percentage line, and a raw over-limit frame with no fallback hits the #762 untrustworthy-zeros branch and returns zeros, so the header holds its last good value.

What ships here is the removal of the **laundering**, not a new number: the day a trustworthy over-limit numerator reaches that line (post-Q1 occupancy snapshots), the header agrees with the timeline automatically instead of flatly reporting `100%`. A cross-surface test pins that asymmetry as structural rather than accidental, so it cannot silently regress.

Two bounds are deliberately left in place: the #762 untrustworthy-zeros branch, and the accumulated-turn fallback (a stored `contextUsage` is 0-100 by construction, so a percentage recovered from it is not an over-limit measurement and must not be presented as one).

## Testing

Scoped only, no full-suite run. 198 tests across `contextUsage`, `theme`, `MainPanelHeader` and the ContextTimeline components. Three tsc configs, prettier clean.

New `header and timeline cross-surface agreement` block feeds one tokens/window pair through both paths and asserts under-limit (45/45), at-limit (100/100, `overLimit` false - exactly at the window is not over it), and the documented over-limit divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Context usage displays now preserve and show percentages above 100%.
  * Timeline bars use a shared scale with visible 100% markers.
  * Over-limit usage includes clearer tooltips and error-state coloring.
  * Context gauges safely cap visual progress while retaining the true percentage.

* **Bug Fixes**
  * Prevented invalid gauge rendering when context usage exceeds its limit.

* **Tests**
  * Added comprehensive coverage for over-limit displays, scaling, tooltips, colors, and percentage formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->