### PR TITLE
fix(docs): repair the dash rule's own wording, and guard tests + scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,10 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npx prettier --check .
-      - run: npx eslint src/
+      # Use the npm script rather than a bare `eslint src/` so CI and a local
+      # `npm run lint:eslint` cannot drift apart. It chains the second,
+      # dash-rule-only pass over src/__tests__ and scripts.
+      - run: npm run lint:eslint
       - run: npm run lint # TypeScript type checking
 
   test:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,12 +170,12 @@ This codebase uses **tabs for indentation**, not spaces. Always match existing f
 
 ### Writing Style: No Em-Dashes or En-Dashes
 
-**NEVER use em-dashes (`-`, U+2014) or en-dashes (`-`, U+2013) anywhere.** This applies to everything you write: user docs (`docs/`), in-app documentation, system prompts (`src/prompts/`), UI copy, code comments, commit messages, PR descriptions, and your own responses. Em-dashes are a tell-tale sign of bot-authored text; humans almost never type them. Use one of these instead, whichever fits the sentence:
+**NEVER use U+2014 (em dash) or U+2013 (en dash) anywhere.** This applies to everything you write: user docs (`docs/`), in-app documentation, system prompts (`src/prompts/`), UI copy, code comments, commit messages, PR descriptions, and your own responses. Em dashes are a tell-tale sign of bot-authored text; humans almost never type them. Use one of these instead, whichever fits the sentence:
 
 - A spaced hyphen (`-`) for an aside or appositive.
 - A comma, colon, or parentheses to set off a clause.
 - Two separate sentences when the clauses stand on their own.
-- A plain hyphen (`-`) for numeric ranges (e.g. `10-20`, not `10-20`).
+- A plain hyphen (`-`) for numeric ranges (e.g. `10-20`; do not use U+2013 for ranges).
 
 This is non-negotiable. If you catch an em-dash or en-dash in anything you produce or edit, replace it.
 

--- a/eslint.dashes.config.mjs
+++ b/eslint.dashes.config.mjs
@@ -1,0 +1,49 @@
+// @ts-check
+//
+// A second, deliberately tiny ESLint pass that runs ONLY the em/en-dash rule,
+// over the directories the main config puts in its global `ignores` block:
+// `src/__tests__/**` and `scripts/**`.
+//
+// Why a separate config rather than widening eslint.config.mjs: a flat-config
+// object whose only key is `ignores` is a GLOBAL ignore, and no later config
+// entry can re-enable a path it excludes. Un-ignoring the tests would therefore
+// mean scoping every recommended rule set away from them by hand, which changes
+// lint semantics for thousands of files to gain one rule. This keeps the main
+// config untouched.
+//
+// Worth guarding: when the dash cleanup measured the drift between `main` and
+// `rc`, 250 of the 634 files that differed by dash characters alone lived under
+// `src/__tests__/`. Tests are roughly 40% of the surface the rule exists to
+// protect, and they were the part nothing was watching.
+//
+// Chained after the main pass in the `lint:eslint` npm script, which CI runs.
+
+import tseslint from 'typescript-eslint';
+import maestroPlugin from './eslint-rules/no-em-dash-in-comments.mjs';
+
+export default tseslint.config({
+	files: ['src/__tests__/**/*.ts', 'src/__tests__/**/*.tsx', 'scripts/**/*.mjs'],
+	languageOptions: {
+		parser: tseslint.parser,
+		ecmaVersion: 2022,
+		sourceType: 'module',
+		parserOptions: {
+			ecmaFeatures: { jsx: true },
+		},
+	},
+	// The typescript-eslint plugin is registered but none of its rules are
+	// enabled. Test files carry inline `eslint-disable-next-line
+	// @typescript-eslint/...` comments, and a directive naming a rule ESLint
+	// cannot resolve is itself an error ("Definition for rule ... was not
+	// found"). Registering the plugin makes those names resolve to a no-op
+	// instead, so this pass reports dashes and nothing else.
+	plugins: { maestro: maestroPlugin, '@typescript-eslint': tseslint.plugin },
+	linterOptions: {
+		// Every disable directive in these files targets a rule this pass leaves
+		// off, so all of them would otherwise be reported as unused.
+		reportUnusedDisableDirectives: 'off',
+	},
+	// Only this rule. Everything else about these files is intentionally
+	// unlinted, exactly as before.
+	rules: { 'maestro/no-em-dash-in-comments': 'error' },
+});

--- a/eslint.dashes.config.mjs
+++ b/eslint.dashes.config.mjs
@@ -22,7 +22,16 @@ import tseslint from 'typescript-eslint';
 import maestroPlugin from './eslint-rules/no-em-dash-in-comments.mjs';
 
 export default tseslint.config({
-	files: ['src/__tests__/**/*.ts', 'src/__tests__/**/*.tsx', 'scripts/**/*.mjs'],
+	// `scripts/` is mostly .mjs but holds a .js too (notarize.js), so match every
+	// JS flavour ESLint can parse. The .ps1 / .sh helpers in there are out of
+	// reach for any ESLint rule.
+	files: [
+		'src/__tests__/**/*.ts',
+		'src/__tests__/**/*.tsx',
+		'scripts/**/*.mjs',
+		'scripts/**/*.js',
+		'scripts/**/*.cjs',
+	],
 	languageOptions: {
 		parser: tseslint.parser,
 		ecmaVersion: 2022,

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"prepare": "node scripts/setup-git-hooks.mjs",
 		"postinstall": "patch-package && electron-rebuild -f -w node-pty,better-sqlite3",
 		"lint": "tsc -p tsconfig.lint.json && tsc -p tsconfig.main.json --noEmit && tsc -p tsconfig.cli.json --noEmit",
-		"lint:eslint": "eslint src/",
+		"lint:eslint": "eslint src/ && eslint -c eslint.dashes.config.mjs src/__tests__ scripts",
 		"format": "prettier --write \"src/**/*.{ts,tsx}\"",
 		"format:all": "prettier --write .",
 		"format:check": "prettier --check \"src/**/*.{ts,tsx}\"",

--- a/src/__tests__/main/auto-updater.test.ts
+++ b/src/__tests__/main/auto-updater.test.ts
@@ -153,7 +153,7 @@ describe('main/auto-updater', () => {
 				mockAutoUpdater as unknown as Parameters<typeof __setAutoUpdaterForTesting>[0]
 			);
 			const onBeforeQuitAndInstall = vi.fn(() => {
-				// eslint-disable-next-line @typescript-eslint/no-throw-literal
+				// eslint-disable-next-line @typescript-eslint/only-throw-error
 				throw 'string-thrown';
 			});
 

--- a/src/__tests__/main/cue/cue-engine.test.ts
+++ b/src/__tests__/main/cue/cue-engine.test.ts
@@ -2316,7 +2316,7 @@ describe('CueEngine', () => {
 						enabled: true,
 						prompt: 'filtered task',
 						schedule_times: ['09:00'],
-						filter: { matched_day: 'tue' }, // Won't match — today is Monday
+						filter: { matched_day: 'tue' }, // Won't match - today is Monday
 					},
 				],
 			});

--- a/src/__tests__/main/cue/cue-process-lifecycle.test.ts
+++ b/src/__tests__/main/cue/cue-process-lifecycle.test.ts
@@ -598,7 +598,7 @@ describe('cue-process-lifecycle', () => {
 			await vi.advanceTimersByTimeAsync(0);
 
 			mockChild.emit('close', 0);
-			mockChild.emit('close', 1); // duplicate — should be ignored
+			mockChild.emit('close', 1); // duplicate - should be ignored
 			const result = await resultPromise;
 
 			expect(result.status).toBe('completed');

--- a/src/__tests__/main/cue/cue-yaml-loader.test.ts
+++ b/src/__tests__/main/cue/cue-yaml-loader.test.ts
@@ -654,7 +654,7 @@ subscriptions:
 			expect(changeHandler).toBeDefined();
 
 			changeHandler!();
-			expect(onChange).not.toHaveBeenCalled(); // Not yet — debounced
+			expect(onChange).not.toHaveBeenCalled(); // Not yet - debounced
 
 			vi.advanceTimersByTime(1000);
 			expect(onChange).toHaveBeenCalledTimes(1);

--- a/src/__tests__/main/ipc/handlers/git.test.ts
+++ b/src/__tests__/main/ipc/handlers/git.test.ts
@@ -2423,7 +2423,7 @@ export function Component() {
 				'/worktrees/existing',
 				'already-exists',
 				undefined,
-				'rc' // baseBranch — ignored when branch already exists
+				'rc' // baseBranch - ignored when branch already exists
 			);
 
 			expect(execFile.execFileNoThrow).toHaveBeenCalledWith(

--- a/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
+++ b/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
@@ -1680,7 +1680,7 @@ describe('FileExplorerPanel', () => {
 	describe('Indent Alignment (locked invariants)', () => {
 		const BASE_PAD = 8;
 		const INDENT_STEP = 20;
-		const CHEVRON_PLUS_GAP = 20; // w-3 (12) + gap-2 (8) — must equal INDENT_STEP
+		const CHEVRON_PLUS_GAP = 20; // w-3 (12) + gap-2 (8) - must equal INDENT_STEP
 		const expectedPad = (depth: number) => `${BASE_PAD + depth * INDENT_STEP}px`;
 
 		const getRowByText = (container: HTMLElement, text: string) =>

--- a/src/__tests__/renderer/hooks/useAgentSessionManagement.test.ts
+++ b/src/__tests__/renderer/hooks/useAgentSessionManagement.test.ts
@@ -284,7 +284,7 @@ describe('useAgentSessionManagement', () => {
 		const existingTab = createMockTab({
 			id: 'tab-existing',
 			agentSessionId: 'agent-123',
-			logs: [], // Empty logs — should trigger reload from disk
+			logs: [], // Empty logs - should trigger reload from disk
 		});
 		const activeSession = createMockSession({
 			aiTabs: [createMockTab({ id: 'tab-1' }), existingTab],

--- a/src/__tests__/renderer/hooks/useBatchProcessor.test.ts
+++ b/src/__tests__/renderer/hooks/useBatchProcessor.test.ts
@@ -1260,7 +1260,7 @@ describe('useBatchProcessor hook', () => {
 			const endCall = (window.maestro.stats.endAutoRun as ReturnType<typeof vi.fn>).mock.calls[0];
 			expect(endCall[0]).toBe('auto-run-id'); // statsAutoRunId from setup mock
 			expect(endCall[1]).toBeGreaterThan(0); // elapsed duration in ms
-			expect(endCall[2]).toBe(0); // completedTasks — nothing finished before kill
+			expect(endCall[2]).toBe(0); // completedTasks - nothing finished before kill
 
 			// A history entry tagged as AUTO must be written with the elapsed time
 			const historyEntry = mockOnAddHistoryEntry.mock.calls.find(
@@ -5705,7 +5705,7 @@ describe('useBatchProcessor hook', () => {
 				'/projects/worktrees/auto-run-rc-0514',
 				'auto-run-rc-0514',
 				undefined, // sshRemoteId
-				'rc' // baseBranch — must reach IPC, not get dropped
+				'rc' // baseBranch - must reach IPC, not get dropped
 			);
 		});
 	});

--- a/src/__tests__/renderer/hooks/useInputProcessing.test.ts
+++ b/src/__tests__/renderer/hooks/useInputProcessing.test.ts
@@ -1324,7 +1324,7 @@ describe('useInputProcessing', () => {
 				const deps = createDeps({
 					activeSession: session,
 					sessionsRef: { current: [session] },
-					inputValue: '', // input is empty — staged images must come from options
+					inputValue: '', // input is empty - staged images must come from options
 					stagedImages: [], // active tab has no staged images at click time
 				});
 				const { result } = renderHook(() => useInputProcessing(deps));

--- a/src/__tests__/renderer/hooks/useMainKeyboardHandler.test.ts
+++ b/src/__tests__/renderer/hooks/useMainKeyboardHandler.test.ts
@@ -1713,7 +1713,7 @@ describe('useMainKeyboardHandler', () => {
 						filePreviewTabs: [
 							{ id: 'file-tab-1', path: '/test/file.ts', name: 'file', extension: '.ts' },
 						],
-						activeFileTabId: 'file-tab-1', // File tab is active — inputMode stays 'ai'
+						activeFileTabId: 'file-tab-1', // File tab is active - inputMode stays 'ai'
 						unifiedTabOrder: ['ai-tab-1', 'file-tab-1'],
 						inputMode: 'ai',
 					},

--- a/src/__tests__/renderer/stores/agentStore.test.ts
+++ b/src/__tests__/renderer/stores/agentStore.test.ts
@@ -1280,7 +1280,7 @@ describe('agentStore', () => {
 				aiTabs: [
 					{
 						id: 'tab-1',
-						agentSessionId: null, // NEW session — no conversation ID
+						agentSessionId: null, // NEW session - no conversation ID
 						name: null,
 						starred: false,
 						logs: [],

--- a/src/__tests__/renderer/utils/tabHelpers.test.ts
+++ b/src/__tests__/renderer/utils/tabHelpers.test.ts
@@ -3394,7 +3394,7 @@ describe('tabHelpers', () => {
 			const session = createMockSession({
 				aiTabs: [aiTab],
 				browserTabs: [browserTab],
-				activeTabId: 'ai-1', // Stale — points at the AI tab we're about to navigate to
+				activeTabId: 'ai-1', // Stale - points at the AI tab we're about to navigate to
 				activeBrowserTabId: 'browser-1', // What the user is actually on
 				activeFileTabId: null,
 				activeTerminalTabId: null,


### PR DESCRIPTION
Follow-up to #1374. Two pieces of fallout from that cleanup.

## 1. The dash rule described itself into nonsense

The normalizer in #1374 rewrote the very sentence that names the characters. `CLAUDE.md` on main currently reads:

> **NEVER use em-dashes (`-`, U+2014) or en-dashes (`-`, U+2013) anywhere.**
> - A plain hyphen (`-`) for numeric ranges (e.g. `10-20`, not `10-20`).

Both illustrate the forbidden character *with the replacement*. An agent reading it learns nothing.

Restored to rc's phrasing, which names the codepoints rather than printing them and is therefore immune to its own rule. `CLAUDE.md` is now byte-identical to rc's copy through the whole Writing Style section.

My bug, from #1374.

## 2. The guard had a hole exactly where the drift was worst

`eslint.config.mjs` globally ignores `src/__tests__/**` and `scripts/**`, so the rule added in #1374 never looked at them. That is not a small corner:

> of the **634** files that differed between `main` and `rc` by dash characters alone, **250 lived under `src/__tests__`**.

Roughly 40% of the surface the rule exists to protect was unwatched.

A flat-config object whose only key is `ignores` is a **global** ignore that no later entry can re-enable, so covering tests from inside the main config would mean scoping every recommended rule set away from them by hand - changing lint semantics for thousands of files to gain one rule. Instead this adds `eslint.dashes.config.mjs`: a second pass running **only** the dash rule over those two directories, chained after the main pass in `lint:eslint`. The main config is untouched.

CI ran a bare `npx eslint src/` rather than the npm script, which would have silently left the new pass out, so the workflow now calls `npm run lint:eslint`. One source of truth for what "lint" means.

Verified with a negative control: planting an em-dash comment in a test file yields exactly one violation and a non-zero exit.

## What the new pass found

- **12 trailing comments** across 11 test files, autofixed.
- **A stale ESLint directive** in `auto-updater.test.ts` referencing `@typescript-eslint/no-throw-literal`, a rule typescript-eslint removed when it was renamed to `only-throw-error`. Nothing had been linting that file, so the dead directive sat there unnoticed. Corrected to the current name, matching how `ipcHandler.test.ts` already spells it.

## Honest scoping

Those 12 fixes **converge nothing with rc today** - rc's copies of those files differ for unrelated reasons anyway. Their value is forward-looking; the guard is what stops the test tree from drifting again.

For the same reason this PR is small. The convergence work is already done: across all **3,165** shared text files, `main` and `rc` now have **zero** that differ by dash characters alone (was 603 `.ts`/`.tsx` before #1374). What was left worth doing was the bug and the coverage gap.

Still not covered, deliberately: markdown is not linted by ESLint, so the 6 remaining dashes in `.md` files are unguarded. Fixing the rule text to name codepoints is what actually prevents a recurrence there, and that is done here.

## Validation

- `tsc` on all three configs - clean
- `npm run lint:eslint` including the new pass - clean
- `prettier --check .` - clean
- Full vitest suite - **32,721 passed, 108 skipped, 0 failed**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved automated linting coverage for tests and scripts.
  - Added checks to prevent em dashes in comments and project documentation.
  - Updated lint commands and guidance for more consistent writing standards.
  - Integrated the expanded lint checks into continuous integration.

- **Documentation**
  - Clarified dash usage rules and updated examples.

- **Tests**
  - Refreshed test comments and lint suppressions without changing test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->