### PR TITLE
feat(mentions): show an SSH pill on remote agents in the @ picker

### DIFF
--- a/src/__tests__/renderer/components/InputArea/overlays/AtMentionPopover.test.tsx
+++ b/src/__tests__/renderer/components/InputArea/overlays/AtMentionPopover.test.tsx
@@ -1,10 +1,11 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AtMentionPopover } from '../../../../../renderer/components/InputArea/overlays/AtMentionPopover';
 import type {
 	MentionCategory,
 	MentionPickerItem,
 } from '../../../../../renderer/hooks/input/useMentionPicker';
+import { ipcCache } from '../../../../../renderer/services/ipcWrapper';
 import { createItemRefs, inputAreaTheme } from '../_fixtures';
 
 /**
@@ -44,6 +45,12 @@ describe('AtMentionPopover', () => {
 		directories: 1,
 		agents: 1,
 	};
+
+	beforeEach(() => {
+		// The SSH name lookup reads through the shared 30s ipcCache entry, so a
+		// prior test's configs would otherwise leak into the next one.
+		ipcCache.invalidate('ssh-configs');
+	});
 
 	function renderPopover(overrides: Record<string, unknown> = {}) {
 		return render(
@@ -117,6 +124,71 @@ describe('AtMentionPopover', () => {
 		expect(
 			screen.getByText(/No other agents available - open another agent in the Left Bar/)
 		).toBeInTheDocument();
+	});
+
+	describe('SSH pill on agent rows', () => {
+		const agentItems: MentionPickerItem[] = [
+			{
+				kind: 'agent',
+				value: '@Local ',
+				displayText: 'Local',
+				targetSessionId: 'local',
+				toolType: 'claude-code',
+				isSshRemote: false,
+				sshRemoteId: null,
+				score: 1,
+			},
+			{
+				kind: 'agent',
+				value: '@Remote ',
+				displayText: 'Remote',
+				targetSessionId: 'remote',
+				toolType: 'claude-code',
+				isSshRemote: true,
+				sshRemoteId: 'remote-1',
+				score: 1,
+			},
+		];
+
+		function renderAgents() {
+			return renderPopover({
+				items: agentItems,
+				category: 'agents' as MentionCategory,
+				filter: '',
+			});
+		}
+
+		it('labels an SSH agent with its resolved remote name and leaves local rows bare', async () => {
+			vi.mocked(window.maestro.sshRemote.getConfigs).mockResolvedValueOnce({
+				success: true,
+				configs: [{ id: 'remote-1', name: 'build-box' }],
+			} as never);
+
+			renderAgents();
+
+			await waitFor(() => expect(screen.getByText('build-box')).toBeInTheDocument());
+
+			// The pill lives on the SSH row only - absence means local.
+			const remoteRow = screen.getByText('Remote').closest('button')!;
+			const localRow = screen.getByText('Local').closest('button')!;
+			expect(remoteRow).toContainElement(screen.getByText('build-box'));
+			expect(localRow.textContent).not.toMatch(/build-box|SSH/);
+		});
+
+		it('falls back to a generic SSH label when the remote name cannot be resolved', async () => {
+			vi.mocked(window.maestro.sshRemote.getConfigs).mockResolvedValueOnce({
+				success: true,
+				configs: [],
+			} as never);
+
+			renderAgents();
+
+			// Still marked remote: a missing name must never read as "local".
+			await waitFor(() => expect(screen.getByText('SSH')).toBeInTheDocument());
+			expect(screen.getByText('Remote').closest('button')).toContainElement(
+				screen.getByText('SSH')
+			);
+		});
 	});
 
 	it('replaces @filter on click and clears mention state', () => {

--- a/src/__tests__/renderer/hooks/useAgentMentionCompletion.test.ts
+++ b/src/__tests__/renderer/hooks/useAgentMentionCompletion.test.ts
@@ -78,6 +78,30 @@ describe('useAgentMentionCompletion', () => {
 		expect(only.toolType).toBe('codex');
 	});
 
+	it('flags SSH agents with their remote id, and leaves local agents unflagged', () => {
+		const suggestions = getSuggestions(
+			[
+				agent('local', 'Local'),
+				agent('remote', 'Remote', {
+					sessionSshRemoteConfig: { enabled: true, remoteId: 'remote-1' },
+				}),
+				// Configured but switched off: the message runs locally, so no pill.
+				agent('off', 'Off', {
+					sessionSshRemoteConfig: { enabled: false, remoteId: 'remote-1' },
+				}),
+			],
+			[],
+			'current'
+		);
+
+		const byName = new Map(suggestions.map((s) => [s.displayText, s]));
+		expect(byName.get('Remote')?.isSshRemote).toBe(true);
+		expect(byName.get('Remote')?.sshRemoteId).toBe('remote-1');
+		expect(byName.get('Local')?.isSshRemote).toBe(false);
+		expect(byName.get('Local')?.sshRemoteId).toBeNull();
+		expect(byName.get('Off')?.isSshRemote).toBe(false);
+	});
+
 	it('surfaces groups with at least one non-terminal member, carrying member ids', () => {
 		const sessions = [
 			agent('a', 'Alpha', { groupId: 'g1' }),

--- a/src/__tests__/renderer/hooks/useSshRemoteNames.test.ts
+++ b/src/__tests__/renderer/hooks/useSshRemoteNames.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useSshRemoteNames } from '../../../renderer/hooks/remote/useSshRemoteNames';
+import { ipcCache } from '../../../renderer/services/ipcWrapper';
+
+const mockGetConfigs = vi.fn();
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	// Shared cache entry with useSshRemotes - clear it so each case fetches.
+	ipcCache.invalidate('ssh-configs');
+	(window as any).maestro = {
+		sshRemote: {
+			getConfigs: mockGetConfigs,
+		},
+	};
+});
+
+describe('useSshRemoteNames', () => {
+	it('starts empty and resolves into an id -> name map', async () => {
+		mockGetConfigs.mockResolvedValue({
+			success: true,
+			configs: [
+				{ id: 'r1', name: 'build-box' },
+				{ id: 'r2', name: 'gpu-rig' },
+			],
+		});
+
+		const { result } = renderHook(() => useSshRemoteNames());
+		expect(result.current.size).toBe(0);
+
+		await waitFor(() => expect(result.current.get('r1')).toBe('build-box'));
+		expect(result.current.get('r2')).toBe('gpu-rig');
+	});
+
+	it('stays empty when the configs fail to load', async () => {
+		mockGetConfigs.mockResolvedValue({ success: false, error: 'nope' });
+
+		const { result } = renderHook(() => useSshRemoteNames());
+		await waitFor(() => expect(mockGetConfigs).toHaveBeenCalled());
+		expect(result.current.size).toBe(0);
+	});
+
+	it('swallows a rejected lookup instead of crashing the caller', async () => {
+		mockGetConfigs.mockRejectedValue(new Error('ipc down'));
+
+		const { result } = renderHook(() => useSshRemoteNames());
+		await waitFor(() => expect(mockGetConfigs).toHaveBeenCalled());
+		expect(result.current.size).toBe(0);
+	});
+
+	it('serves a second mount from the shared cache without a second IPC call', async () => {
+		mockGetConfigs.mockResolvedValue({
+			success: true,
+			configs: [{ id: 'r1', name: 'build-box' }],
+		});
+
+		const first = renderHook(() => useSshRemoteNames());
+		await waitFor(() => expect(first.result.current.get('r1')).toBe('build-box'));
+
+		const second = renderHook(() => useSshRemoteNames());
+		await waitFor(() => expect(second.result.current.get('r1')).toBe('build-box'));
+		expect(mockGetConfigs).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/renderer/components/InputArea/overlays/AtMentionPopover.tsx
+++ b/src/renderer/components/InputArea/overlays/AtMentionPopover.tsx
@@ -10,6 +10,8 @@ import {
 } from '../../../hooks/input/useMentionPicker';
 import { getAgentIcon } from '../../../constants/agentIcons';
 import { getAgentDisplayName } from '../../../../shared/agentMetadata';
+import { useSshRemoteNames } from '../../../hooks/remote/useSshRemoteNames';
+import { SshRemotePill } from '../../ui/SshRemotePill';
 
 interface AtMentionPopoverProps {
 	isOpen: boolean;
@@ -85,6 +87,10 @@ export const AtMentionPopover = memo(function AtMentionPopover({
 	setSelectedIndex,
 	inputRef,
 }: AtMentionPopoverProps) {
+	// Resolved before the early return (hooks can't sit behind a conditional).
+	// One shared, cached lookup labels every SSH row in the list.
+	const sshRemoteNames = useSshRemoteNames();
+
 	// The picker stays mounted while open (even with zero rows) so the category
 	// bar and empty-state row remain visible - it never silently collapses.
 	if (!isOpen || isTerminalMode) {
@@ -213,6 +219,16 @@ export const AtMentionPopover = memo(function AtMentionPopover({
 										</span>
 									)}
 									<span className="flex-1 truncate font-medium">{item.displayText}</span>
+									{/* Where the message will actually run. No pill means local -
+									    the same convention the Left Bar and header use. */}
+									{!isGroup && item.isSshRemote && (
+										<SshRemotePill
+											remoteName={
+												item.sshRemoteId ? sshRemoteNames.get(item.sshRemoteId) : undefined
+											}
+											className="max-w-[140px]"
+										/>
+									)}
 									{!isGroup && item.toolType && (
 										<span className="text-[10px] opacity-50 flex-shrink-0">
 											{getAgentDisplayName(item.toolType)}

--- a/src/renderer/components/ParticipantCard.tsx
+++ b/src/renderer/components/ParticipantCard.tsx
@@ -11,7 +11,6 @@ import {
 	Check,
 	DollarSign,
 	RotateCcw,
-	Server,
 	UserMinus,
 	Eye,
 	EyeOff,
@@ -25,6 +24,7 @@ import { parsePeekOutput, formatPeekLines } from '../utils/peekOutputParser';
 import { formatTimestamp } from '../../shared/formatters';
 import { notifyToast } from '../stores/notificationStore';
 import { logger } from '../utils/logger';
+import { SshRemotePill } from './ui/SshRemotePill';
 
 interface ParticipantCardProps {
 	theme: Theme;
@@ -173,13 +173,7 @@ export function ParticipantCard({
 			<div className="flex items-center gap-2 mt-1.5 flex-wrap">
 				{/* SSH Remote pill - shown when running on SSH remote */}
 				{participant.sshRemoteName && (
-					<span
-						className="flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full shrink-0 border border-purple-500/30 text-purple-500 bg-purple-500/10"
-						title={`SSH Remote: ${participant.sshRemoteName}`}
-					>
-						<Server className="w-2.5 h-2.5 shrink-0" />
-						<span className="uppercase">{participant.sshRemoteName}</span>
-					</span>
+					<SshRemotePill remoteName={participant.sshRemoteName} size="sm" />
 				)}
 				{/* Session ID pill */}
 				{isPending ? (

--- a/src/renderer/components/ui/SshRemotePill.tsx
+++ b/src/renderer/components/ui/SshRemotePill.tsx
@@ -1,0 +1,64 @@
+/**
+ * SshRemotePill - the canonical "this agent runs on an SSH remote" badge.
+ *
+ * Maestro marks remote agents in several surfaces (Main Panel header, group
+ * chat participant cards, the `@` mention picker). They all used to hand-roll
+ * the same purple `Server` + host-name pill, which drifted in size and casing.
+ * Import this instead of writing another one.
+ *
+ * The absence of this pill means "local" - that is the app-wide convention, so
+ * do not pair it with a LOCAL badge.
+ *
+ * The purple palette is intentionally fixed rather than theme-derived: SSH is a
+ * safety-relevant fact (your prompt leaves this machine) and it reads the same
+ * in every theme. Only the size varies.
+ */
+
+import { Server } from 'lucide-react';
+import type { CSSProperties } from 'react';
+
+export interface SshRemotePillProps {
+	/**
+	 * Remote display name. When omitted (config not loaded yet, or the remote was
+	 * deleted) the pill falls back to the literal "SSH" so the row still says
+	 * "not local" instead of silently looking local.
+	 */
+	remoteName?: string | null;
+	/** `xs` for dense list rows, `sm` for headers and cards. */
+	size?: 'xs' | 'sm';
+	/** Overrides the default `SSH Remote: <name>` tooltip. */
+	title?: string;
+	className?: string;
+	style?: CSSProperties;
+}
+
+const SIZE_CLASSES: Record<'xs' | 'sm', { pill: string; icon: string }> = {
+	xs: { pill: 'text-[9px] px-1.5 py-0.5 gap-1', icon: 'w-2.5 h-2.5' },
+	sm: { pill: 'text-[10px] px-2 py-0.5 gap-1', icon: 'w-2.5 h-2.5' },
+};
+
+export function SshRemotePill({
+	remoteName,
+	size = 'xs',
+	title,
+	className,
+	style,
+}: SshRemotePillProps) {
+	const label = remoteName || 'SSH';
+	const sizes = SIZE_CLASSES[size];
+
+	return (
+		<span
+			className={`flex items-center shrink-0 rounded-full border border-purple-500/30 text-purple-500 bg-purple-500/10 ${sizes.pill} ${className ?? ''}`}
+			title={
+				title ?? (remoteName ? `SSH Remote: ${remoteName}` : 'Running on a remote host via SSH')
+			}
+			style={style}
+		>
+			<Server className={`${sizes.icon} shrink-0`} />
+			<span className="uppercase truncate">{label}</span>
+		</span>
+	);
+}
+
+export default SshRemotePill;

--- a/src/renderer/hooks/input/useAgentMentionCompletion.ts
+++ b/src/renderer/hooks/input/useAgentMentionCompletion.ts
@@ -29,6 +29,18 @@ export interface AgentMentionSuggestion {
 	memberSessionIds?: string[];
 	/** For agents: the tool type, used to pick the row icon. */
 	toolType?: ToolType;
+	/**
+	 * For agents: true when the target runs on an SSH remote rather than this
+	 * machine. Drives the picker's SSH pill so the sender can tell where the
+	 * message is about to land. Absent/false means local.
+	 */
+	isSshRemote?: boolean;
+	/**
+	 * For SSH agents: the remote's config id. The picker resolves it to a display
+	 * name (see `useSshRemoteNames`); ids are carried instead of names so this
+	 * builder stays pure and synchronous.
+	 */
+	sshRemoteId?: string | null;
 	/** Relevance score for sorting (higher is better). */
 	score: number;
 }
@@ -89,6 +101,8 @@ export function buildAgentMentionSuggestions(
 			kind: 'agent',
 			targetSessionId: s.id,
 			toolType: s.toolType,
+			isSshRemote: Boolean(s.sessionSshRemoteConfig?.enabled),
+			sshRemoteId: s.sessionSshRemoteConfig?.remoteId ?? null,
 			score: 0,
 		});
 	}

--- a/src/renderer/hooks/remote/index.ts
+++ b/src/renderer/hooks/remote/index.ts
@@ -30,6 +30,9 @@ export type {
 export { useSshRemotes } from './useSshRemotes';
 export type { UseSshRemotesReturn } from './useSshRemotes';
 
+// SSH remote id -> display name lookup (for list surfaces labelling many agents)
+export { useSshRemoteNames } from './useSshRemoteNames';
+
 // Remote command handling & SSH name mapping (Phase 2K)
 export { useRemoteHandlers } from './useRemoteHandlers';
 export type { UseRemoteHandlersDeps, UseRemoteHandlersReturn } from './useRemoteHandlers';

--- a/src/renderer/hooks/remote/useSshRemoteNames.ts
+++ b/src/renderer/hooks/remote/useSshRemoteNames.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import { ipcCache } from '../../services/ipcWrapper';
+import { logger } from '../../utils/logger';
+
+/** Shared cache key with {@link useSshRemotes} so both share one IPC round trip. */
+const SSH_CONFIGS_CACHE_KEY = 'ssh-configs';
+const SSH_CONFIGS_TTL_MS = 30000;
+
+const EMPTY_NAMES: ReadonlyMap<string, string> = new Map();
+
+/**
+ * Remote id -> display name, for surfaces that label MANY agents at once (the
+ * `@` mention picker, agent lists) and only need the name.
+ *
+ * {@link useSshRemotes} is the full CRUD hook and `useSshRemoteName` resolves a
+ * SINGLE session's remote; neither fits a list, where one lookup table beats N
+ * per-row fetches. This reads through the same `ssh-configs` ipcCache entry, so
+ * mounting it alongside those hooks costs no extra IPC.
+ *
+ * Returns an empty map until the configs load. Callers should render a neutral
+ * "SSH" label in that window rather than treating the agent as local.
+ */
+export function useSshRemoteNames(): ReadonlyMap<string, string> {
+	const [names, setNames] = useState<ReadonlyMap<string, string>>(EMPTY_NAMES);
+
+	useEffect(() => {
+		let mounted = true;
+
+		ipcCache
+			.getOrFetch(
+				SSH_CONFIGS_CACHE_KEY,
+				() => window.maestro.sshRemote.getConfigs(),
+				SSH_CONFIGS_TTL_MS
+			)
+			.then((result) => {
+				if (!mounted) return;
+				if (!result.success || !result.configs) return;
+				setNames(new Map(result.configs.map((c) => [c.id, c.name])));
+			})
+			.catch((error) => {
+				// Non-fatal: rows fall back to the generic "SSH" label.
+				logger.error('[useSshRemoteNames] Failed to load SSH remote configs:', undefined, error);
+			});
+
+		return () => {
+			mounted = false;
+		};
+	}, []);
+
+	return names;
+}


### PR DESCRIPTION
## What

When you `@`-mention an agent, the picker gave no hint about **where** that message would actually run. Remote agents now carry the same purple `Server` pill the Main Panel header and group-chat participant cards use, labelled with the SSH remote's name.

No pill means local - the convention already used by the Left Bar, the agent tooltip, and the header.

## Changes

- **New shared `SshRemotePill`** (`src/renderer/components/ui/SshRemotePill.tsx`). Three hand-rolled copies of this pill already existed and had drifted in size and casing. `ParticipantCard` now imports it. `MainPanelHeader`'s copy is an interactive button with its own click/tooltip behavior and is left alone; the icon-only theme-colored variants in `SessionItem` / `SessionTooltipContent` are a different design language and unchanged.
- **New `useSshRemoteNames()`** (`src/renderer/hooks/remote/`). One cached `id -> name` map for surfaces that label many agents at once. `useSshRemotes` is the full CRUD hook and `useSshRemoteName` resolves a single session; neither fits a list. Reads through the same `ssh-configs` `ipcCache` entry, so it adds no IPC.
- **Agent mention suggestions carry `isSshRemote` + `sshRemoteId`.** Ids rather than names, so `buildAgentMentionSuggestions` (shared with the send-path resolver) stays pure and synchronous. The picker resolves the name; if configs are still loading or the remote was deleted, the pill falls back to a literal `SSH` so a remote row never reads as local.

## Tests

- `AtMentionPopover.test.tsx`: SSH row labelled with the resolved remote name, local row bare, generic `SSH` fallback when the name cannot be resolved.
- `useAgentMentionCompletion.test.ts`: SSH flags set, including the "configured but disabled -> local" case.
- `useSshRemoteNames.test.ts`: load, failure, rejection, and shared-cache reuse.

Full suite green on push (35961 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSH-connected agents now display a purple remote-status badge in participant lists and agent mentions.
  * Remote badges show the configured remote name when available, with “SSH” as a fallback.
  * Local agents no longer display SSH indicators.
* **Bug Fixes**
  * Improved handling of unavailable or failed remote configuration data while loading agent details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->