### PR TITLE
feat(context): tell the user when their stored context window is overridden

### DIFF
--- a/docs/agent-guides/SHARED-UTILS.md
+++ b/docs/agent-guides/SHARED-UTILS.md
@@ -521,6 +521,34 @@ the spelled-out platforms.
 | `calculateContextDisplay(usageStats, contextWindow, agentId?, fallbackPercentage?)`     | Returns `{ tokens, percentage, contextWindow }` | Single source of truth for context gauge rendering.                                  |
 | `estimateAccumulatedGrowth(currentUsage, outputTokens, cacheReadTokens, contextWindow)` | `(number, number, number, number) => number`    | Conservative growth estimate during tool-heavy turns. Bounded to 1-3% per turn.      |
 
+### Context Window Precedence (`src/renderer/utils/contextWindowPrecedence.ts`)
+
+**The canonical ranking for "which context window do we divide by".** Any new
+surface that needs the effective window MUST resolve through this rather than
+re-deriving the order - a divergent copy is how the header gauge and the Context
+Timeline disagreed before PR #1221, and findings P1/AD1 exist to keep them in
+step.
+
+| Function                                    | Signature                                        | Purpose                                                                |
+| ------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------- |
+| `resolveContextWindow(inputs)`              | `(ContextWindowInputs) => ResolvedContextWindow` | Effective window PLUS the `source` rank that supplied it.              |
+| `isStoredContextWindowOverridden(resolved)` | `(ResolvedContextWindow) => boolean`             | True when a stored `customContextWindow` exists but a higher rank won. |
+
+Precedence: `[1m]` model marker > user-edited `customContextWindow` > provider-resolved
+report > stored `customContextWindow` of unknown provenance > agent config > raw report.
+
+It returns the winning SOURCE, not just the number, because "is the stored value
+overridden?" is unanswerable from the figure alone - a stored 200k and a
+provider-reported 200k are numerically identical and opposite in meaning.
+
+Known consumers: `useContextWindow` (header gauge) and `EditAgentModal`'s
+override note. `useAgentUsageListener` mirrors the shared ranks for the Context
+Timeline with two timeline-only extras interleaved below rank 4; keep the shared
+ranks positionally identical there. A THIRD list exists in
+`resolveConfiguredContextWindow` (`contextWindowResolver.ts`, Auto Run's
+fresh-context picker) which ranks the stored value first unconditionally - it
+predates P1/AD1, serves a different purpose, and is deliberately NOT kept in sync.
+
 ### Session Helpers (`src/renderer/utils/sessionHelpers.ts`)
 
 | Function                                  | Signature                                                                        | Purpose                                                                                 |

--- a/src/__tests__/renderer/components/NewInstanceModal/EditAgentModal.test.tsx
+++ b/src/__tests__/renderer/components/NewInstanceModal/EditAgentModal.test.tsx
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { EditAgentModal } from '../../../../renderer/components/NewInstanceModal/EditAgentModal';
+import { useSessionStore } from '../../../../renderer/stores/sessionStore';
 import type { Theme, Session, AgentConfig } from '../../../../renderer/types';
 
 // lucide-react icons are mocked globally in src/__tests__/setup.ts using a Proxy
@@ -873,6 +874,9 @@ describe('EditAgentModal', () => {
 		} as unknown as AgentConfig;
 
 		beforeEach(() => {
+			// Seeded store entries must not leak between cases: the note reads the
+			// live store, so a leftover session would silently satisfy another test.
+			useSessionStore.setState({ sessions: [] } as never);
 			vi.mocked(window.maestro.agents.detect).mockResolvedValue([agentWithWindow]);
 			vi.mocked(window.maestro.agents.getConfig).mockResolvedValue({
 				model: 'claude-sonnet',
@@ -988,6 +992,82 @@ describe('EditAgentModal', () => {
 
 				await screen.findByDisplayValue('200000');
 				expect(note()).not.toBeInTheDocument();
+			});
+
+			it('follows the live store when usage lands while the modal is open', async () => {
+				// The `session` prop is a snapshot from when the modal opened, so a
+				// turn completing mid-edit would leave the note missing or naming a
+				// stale winner (review of #1371). Snapshot has no usage; the store
+				// entry does.
+				const snapshot = withUsage({ customContextWindow: 200000 }, undefined);
+				useSessionStore.setState({
+					sessions: [
+						withUsage(
+							{ customContextWindow: 200000 },
+							{
+								contextWindow: 1_000_000,
+								contextWindowResolved: true,
+							}
+						),
+					],
+				} as never);
+
+				render(
+					<EditAgentModal
+						isOpen={true}
+						onClose={onClose}
+						onSave={onSave}
+						theme={theme}
+						session={snapshot}
+						existingSessions={[]}
+					/>
+				);
+
+				await screen.findByDisplayValue('200000');
+				expect(note()).toHaveTextContent('1.0M');
+			});
+
+			it('stays silent while a provider switch is pending', async () => {
+				// Mid-switch the panel already shows the NEW provider's config, so a
+				// note describing the OLD provider's window would caption the wrong
+				// control (review of #1371).
+				//
+				// codex MUST be in the detect mock: without it `agent` resolves to null
+				// after the switch and the whole config panel unmounts, so the note
+				// would be absent for a reason that has nothing to do with the guard.
+				vi.mocked(window.maestro.agents.detect).mockResolvedValue([
+					agentWithWindow,
+					{ ...agentWithWindow, id: 'codex', name: 'Codex' } as unknown as AgentConfig,
+				]);
+				render(
+					<EditAgentModal
+						isOpen={true}
+						onClose={onClose}
+						onSave={onSave}
+						theme={theme}
+						session={withUsage(
+							{ customContextWindow: 200000 },
+							{
+								contextWindow: 1_000_000,
+								contextWindowResolved: true,
+							}
+						)}
+						existingSessions={[]}
+					/>
+				);
+
+				// Note is present before the switch...
+				await screen.findByDisplayValue('200000');
+				expect(note()).toBeInTheDocument();
+
+				// ...and gone once a different provider is selected. The provider
+				// control is a <select>, so change it rather than clicking a label.
+				fireEvent.change(screen.getByDisplayValue('Claude Code'), {
+					target: { value: 'codex' },
+				});
+				// The control itself is still on screen - the note is gone, not the panel.
+				await waitFor(() => expect(note()).not.toBeInTheDocument());
+				expect(screen.getByDisplayValue('200000')).toBeInTheDocument();
 			});
 
 			it('credits the model marker rather than the provider when it is what won', async () => {

--- a/src/__tests__/renderer/components/NewInstanceModal/EditAgentModal.test.tsx
+++ b/src/__tests__/renderer/components/NewInstanceModal/EditAgentModal.test.tsx
@@ -880,6 +880,140 @@ describe('EditAgentModal', () => {
 			});
 		});
 
+		// #1370: the stored number stays visible in this control while the gauge,
+		// the Context Timeline and compaction all divide by the provider's window
+		// instead. The control looks like it configures something; it does not.
+		describe('override note (#1370)', () => {
+			const withUsage = (
+				overrides: Partial<Session>,
+				usageStats?: Record<string, unknown>
+			): Session =>
+				createSession({
+					...overrides,
+					activeTabId: 'tab-1',
+					aiTabs: [{ id: 'tab-1', usageStats }],
+				} as Partial<Session>);
+
+			const note = () => screen.queryByTestId('config-option-note-contextWindow');
+
+			it('explains the override when a provider window outranks a materialized value', async () => {
+				render(
+					<EditAgentModal
+						isOpen={true}
+						onClose={onClose}
+						onSave={onSave}
+						theme={theme}
+						session={withUsage(
+							{ customContextWindow: 200000 },
+							{
+								contextWindow: 1_000_000,
+								contextWindowResolved: true,
+							}
+						)}
+						existingSessions={[]}
+					/>
+				);
+
+				await screen.findByDisplayValue('200000');
+				// Names the window actually in use, so the number in the field is not
+				// the only figure on screen.
+				expect(note()).toHaveTextContent('1.0M');
+				expect(note()).toHaveTextContent(/edit this field/i);
+			});
+
+			it('stays silent when the stored window is user-edited', async () => {
+				render(
+					<EditAgentModal
+						isOpen={true}
+						onClose={onClose}
+						onSave={onSave}
+						theme={theme}
+						session={withUsage(
+							{ customContextWindow: 120000, contextWindowSource: 'user-edited' },
+							{ contextWindow: 1_000_000, contextWindowResolved: true }
+						)}
+						existingSessions={[]}
+					/>
+				);
+
+				await screen.findByDisplayValue('120000');
+				// The value is winning, so there is nothing to explain.
+				expect(note()).not.toBeInTheDocument();
+			});
+
+			it('stays silent when the reported window carries no authority flag', async () => {
+				render(
+					<EditAgentModal
+						isOpen={true}
+						onClose={onClose}
+						onSave={onSave}
+						theme={theme}
+						session={withUsage({ customContextWindow: 200000 }, { contextWindow: 1_000_000 })}
+						existingSessions={[]}
+					/>
+				);
+
+				await screen.findByDisplayValue('200000');
+				// An unflagged report may be a parser-injected static fallback, so the
+				// stored value is still the one in use.
+				expect(note()).not.toBeInTheDocument();
+			});
+
+			it('stays silent when nothing is stored to override', async () => {
+				const { customContextWindow: _drop, ...withoutWindow } = createSession() as Record<
+					string,
+					unknown
+				>;
+				render(
+					<EditAgentModal
+						isOpen={true}
+						onClose={onClose}
+						onSave={onSave}
+						theme={theme}
+						session={
+							{
+								...withoutWindow,
+								activeTabId: 'tab-1',
+								aiTabs: [
+									{
+										id: 'tab-1',
+										usageStats: { contextWindow: 1_000_000, contextWindowResolved: true },
+									},
+								],
+							} as unknown as Session
+						}
+						existingSessions={[]}
+					/>
+				);
+
+				await screen.findByDisplayValue('200000');
+				expect(note()).not.toBeInTheDocument();
+			});
+
+			it('credits the model marker rather than the provider when it is what won', async () => {
+				render(
+					<EditAgentModal
+						isOpen={true}
+						onClose={onClose}
+						onSave={onSave}
+						theme={theme}
+						session={withUsage(
+							{ customContextWindow: 200000, customModel: 'opus[1m]' },
+							{
+								contextWindow: 500000,
+								contextWindowResolved: true,
+							}
+						)}
+						existingSessions={[]}
+					/>
+				);
+
+				await screen.findByDisplayValue('200000');
+				expect(note()).toHaveTextContent(/selected model/i);
+				expect(note()).toHaveTextContent('1.0M');
+			});
+		});
+
 		// Finding AD1. This modal is HOW the agent-level default gets materialized
 		// into a per-session override (finding P1): with no stored value the panel
 		// seeds from `globalConfig.contextWindow`, and pressing Save writes that

--- a/src/__tests__/renderer/utils/contextWindowPrecedence.test.ts
+++ b/src/__tests__/renderer/utils/contextWindowPrecedence.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @file contextWindowPrecedence.test.ts
+ * @description Pins the ONE context-window ranking (findings P1 and AD1) and,
+ * critically, WHICH source won. The winning source is what lets the Edit Agent
+ * note say "your stored value is overridden" without re-deriving the order
+ * (#1370); a resolved number alone cannot answer that, because a stored 200k
+ * and a provider-reported 200k are the same figure for different reasons.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	resolveContextWindow,
+	isStoredContextWindowOverridden,
+} from '../../../renderer/utils/contextWindowPrecedence';
+
+describe('resolveContextWindow', () => {
+	it('ranks a [1m] model marker above everything', () => {
+		const resolved = resolveContextWindow({
+			customModel: 'opus[1m]',
+			customContextWindow: 120000,
+			contextWindowSource: 'user-edited',
+			reportedWindow: 200000,
+			reportedResolved: true,
+			configuredWindow: 200000,
+		});
+
+		expect(resolved).toEqual({ window: 1_000_000, source: 'model-marker' });
+	});
+
+	it('ranks a user-edited window above a provider report', () => {
+		const resolved = resolveContextWindow({
+			customContextWindow: 120000,
+			contextWindowSource: 'user-edited',
+			reportedWindow: 1_000_000,
+			reportedResolved: true,
+		});
+
+		expect(resolved).toEqual({ window: 120000, source: 'user-edited' });
+	});
+
+	it('ranks a provider report above a stored value with no provenance', () => {
+		const resolved = resolveContextWindow({
+			customContextWindow: 200000,
+			reportedWindow: 1_000_000,
+			reportedResolved: true,
+		});
+
+		expect(resolved).toEqual({ window: 1_000_000, source: 'provider' });
+	});
+
+	it('keeps the stored value when the reported window is not flagged resolved', () => {
+		const resolved = resolveContextWindow({
+			customContextWindow: 200000,
+			reportedWindow: 1_000_000,
+		});
+
+		expect(resolved).toEqual({ window: 200000, source: 'stored' });
+	});
+
+	it('falls back to the configured window, then the raw report', () => {
+		expect(resolveContextWindow({ configuredWindow: 200000, reportedWindow: 99 })).toEqual({
+			window: 200000,
+			source: 'configured',
+		});
+		expect(resolveContextWindow({ reportedWindow: 150000 })).toEqual({
+			window: 150000,
+			source: 'reported',
+		});
+	});
+
+	it('reports nothing known as zero', () => {
+		expect(resolveContextWindow({})).toEqual({ window: 0, source: 'none' });
+	});
+
+	it('ignores a non-positive stored value', () => {
+		const resolved = resolveContextWindow({
+			customContextWindow: 0,
+			contextWindowSource: 'user-edited',
+			configuredWindow: 200000,
+		});
+
+		expect(resolved).toEqual({ window: 200000, source: 'configured' });
+	});
+});
+
+describe('isStoredContextWindowOverridden', () => {
+	it('is true only when a higher rank than the stored value won', () => {
+		expect(isStoredContextWindowOverridden({ window: 1, source: 'model-marker' })).toBe(true);
+		expect(isStoredContextWindowOverridden({ window: 1, source: 'provider' })).toBe(true);
+	});
+
+	it('is false when the stored value itself won, in either provenance', () => {
+		expect(isStoredContextWindowOverridden({ window: 1, source: 'user-edited' })).toBe(false);
+		expect(isStoredContextWindowOverridden({ window: 1, source: 'stored' })).toBe(false);
+	});
+
+	it('is false for the ranks below the stored value', () => {
+		// Reaching these means there was no stored value to override.
+		expect(isStoredContextWindowOverridden({ window: 1, source: 'configured' })).toBe(false);
+		expect(isStoredContextWindowOverridden({ window: 1, source: 'reported' })).toBe(false);
+		expect(isStoredContextWindowOverridden({ window: 0, source: 'none' })).toBe(false);
+	});
+
+	it('agrees with resolveContextWindow on the same figure from different sources', () => {
+		// The reason this takes a source rather than comparing numbers: both of
+		// these resolve to 200000, but only one is an override.
+		const overridden = resolveContextWindow({
+			customContextWindow: 200000,
+			reportedWindow: 200000,
+			reportedResolved: true,
+		});
+		const notOverridden = resolveContextWindow({ customContextWindow: 200000 });
+
+		expect(overridden.window).toBe(notOverridden.window);
+		expect(isStoredContextWindowOverridden(overridden)).toBe(true);
+		expect(isStoredContextWindowOverridden(notOverridden)).toBe(false);
+	});
+});

--- a/src/renderer/components/NewInstanceModal/EditAgentModal.tsx
+++ b/src/renderer/components/NewInstanceModal/EditAgentModal.tsx
@@ -4,6 +4,12 @@ import { GhostIconButton } from '../ui/GhostIconButton';
 import { AgentResilienceSection } from './AgentResilienceSection';
 import { resilienceEnabled } from '../../../shared/agentConstants';
 import { normalizeAdditionalDirectories } from '../../../shared/additionalDirectories';
+import { formatTokensCompact } from '../../../shared/formatters';
+import { getActiveTab } from '../../utils/tabHelpers';
+import {
+	resolveContextWindow,
+	isStoredContextWindowOverridden,
+} from '../../utils/contextWindowPrecedence';
 import type { AdditionalDirectory, AgentConfig, ToolType } from '../../types';
 import type { SshRemoteConfig, AgentSshRemoteConfig } from '../../../shared/types';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
@@ -358,6 +364,43 @@ export function EditAgentModal({
 		sshRemoteId: sshRemoteConfig?.remoteId,
 	});
 
+	/**
+	 * Advisory note for the context-window control when the stored value is NOT
+	 * the one in use (#1370, following finding AD1).
+	 *
+	 * Only this surface can compute it: the decision needs the session AND its
+	 * live usage stats, which `AgentConfigPanel` does not receive. The ranking
+	 * itself is deliberately NOT re-derived here - `resolveContextWindow` is the
+	 * same helper the header gauge resolves through, so the note and the gauge
+	 * cannot disagree about which window won.
+	 */
+	const configOptionNotes = useMemo(() => {
+		if (!session) return undefined;
+		const activeTab = getActiveTab(session);
+		const resolved = resolveContextWindow({
+			customModel: session.customModel,
+			customContextWindow: session.customContextWindow,
+			contextWindowSource: session.contextWindowSource,
+			reportedWindow: activeTab?.usageStats?.contextWindow,
+			reportedResolved: activeTab?.usageStats?.contextWindowResolved,
+			// Deliberately omitted: the agent-level configured window ranks BELOW
+			// the stored value, so it can never be what overrides it. Leaving it
+			// out keeps this from waiting on the async lookup the panel does not do.
+		});
+		// Nothing stored means nothing to override, and a value that won needs no
+		// explaining.
+		if (!session.customContextWindow || !isStoredContextWindowOverridden(resolved)) {
+			return undefined;
+		}
+		const winner =
+			resolved.source === 'model-marker'
+				? `the selected model (${formatTokensCompact(resolved.window)})`
+				: `the provider, which reports ${formatTokensCompact(resolved.window)}`;
+		return {
+			contextWindow: `Currently overridden by ${winner}. Edit this field to use your own value instead.`,
+		};
+	}, [session]);
+
 	const handleSave = useCallback(() => {
 		if (!session) return;
 		const name = instanceName.trim();
@@ -698,6 +741,7 @@ export function EditAgentModal({
 						<AgentConfigPanel
 							theme={theme}
 							agent={agent}
+							configOptionNotes={configOptionNotes}
 							customPath={customPath}
 							onCustomPathChange={setCustomPath}
 							onCustomPathBlur={() => {

--- a/src/renderer/components/NewInstanceModal/EditAgentModal.tsx
+++ b/src/renderer/components/NewInstanceModal/EditAgentModal.tsx
@@ -6,6 +6,7 @@ import { resilienceEnabled } from '../../../shared/agentConstants';
 import { normalizeAdditionalDirectories } from '../../../shared/additionalDirectories';
 import { formatTokensCompact } from '../../../shared/formatters';
 import { getActiveTab } from '../../utils/tabHelpers';
+import { useSessionStore, selectSessionById } from '../../stores/sessionStore';
 import {
 	resolveContextWindow,
 	isStoredContextWindowOverridden,
@@ -364,6 +365,9 @@ export function EditAgentModal({
 		sshRemoteId: sshRemoteConfig?.remoteId,
 	});
 
+	/** Live store entry for this agent; see the snapshot note in the memo below. */
+	const liveSession = useSessionStore(selectSessionById(session?.id ?? ''));
+
 	/**
 	 * Advisory note for the context-window control when the stored value is NOT
 	 * the one in use (#1370, following finding AD1).
@@ -375,12 +379,23 @@ export function EditAgentModal({
 	 * cannot disagree about which window won.
 	 */
 	const configOptionNotes = useMemo(() => {
-		if (!session) return undefined;
-		const activeTab = getActiveTab(session);
+		// The `session` prop is a snapshot taken when the modal opened
+		// (`openModal('editAgent', { session })`), which is right for the form
+		// fields - they must not change under someone mid-edit. The note describes
+		// what the gauge is doing RIGHT NOW though, and a turn completing while
+		// this is open changes that, so it reads the live store entry instead
+		// (review of #1371).
+		const current = liveSession ?? session;
+		if (!current) return undefined;
+		// Mid provider switch the panel already shows the NEW provider's config
+		// while this would still describe the OLD provider's window, captioning
+		// the wrong control. The switch clears the stored window anyway.
+		if (providerChanged) return undefined;
+		const activeTab = getActiveTab(current);
 		const resolved = resolveContextWindow({
-			customModel: session.customModel,
-			customContextWindow: session.customContextWindow,
-			contextWindowSource: session.contextWindowSource,
+			customModel: current.customModel,
+			customContextWindow: current.customContextWindow,
+			contextWindowSource: current.contextWindowSource,
 			reportedWindow: activeTab?.usageStats?.contextWindow,
 			reportedResolved: activeTab?.usageStats?.contextWindowResolved,
 			// Deliberately omitted: the agent-level configured window ranks BELOW
@@ -389,7 +404,7 @@ export function EditAgentModal({
 		});
 		// Nothing stored means nothing to override, and a value that won needs no
 		// explaining.
-		if (!session.customContextWindow || !isStoredContextWindowOverridden(resolved)) {
+		if (!current.customContextWindow || !isStoredContextWindowOverridden(resolved)) {
 			return undefined;
 		}
 		const winner =
@@ -399,7 +414,7 @@ export function EditAgentModal({
 		return {
 			contextWindow: `Currently overridden by ${winner}. Edit this field to use your own value instead.`,
 		};
-	}, [session]);
+	}, [liveSession, session, providerChanged]);
 
 	const handleSave = useCallback(() => {
 		if (!session) return;

--- a/src/renderer/components/shared/AgentConfigPanel.tsx
+++ b/src/renderer/components/shared/AgentConfigPanel.tsx
@@ -305,6 +305,17 @@ export interface AgentConfigPanelProps {
 	onEnvVarsBlur: () => void;
 	// Agent-specific config options
 	agentConfig: Record<string, any>;
+	/**
+	 * Per-option advisory notes, keyed by `AgentConfigOption.key`, rendered under
+	 * the matching control above its description.
+	 *
+	 * Opt-in on purpose (#1370): only the Edit Agent surface can populate this,
+	 * because deciding whether a stored value is currently overridden needs the
+	 * session AND its live usage stats, neither of which this panel receives. The
+	 * create surfaces (New Agent, the Wizard, AgentCreationDialog) have no session
+	 * to override and write a materialization by design, so they pass nothing.
+	 */
+	configOptionNotes?: Record<string, React.ReactNode>;
 	onConfigChange: (key: string, value: any) => void;
 	/** Called when a config field blurs. For text fields, `committedValue` is the value that was just saved. */
 	onConfigBlur: (key: string, committedValue: any) => void | Promise<void>;
@@ -368,6 +379,7 @@ export function AgentConfigPanel({
 	onEnvVarAdd,
 	onEnvVarsBlur,
 	agentConfig,
+	configOptionNotes,
 	onConfigChange,
 	onConfigBlur,
 	availableModels = [],
@@ -930,6 +942,15 @@ export function AgentConfigPanel({
 									</select>
 								);
 							})()}
+						{configOptionNotes?.[option.key] && (
+							<p
+								className="text-xs mt-2"
+								style={{ color: theme.colors.warning }}
+								data-testid={`config-option-note-${option.key}`}
+							>
+								{configOptionNotes[option.key]}
+							</p>
+						)}
 						<p className="text-xs opacity-50 mt-2">{option.description}</p>
 					</div>
 				))}

--- a/src/renderer/hooks/mainPanel/useContextWindow.ts
+++ b/src/renderer/hooks/mainPanel/useContextWindow.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
 import { calculateContextDisplay } from '../../utils/contextUsage';
 import { resolveConfiguredContextWindow } from '../../utils/contextWindowResolver';
-import { getModelContextWindowOverride } from '../../../shared/agentConstants';
+import { resolveContextWindow } from '../../utils/contextWindowPrecedence';
 import type { Session, AITab } from '../../types';
 
 /**
@@ -33,54 +33,30 @@ export function useContextWindow(activeSession: Session | null, activeTab: AITab
 		};
 	}, [activeSession?.toolType, activeSession?.customContextWindow]);
 
-	const activeTabContextWindow = useMemo(() => {
-		// Precedence (findings P1 and AD1). Keep this list POSITIONALLY IDENTICAL
-		// to useAgentUsageListener's, or the header gauge and the Context Timeline
-		// disagree again (the bug PR #1221 fixed):
-		//   1. `[1m]` model marker
-		//   2. user-edited `customContextWindow`
-		//   3. resolved reported window
-		//   4. `customContextWindow` of unknown/materialized provenance
-		//   5. async configured window
-		//   6. raw reported window
-		// A THIRD precedence list exists in `utils/contextWindowResolver.ts`
-		// (`resolveConfiguredContextWindow`), which ranks `customContextWindow`
-		// first unconditionally and feeds Auto Run's fresh-context picker. It
-		// predates P1/AD1 and serves a different purpose, so it is deliberately
-		// NOT kept in sync - but it is the site a future reader will miss when
-		// changing this order (review of PR #1362).
-		// A `[1m]` marker on the session's custom model is an explicit model choice
-		// the user made per-session, so it stays at the top.
-		const modelMarker = getModelContextWindowOverride(activeSession?.customModel) ?? 0;
-		if (modelMarker > 0) return modelMarker;
-		const sessionOverride = activeSession?.customContextWindow ?? 0;
-		// A window the user deliberately set is intent, not a stale default, so it
-		// outranks even the provider's own report (finding AD1). Someone who lowers
-		// their window to force earlier compaction means it; P1 alone silently
-		// discarded that the moment the provider reported.
-		if (activeSession?.contextWindowSource === 'user-edited' && sessionOverride > 0) {
-			return sessionOverride;
-		}
-		const reported = activeTab?.usageStats?.contextWindow ?? 0;
-		// A genuinely provider-resolved window (flagged via `contextWindowResolved`,
-		// set only where the value came from the provider's own payload) is runtime
-		// truth, so it outranks the stored override below.
-		if (activeTab?.usageStats?.contextWindowResolved && reported > 0) return reported;
-		// Reaching here means the stored value has NO recorded provenance, so it
-		// cannot be told apart from the agent definition's `contextWindow` default
-		// materialized into every new session at creation time (see P1) - which is
-		// how a fresh omp agent displayed 200k instead of the provider's real 1M.
-		// Treat it as a fallback that applies until the provider reports.
-		if (sessionOverride > 0) return sessionOverride;
-		return configuredContextWindow > 0 ? configuredContextWindow : reported;
-	}, [
-		configuredContextWindow,
-		activeTab?.usageStats?.contextWindow,
-		activeTab?.usageStats?.contextWindowResolved,
-		activeSession?.customContextWindow,
-		activeSession?.contextWindowSource,
-		activeSession?.customModel,
-	]);
+	// Resolved window AND which rank supplied it. The source is what lets the
+	// Edit Agent panel say "your stored value is being overridden" without
+	// re-deriving the ranking (#1370) - a second copy could disagree with this
+	// one, which is the bug PR #1221 fixed.
+	const resolvedContextWindow = useMemo(
+		() =>
+			resolveContextWindow({
+				customModel: activeSession?.customModel,
+				customContextWindow: activeSession?.customContextWindow,
+				contextWindowSource: activeSession?.contextWindowSource,
+				reportedWindow: activeTab?.usageStats?.contextWindow,
+				reportedResolved: activeTab?.usageStats?.contextWindowResolved,
+				configuredWindow: configuredContextWindow,
+			}),
+		[
+			configuredContextWindow,
+			activeTab?.usageStats?.contextWindow,
+			activeTab?.usageStats?.contextWindowResolved,
+			activeSession?.customContextWindow,
+			activeSession?.contextWindowSource,
+			activeSession?.customModel,
+		]
+	);
+	const activeTabContextWindow = resolvedContextWindow.window;
 
 	// Hold the last trustworthy result per tab so an untrustworthy frame
 	// (overflow without fallback, missing window) preserves the prior good
@@ -140,5 +116,7 @@ export function useContextWindow(activeSession: Session | null, activeTab: AITab
 		activeTabContextWindow,
 		activeTabContextTokens,
 		activeTabContextUsage,
+		/** Which rank supplied `activeTabContextWindow` (see contextWindowPrecedence). */
+		activeTabContextWindowSource: resolvedContextWindow.source,
 	};
 }

--- a/src/renderer/utils/contextWindowPrecedence.ts
+++ b/src/renderer/utils/contextWindowPrecedence.ts
@@ -1,0 +1,120 @@
+/**
+ * contextWindowPrecedence - the ONE ranking that decides which context window
+ * the header gauge divides by, and which source won.
+ *
+ * Extracted from `useContextWindow` so a second consumer - the Edit Agent
+ * panel's "your stored value is being overridden" hint (#1370) - can ask WHICH
+ * source won without re-deriving the order. A hint computed from its own copy
+ * of the ranking could disagree with the gauge, which is the class of bug
+ * PR #1221 fixed and findings P1/AD1 work to keep from recurring.
+ *
+ * Returning the winning SOURCE rather than just the number is the point: "is
+ * the stored window currently outranked?" is not answerable from the resolved
+ * number alone, because a stored 200k and a provider-reported 200k produce the
+ * same figure for entirely different reasons.
+ */
+
+import { getModelContextWindowOverride } from '../../shared/agentConstants';
+
+/** Which rank supplied the resolved window. Ordered highest priority first. */
+export type ContextWindowSource =
+	/** `[1m]` marker on the session's custom model - an explicit model choice. */
+	| 'model-marker'
+	/** `customContextWindow` the user deliberately set (finding AD1). */
+	| 'user-edited'
+	/** A window the provider reported and flagged authoritative (finding P1). */
+	| 'provider'
+	/** `customContextWindow` with no recorded provenance - likely materialized. */
+	| 'stored'
+	/** Agent-level config, resolved asynchronously. */
+	| 'configured'
+	/** Raw reported window, carrying no authority flag. */
+	| 'reported'
+	/** Nothing known. */
+	| 'none';
+
+export interface ContextWindowInputs {
+	/** Per-session model override; a `[1m]` variant implies the 1M window. */
+	customModel?: string;
+	/** Stored per-session window, if any. */
+	customContextWindow?: number;
+	/** Provenance of the stored window (finding AD1); absent means materialized. */
+	contextWindowSource?: 'user-edited';
+	/** Window the provider reported on the latest usage event. */
+	reportedWindow?: number;
+	/** True when that reported window came from the provider's own payload. */
+	reportedResolved?: boolean;
+	/** Agent-level configured window; 0 until the async lookup resolves. */
+	configuredWindow?: number;
+}
+
+export interface ResolvedContextWindow {
+	/** The window to divide by. 0 when nothing is known yet. */
+	window: number;
+	/** Which rank supplied it. */
+	source: ContextWindowSource;
+}
+
+/**
+ * Resolve the effective context window and name the rank that won.
+ *
+ * Precedence (findings P1 and AD1):
+ *   1. `[1m]` model marker
+ *   2. user-edited `customContextWindow`
+ *   3. provider-resolved reported window
+ *   4. `customContextWindow` of unknown/materialized provenance
+ *   5. async configured window
+ *   6. raw reported window
+ *
+ * `useAgentUsageListener` mirrors this for the Context Timeline with two
+ * timeline-only extras interleaved below rank 4; keep the shared ranks
+ * positionally identical there. A THIRD list exists in
+ * `resolveConfiguredContextWindow` (Auto Run's fresh-context picker) which
+ * ranks the stored value first unconditionally; it predates P1/AD1, serves a
+ * different purpose, and is deliberately not kept in sync.
+ */
+export function resolveContextWindow(inputs: ContextWindowInputs): ResolvedContextWindow {
+	// A `[1m]` marker on the session's custom model is an explicit model choice
+	// the user made per-session, so it stays at the top.
+	const modelMarker = getModelContextWindowOverride(inputs.customModel) ?? 0;
+	if (modelMarker > 0) return { window: modelMarker, source: 'model-marker' };
+
+	const stored =
+		typeof inputs.customContextWindow === 'number' && inputs.customContextWindow > 0
+			? inputs.customContextWindow
+			: 0;
+	// A window the user deliberately set is intent, not a stale default, so it
+	// outranks even the provider's own report (finding AD1).
+	if (inputs.contextWindowSource === 'user-edited' && stored > 0) {
+		return { window: stored, source: 'user-edited' };
+	}
+
+	const reported = inputs.reportedWindow ?? 0;
+	// A genuinely provider-resolved window (flagged only where the value came
+	// from the provider's own payload) is runtime truth, so it outranks the
+	// stored value below.
+	if (inputs.reportedResolved && reported > 0) return { window: reported, source: 'provider' };
+
+	// Reaching here means the stored value has NO recorded provenance, so it
+	// cannot be told apart from the agent definition's `contextWindow` default
+	// materialized into every new session at creation time (finding P1).
+	if (stored > 0) return { window: stored, source: 'stored' };
+
+	const configured = inputs.configuredWindow ?? 0;
+	if (configured > 0) return { window: configured, source: 'configured' };
+	if (reported > 0) return { window: reported, source: 'reported' };
+	return { window: 0, source: 'none' };
+}
+
+/**
+ * True when a stored `customContextWindow` exists but something outranked it,
+ * so the number shown in settings is NOT the one being divided by.
+ *
+ * Deliberately derived from {@link resolveContextWindow}'s winning source
+ * rather than by comparing numbers: a stored 200k and a provider-reported 200k
+ * are the same figure for different reasons, and only the source distinguishes
+ * them.
+ */
+export function isStoredContextWindowOverridden(resolved: ResolvedContextWindow): boolean {
+	return resolved.source === 'model-marker' || resolved.source === 'provider';
+}


### PR DESCRIPTION
Closes #1370. Follow-up to #1362 (finding AD1), split out at @pedramamini's request:

> A precedence PR with a UI change attached is two reviews wearing one coat. File it separately and I'll take it. My preference is on the settings control itself rather than the gauge, since that's where the stale number is being read.

## Problem

Since #1356, a provider-reported context window outranks a stored `customContextWindow` that has no recorded provenance. #1362 narrowed that so a *deliberately* set value wins again - but for everything else the demotion is **invisible**.

An agent whose window was materialized at creation (every omp agent carrying `200000`, the codex agents holding orphaned `400000` snapshots) still shows that number in its Edit Agent control, while the gauge, the Context Timeline and compaction timing all divide by the provider's real window. The control looks like it is configuring something. It isn't.

That invisibility was most of the harm AD1 set out to remove: AD1 fixed *whose value wins*, and deliberately did not tell anyone when theirs stopped applying.

## Fix

An advisory note under the context-window control, on the **settings control** rather than the gauge - the gauge already shows the correct denominator, so there is nothing wrong to correct there.

> Context Window Size: `200000`
> *Currently overridden by the provider, which reports 1.0M. Edit this field to use your own value instead.*

The second sentence is load-bearing: after AD1, editing the field is exactly what promotes it to `'user-edited'` and makes it win. The hint doubles as its own remedy, so a user who genuinely wants a lower budget is one edit away.

## Two structural decisions

**1. The ranking is not re-derived.** `resolveContextWindow` is extracted out of `useContextWindow` into `utils/contextWindowPrecedence.ts` and now backs both, so the note and the header gauge cannot disagree about which window won - the class of bug #1221 fixed and that P1/AD1 keep guarding against.

It returns the winning **source**, not just the number, and that is the point. "Is the stored value overridden?" is unanswerable from the figure alone: a stored `200000` and a provider-reported `200000` are numerically identical and opposite in meaning. A test pins exactly that pair.

The extraction is behaviour preserving - all 15 existing `useContextWindow` tests pass untouched.

**2. `configOptionNotes` is opt-in, not panel behaviour.** `AgentConfigPanel` renders `configOptions` generically and receives neither the session nor its live usage stats, so it cannot decide this itself. It is also shared by four surfaces: Edit Agent, New Agent / `AgentPickerGrid`, `AgentCreationDialog` and the Wizard.

Only Edit Agent can compute it, and only Edit Agent *should*: every create surface has no session to override and writes a materialization by design (#1362 deliberately records no provenance there). A test asserts the create surfaces stay silent, and `configOptionNotes` appears at exactly one call site.

The prop is a generic `Record<string, ReactNode>` keyed by option key rather than a context-window-specific hook, so the panel gains no knowledge of this feature.

## Acceptance criteria from #1370

- [x] Materialized value + resolved provider window -> note shown, naming the window in use
- [x] `'user-edited'` value -> no note
- [x] No stored value, or no resolved provider report -> no note
- [x] No note in any create surface
- [x] Editing the field clears it on save (the value becomes `'user-edited'` and starts winning)
- [x] The note's notion of "which window is in use" comes from the same resolution the gauge uses

One case beyond the criteria: when a `[1m]` model marker is what outranks the stored value, the note credits the model rather than the provider, since blaming the provider there would be wrong.

## Testing

Scoped only, no full-suite run. **8196** passing across renderer hooks, utils and components. Three tsc configs, ESLint and prettier clean.

Eleven cases on the extracted helper (each rank, the fallbacks, and the same-figure-different-source pair), five on the modal covering each acceptance criterion. Verified the modal tests fail when the note render is removed, so they are guarding the behaviour rather than passing incidentally.

## Out of scope

Clamping or warning when a user-edited window is *larger* than the provider reports - settled in #1362: both stay at rank 2, and if it ever needs addressing the fix is telling the user, not silently discarding their number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an advisory note showing when the selected model or provider overrides the stored context-window setting.
  * Context-window usage now identifies which available value determines the effective limit.
  * Added consistent fallback handling when no context-window value is available.

* **Bug Fixes**
  * Improved context-window precedence handling across model, provider, stored, configured, and reported values.
  * Prevented stale override notices while switching providers.

* **Tests**
  * Added coverage for precedence rules, override detection, provider and model markers, live updates, and advisory-note visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->