### PR TITLE
feat(agents): Antigravity CLI (agy) as a supported provider

### DIFF
--- a/AGENT_SUPPORT.md
+++ b/AGENT_SUPPORT.md
@@ -29,14 +29,18 @@ To add support for a new agent, follow this checklist. The agent completeness te
 3. **Define capabilities** in `src/main/agents/capabilities.ts` → `AGENT_CAPABILITIES` record (24 boolean fields)
 4. **Add display name & beta status** to `src/shared/agentMetadata.ts` - add entry to the internal `AGENT_DISPLAY_NAMES` record and optionally to `BETA_AGENTS` set (both are module-private; use `getAgentDisplayName()` and `isBetaAgent()` to read them)
 5. **Add context window default** (if applicable) to `src/shared/agentConstants.ts` → `DEFAULT_CONTEXT_WINDOWS`
-6. **Sync renderer interfaces** - add any new capability flags to `AgentCapabilities` in `src/renderer/hooks/agent/useAgentCapabilities.ts`, `src/renderer/types/index.ts`, and `src/renderer/global.d.ts`
+6. **Register it in the provider pickers** - add an entry to `AGENT_PICKER_META` in `src/shared/agentMetadata.ts` (description + brand color), or `null` if the agent must never be offered. This is what puts the provider in the New Agent modal, the New Agent Wizard's tile strip, and the Group Chat moderator dropdown, all at once. See [Step 2.6](#step-26-register-the-provider-in-the-pickers)
+7. **Add a re-auth command** to `AGENT_LOGIN_COMMANDS` in `src/shared/agentMetadata.ts` (`null` only when the agent carries no credentials of its own)
+8. **Draw the tile logo** - add a `case` to `AgentLogo` in `src/renderer/components/Wizard/screens/AgentSelectionScreen/components/AgentLogo.tsx`, and a glyph to `AGENT_ICONS` in `src/renderer/constants/agentIcons.ts`
+9. **Sync renderer interfaces** - add any new capability flags to `AgentCapabilities` in `src/renderer/hooks/agent/useAgentCapabilities.ts`, `src/renderer/types/index.ts`, and `src/renderer/global.d.ts`
 
 #### Conditional Steps (based on capabilities)
 
-7. **If `supportsJsonOutput: true`**: Create output parser at `src/main/parsers/{agent}-output-parser.ts`, register in `src/main/parsers/index.ts`
-8. **If output parser exists**: Add error patterns to `src/main/parsers/error-patterns.ts`
-9. **If `supportsSessionStorage: true`**: Create session storage extending `BaseSessionStorage` at `src/main/storage/{agent}-session-storage.ts`, register in `src/main/storage/index.ts`
-10. **If `supportsAdditionalDirectories: true`**: Add `additionalDirArgs` to the agent's definition in `src/main/agents/definitions.ts` - see [Step 3.5](#step-35-additional-directories)
+10. **If `supportsJsonOutput: true`**: Create output parser at `src/main/parsers/{agent}-output-parser.ts`, register in `src/main/parsers/index.ts`
+11. **If output parser exists**: Add error patterns to `src/main/parsers/error-patterns.ts`
+12. **If `supportsSessionStorage: true`**: Create session storage extending `BaseSessionStorage` at `src/main/storage/{agent}-session-storage.ts`, register in `src/main/storage/index.ts`
+13. **If `supportsAdditionalDirectories: true`**: Add `additionalDirArgs` to the agent's definition in `src/main/agents/definitions.ts` - see [Step 3.5](#step-35-additional-directories)
+14. **If the agent needs binary probing beyond `$PATH`**: Add install locations to `src/main/agents/path-prober.ts` (both the Windows and the POSIX tables)
 
 #### CI Enforcement
 
@@ -48,6 +52,9 @@ The `agent-completeness.test.ts` test validates:
 - Every agent with `supportsSessionStorage` has a registered session storage
 - Every agent with an output parser has error patterns registered
 - Every agent declares `additionalDirArgs` **iff** `supportsAdditionalDirectories` is true
+- Every ID in `AGENT_IDS` has a picker decision in `AGENT_PICKER_META` (compile-time: the record is keyed by `AgentId`)
+- Every pickable agent has a real, non-hidden definition and a usable re-auth command
+- Every pickable agent draws a real logo rather than the blank fallback ring (`AgentSelectionScreen/components.test.tsx`)
 
 See detailed instructions below.
 
@@ -365,6 +372,53 @@ const BETA_AGENTS: ReadonlySet<AgentId> = new Set([
 	'your-agent', // Add here if beta
 ]);
 ```
+
+### Step 2.6: Register the Provider in the Pickers
+
+A provider that is defined, capable, and detected is still invisible until it is
+registered for the pickers. Maestro asks the user to choose a provider in three
+places - the New Agent modal, the New Agent Wizard's tile strip, and the Group
+Chat moderator dropdown - and all three read one registry.
+
+Edit `src/shared/agentMetadata.ts`:
+
+```typescript
+export const AGENT_PICKER_META: Record<AgentId, AgentPickerMeta | null> = {
+	// ... existing agents, in the order the pickers render them
+	'your-agent': {
+		description: "Your Vendor's AI coding assistant",
+		brandColor: '#4285F4',
+	},
+	// null withholds an agent from every picker (internal or unshipped)
+	terminal: null,
+};
+```
+
+Three things follow from that one entry:
+
+- `AGENT_TILES` (the wizard strip) is derived from it, so the tile appears with
+  the right name, pitch, brand color, and Beta badge.
+- `SUPPORTED_AGENTS` (the New Agent modal) re-exports the same list, so the row
+  becomes selectable rather than dimmed as "coming soon".
+- The Group Chat moderator dropdown filters the same tiles by what is installed,
+  so an installed provider becomes a choosable moderator.
+
+The record is keyed by `AgentId`, so adding an id to `AGENT_IDS` does not compile
+until a decision is made here. That is deliberate: Grok and Qwen3 Coder each
+shipped selectable in the New Agent modal yet absent from the wizard and
+un-pickable as a moderator, because the three lists were hand-written and nothing
+forced them to agree.
+
+Then draw the mark. Add a `case` for the agent to `AgentLogo`
+(`src/renderer/components/Wizard/screens/AgentSelectionScreen/components/AgentLogo.tsx`)
+and a glyph to `AGENT_ICONS` (`src/renderer/constants/agentIcons.ts`). Without
+the first, the tile renders the fallback empty ring, which reads as a bug; a test
+in `AgentSelectionScreen/components.test.tsx` fails when a pickable provider has
+no mark of its own.
+
+Brand colors are run through `readableTextOn()` before painting, so a near-black
+or near-background brand color is nudged into legibility rather than vanishing.
+Use the real brand color and let the helper do the rest.
 
 ### Step 3: Define Capabilities
 
@@ -1032,7 +1086,6 @@ codex exec --json resume <thread_id> "continue"
 
 ---
 
-<<<<<<< HEAD
 ### Grok CLI ✅ Fully Implemented
 
 **Status:** Beta (marked via `BETA_AGENTS` in `src/shared/agentMetadata.ts`). All facts below verified against grok v0.2.93.
@@ -1090,7 +1143,9 @@ grok --cwd /path/to/project --always-approve --output-format streaming-json --re
 # Read-only plan mode
 grok --cwd /path/to/project --output-format streaming-json --permission-mode plan -p "prompt"
 ```
-=======
+
+---
+
 ### Antigravity CLI ✅ Implemented (unverified against a live binary)
 
 **Status:** Beta (marked beta via `BETA_AGENTS` in `src/shared/agentMetadata.ts`)
@@ -1156,4 +1211,3 @@ window drives the context meter.
 - [Antigravity CLI overview](https://antigravity.google/docs/cli/overview)
 - [Headless mode](https://antigravity.google/docs/cli/headless)
 - [Installation & auth](https://antigravity.google/docs/cli/install)
->>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)

--- a/AGENT_SUPPORT.md
+++ b/AGENT_SUPPORT.md
@@ -1141,7 +1141,11 @@ window drives the context meter.
 
 - **No true read-only mode.** Headless mode auto-allows reading _and writing_ files inside the
   active workspace; `--sandbox` only restricts terminal commands. `supportsReadOnlyMode` is
-  therefore false and `readOnlyCliEnforced` is false.
+  therefore false and `readOnlyCliEnforced` is false. Knock-on effect: tab naming spawns
+  read-only and leans on `noToolsArgs` to stop a task-like first message from becoming a real
+  agentic run, but the CLI has no tool-disabling flag to put there, so a naming run can still
+  touch workspace files. (`noToolsArgs` is Claude-only today, so this is shared with every
+  other non-Claude agent - Antigravity is just the one that also lacks CLI read-only.)
 - **No image input.** No documented attachment flag, so `supportsImageInput` is false.
 - **No slash commands in headless mode.** They are a TUI-only affordance.
 - **Batch runs pass `--dangerously-skip-permissions`.** Without it, headless mode soft-denies

--- a/AGENT_SUPPORT.md
+++ b/AGENT_SUPPORT.md
@@ -948,16 +948,13 @@ Since OpenCode supports multiple providers/models, Maestro should consider:
 
 ---
 
-### Gemini CLI 📋 Planned
+### Gemini CLI 📋 Superseded
 
-**Status:** Not yet implemented
+**Status:** Not shipping. Hidden from the UI, kept only for type/back-compat.
 
-**To Add:**
-
-1. Agent definition in `agents/definitions.ts`
-2. Capabilities in `agents/capabilities.ts`
-3. Output parser for Gemini JSON format
-4. Error patterns for Google API errors
+Google's terminal agent story moved to Antigravity CLI (`agy`). See
+[Antigravity CLI](#antigravity-cli--implemented-unverified-against-a-live-binary) below for
+the shipping integration.
 
 ---
 
@@ -1035,6 +1032,7 @@ codex exec --json resume <thread_id> "continue"
 
 ---
 
+<<<<<<< HEAD
 ### Grok CLI ✅ Fully Implemented
 
 **Status:** Beta (marked via `BETA_AGENTS` in `src/shared/agentMetadata.ts`). All facts below verified against grok v0.2.93.
@@ -1092,3 +1090,66 @@ grok --cwd /path/to/project --always-approve --output-format streaming-json --re
 # Read-only plan mode
 grok --cwd /path/to/project --output-format streaming-json --permission-mode plan -p "prompt"
 ```
+=======
+### Antigravity CLI ✅ Implemented (unverified against a live binary)
+
+**Status:** Beta (marked beta via `BETA_AGENTS` in `src/shared/agentMetadata.ts`)
+
+Google's terminal coding agent, and the successor to the Gemini CLI effort above.
+
+- **Agent ID:** `antigravity`
+- **Binary:** `agy` (installs to `~/.local/bin/agy` on macOS/Linux, `%LOCALAPPDATA%\agy\bin` on Windows)
+- **Auth:** Google account. Headless runs reuse cached credentials, so the user must sign in once from an interactive `agy` session on that machine first.
+
+| Aspect             | Value                                                        |
+| ------------------ | ------------------------------------------------------------ |
+| Batch/headless     | `-p` (aliases `--print`, `--prompt`)                         |
+| JSON Output        | `--output-format stream-json` (also supports `json`, `text`) |
+| Resume             | `--conversation <id>` (`--continue` resumes the most recent) |
+| Session ID Field   | `conversation_id`                                            |
+| Model Selection    | `--model <slug>`                                             |
+| Reasoning Effort   | `--effort low\|medium\|high`                                 |
+| Auto-approve tools | `--dangerously-skip-permissions`                             |
+| Terminal sandbox   | `--sandbox`                                                  |
+| Headless timeout   | `--print-timeout` (CLI default 5m; Maestro defaults to 30m)  |
+| Session Storage    | ❌ On-disk conversation format is undocumented               |
+
+**Implementation Status:**
+
+- ✅ Output Parser: `src/main/parsers/antigravity-output-parser.ts`
+- ✅ Error Patterns: `src/main/parsers/error-patterns.ts` (`ANTIGRAVITY_ERROR_PATTERNS`)
+- ❌ Session Storage: not implemented; `supportsSessionStorage` is false
+- ⏳ Capabilities: derived from the published headless contract, not from a captured live run
+
+**Stream-JSON Event Types:**
+
+Antigravity discriminates on an `event` key and nests the payload under a property of the
+same name, which is why it needs its own parser rather than a Claude-parser subclass:
+
+- `init` → `{ cwd, tools, permission_mode, model, agent }`. Carries no `conversation_id`.
+- `step_update` → `{ conversation_id, step_index, state (ACTIVE|DONE), step_type
+(user_input|agent_response|tool|checkpoint), text_delta, tool_name, tool_info, usage }`
+- `result` → `{ conversation_id, status, response, error, duration_seconds, num_turns, usage }`.
+  `error` is present only on failure, so its presence (not the free-form `status` string) is
+  what the parser keys off to reclassify a result as an error.
+
+Usage fields are snake_case: `input_tokens`, `output_tokens`, `thinking_tokens`,
+`cache_read_tokens`, `total_tokens`. No context window is reported, so the configured
+window drives the context meter.
+
+**Known Limitations:**
+
+- **No true read-only mode.** Headless mode auto-allows reading _and writing_ files inside the
+  active workspace; `--sandbox` only restricts terminal commands. `supportsReadOnlyMode` is
+  therefore false and `readOnlyCliEnforced` is false.
+- **No image input.** No documented attachment flag, so `supportsImageInput` is false.
+- **No slash commands in headless mode.** They are a TUI-only affordance.
+- **Batch runs pass `--dangerously-skip-permissions`.** Without it, headless mode soft-denies
+  shell commands and a run stalls on its first terminal tool call.
+
+**Documentation Sources:**
+
+- [Antigravity CLI overview](https://antigravity.google/docs/cli/overview)
+- [Headless mode](https://antigravity.google/docs/cli/headless)
+- [Installation & auth](https://antigravity.google/docs/cli/install)
+>>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)

--- a/AGENT_SUPPORT.md
+++ b/AGENT_SUPPORT.md
@@ -1014,7 +1014,11 @@ window drives the context meter.
 
 - **No true read-only mode.** Headless mode auto-allows reading _and writing_ files inside the
   active workspace; `--sandbox` only restricts terminal commands. `supportsReadOnlyMode` is
-  therefore false and `readOnlyCliEnforced` is false.
+  therefore false and `readOnlyCliEnforced` is false. Knock-on effect: tab naming spawns
+  read-only and leans on `noToolsArgs` to stop a task-like first message from becoming a real
+  agentic run, but the CLI has no tool-disabling flag to put there, so a naming run can still
+  touch workspace files. (`noToolsArgs` is Claude-only today, so this is shared with every
+  other non-Claude agent - Antigravity is just the one that also lacks CLI read-only.)
 - **No image input.** No documented attachment flag, so `supportsImageInput` is false.
 - **No slash commands in headless mode.** They are a TUI-only affordance.
 - **Batch runs pass `--dangerously-skip-permissions`.** Without it, headless mode soft-denies

--- a/AGENT_SUPPORT.md
+++ b/AGENT_SUPPORT.md
@@ -880,16 +880,13 @@ Since OpenCode supports multiple providers/models, Maestro should consider:
 
 ---
 
-### Gemini CLI 📋 Planned
+### Gemini CLI 📋 Superseded
 
-**Status:** Not yet implemented
+**Status:** Not shipping. Hidden from the UI, kept only for type/back-compat.
 
-**To Add:**
-
-1. Agent definition in `agents/definitions.ts`
-2. Capabilities in `agents/capabilities.ts`
-3. Output parser for Gemini JSON format
-4. Error patterns for Google API errors
+Google's terminal agent story moved to Antigravity CLI (`agy`). See
+[Antigravity CLI](#antigravity-cli--implemented-unverified-against-a-live-binary) below for
+the shipping integration.
 
 ---
 
@@ -964,3 +961,67 @@ codex exec --json resume <thread_id> "continue"
 - **Error Patterns:** auth failures, rate limiting, token exhaustion (7 variants), network errors, model-availability errors, session-not-found.
 - **Model Discovery:** Fetches the `github-copilot` model list from [models.dev](https://models.dev) (3s timeout) and merges it with the user's configured model from `~/.copilot/config.json`. See `readCopilotConfiguredModel` / `fetchCopilotModelsFromApi` in `src/main/agents/detector.ts`.
 - **Known Limitations:** Interactive PTY mode does not go through `wrapSpawnWithSsh()`, so interactive Copilot-CLI over SSH is not supported. Batch mode (`-p`) works over SSH.
+
+---
+
+### Antigravity CLI ✅ Implemented (unverified against a live binary)
+
+**Status:** Beta (marked beta via `BETA_AGENTS` in `src/shared/agentMetadata.ts`)
+
+Google's terminal coding agent, and the successor to the Gemini CLI effort above.
+
+- **Agent ID:** `antigravity`
+- **Binary:** `agy` (installs to `~/.local/bin/agy` on macOS/Linux, `%LOCALAPPDATA%\agy\bin` on Windows)
+- **Auth:** Google account. Headless runs reuse cached credentials, so the user must sign in once from an interactive `agy` session on that machine first.
+
+| Aspect             | Value                                                        |
+| ------------------ | ------------------------------------------------------------ |
+| Batch/headless     | `-p` (aliases `--print`, `--prompt`)                         |
+| JSON Output        | `--output-format stream-json` (also supports `json`, `text`) |
+| Resume             | `--conversation <id>` (`--continue` resumes the most recent) |
+| Session ID Field   | `conversation_id`                                            |
+| Model Selection    | `--model <slug>`                                             |
+| Reasoning Effort   | `--effort low\|medium\|high`                                 |
+| Auto-approve tools | `--dangerously-skip-permissions`                             |
+| Terminal sandbox   | `--sandbox`                                                  |
+| Headless timeout   | `--print-timeout` (CLI default 5m; Maestro defaults to 30m)  |
+| Session Storage    | ❌ On-disk conversation format is undocumented               |
+
+**Implementation Status:**
+
+- ✅ Output Parser: `src/main/parsers/antigravity-output-parser.ts`
+- ✅ Error Patterns: `src/main/parsers/error-patterns.ts` (`ANTIGRAVITY_ERROR_PATTERNS`)
+- ❌ Session Storage: not implemented; `supportsSessionStorage` is false
+- ⏳ Capabilities: derived from the published headless contract, not from a captured live run
+
+**Stream-JSON Event Types:**
+
+Antigravity discriminates on an `event` key and nests the payload under a property of the
+same name, which is why it needs its own parser rather than a Claude-parser subclass:
+
+- `init` → `{ cwd, tools, permission_mode, model, agent }`. Carries no `conversation_id`.
+- `step_update` → `{ conversation_id, step_index, state (ACTIVE|DONE), step_type
+(user_input|agent_response|tool|checkpoint), text_delta, tool_name, tool_info, usage }`
+- `result` → `{ conversation_id, status, response, error, duration_seconds, num_turns, usage }`.
+  `error` is present only on failure, so its presence (not the free-form `status` string) is
+  what the parser keys off to reclassify a result as an error.
+
+Usage fields are snake_case: `input_tokens`, `output_tokens`, `thinking_tokens`,
+`cache_read_tokens`, `total_tokens`. No context window is reported, so the configured
+window drives the context meter.
+
+**Known Limitations:**
+
+- **No true read-only mode.** Headless mode auto-allows reading _and writing_ files inside the
+  active workspace; `--sandbox` only restricts terminal commands. `supportsReadOnlyMode` is
+  therefore false and `readOnlyCliEnforced` is false.
+- **No image input.** No documented attachment flag, so `supportsImageInput` is false.
+- **No slash commands in headless mode.** They are a TUI-only affordance.
+- **Batch runs pass `--dangerously-skip-permissions`.** Without it, headless mode soft-denies
+  shell commands and a run stalls on its first terminal tool call.
+
+**Documentation Sources:**
+
+- [Antigravity CLI overview](https://antigravity.google/docs/cli/overview)
+- [Headless mode](https://antigravity.google/docs/cli/headless)
+- [Installation & auth](https://antigravity.google/docs/cli/install)

--- a/CLAUDE-AGENTS.md
+++ b/CLAUDE-AGENTS.md
@@ -4,15 +4,20 @@ Agent support documentation for the Maestro codebase. For the main guide, see [[
 
 ## Supported Agents
 
-| ID              | Name          | Status     | Notes                                                                                                                                              |
-| --------------- | ------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `claude-code`   | Claude Code   | **Active** | Primary agent, `--print --verbose --output-format stream-json`                                                                                     |
-| `codex`         | Codex         | **Active** | Full support, `--json`, YOLO mode default                                                                                                          |
-| `opencode`      | OpenCode      | **Active** | Multi-provider support (75+ LLMs), stub provider session storage                                                                                   |
-| `factory-droid` | Factory Droid | **Active** | Factory's AI coding assistant, `-o stream-json`                                                                                                    |
-| `copilot-cli`   | Copilot-CLI   | **Beta**   | `-p/--prompt`, `--output-format json`, `--resume`, `@image` mentions, permission filters, reasoning stream, models.dev model picker                |
-| `grok`          | Grok CLI      | **Beta**   | `-p` headless, `--output-format streaming-json` (JSONL), `--resume`, `--permission-mode plan`, thought/text deltas, models_cache.json model picker |
-| `terminal`      | Terminal      | Internal   | Hidden from UI, used for shell sessions                                                                                                            |
+| ID              | Name            | Status     | Notes                                                                                                                                              |
+| --------------- | --------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `claude-code`   | Claude Code     | **Active** | Primary agent, `--print --verbose --output-format stream-json`                                                                                     |
+| `codex`         | Codex           | **Active** | Full support, `--json`, YOLO mode default                                                                                                          |
+| `opencode`      | OpenCode        | **Active** | Multi-provider support (75+ LLMs), stub provider session storage                                                                                   |
+| `factory-droid` | Factory Droid   | **Active** | Factory's AI coding assistant, `-o stream-json`                                                                                                    |
+| `copilot-cli`   | Copilot-CLI     | **Beta**   | `-p/--prompt`, `--output-format json`, `--resume`, `@image` mentions, permission filters, reasoning stream, models.dev model picker                |
+| `grok`          | Grok CLI        | **Beta**   | `-p` headless, `--output-format streaming-json` (JSONL), `--resume`, `--permission-mode plan`, thought/text deltas, models_cache.json model picker |
+| `antigravity`   | Antigravity CLI | **Beta**   | `agy -p`, `--output-format stream-json`, `--conversation <id>`, `--model` / `--effort`, 30m `--print-timeout`                                      |
+| `qwen3-coder`   | Qwen3 Coder     | **Beta**   | Gemini CLI fork, stream-json headless interface, `--resume`                                                                                        |
+| `hermes`        | Hermes          | **Beta**   | Nous Research's coding agent                                                                                                                       |
+| `pi`            | Pi              | **Beta**   | Bring-your-own agent harness                                                                                                                       |
+| `omp`           | Oh My Pi        | **Beta**   | Multi-model coding agent; prompt must be a positional arg, never stdin                                                                             |
+| `terminal`      | Terminal        | Internal   | Hidden from UI, used for shell sessions                                                                                                            |
 
 ## Agent Capabilities
 
@@ -60,8 +65,30 @@ Centralized in `src/shared/agentMetadata.ts` (importable from any process):
 
 - `getAgentDisplayName(agentId)` - human-readable name with fallback
 - `isBetaAgent(agentId)` - beta badge check
+- `getAgentLoginCommand(agentId, customPath?)` - the shell command that re-authenticates the provider
+- `getAgentPickerMeta(agentId)` / `PICKABLE_AGENT_IDS` - which providers a user may choose, and how they present
 
 The backing data (`AGENT_DISPLAY_NAMES` record, `BETA_AGENTS` set) is module-private. Use the functions above to access it.
+
+### Provider Pickers: One Registry, Three Surfaces
+
+Maestro asks the user to choose a provider in three places, and all three read
+`AGENT_PICKER_META` in `src/shared/agentMetadata.ts`:
+
+| Surface                       | Reads                                                     |
+| ----------------------------- | --------------------------------------------------------- |
+| New Agent modal               | `SUPPORTED_AGENTS` (re-exports `PICKABLE_AGENT_IDS`)      |
+| New Agent Wizard tile strip   | `AGENT_TILES` (derived from `AGENT_PICKER_META`)          |
+| Group Chat moderator dropdown | `AGENT_TILES`, filtered by what detection found installed |
+
+The record is keyed by `AgentId`, so a new id does not compile until it is either
+given picker metadata or explicitly set to `null`. Before that was true, the
+three lists were hand-written and drifted: Grok and Qwen3 Coder were selectable
+in the New Agent modal for months while being absent from the wizard and
+un-pickable as a group chat moderator.
+
+Note that the `supportsGroupChatModeration` capability flag is advisory - the
+moderator dropdown does not filter on it, and offers any installed provider.
 
 ## Agent-Specific Details
 
@@ -136,9 +163,13 @@ To add support for a new agent:
 3. Define capabilities in `src/main/agents/capabilities.ts` → `AGENT_CAPABILITIES` (24 boolean flags)
 4. Add display name and beta status to `src/shared/agentMetadata.ts` (internal maps, accessed via `getAgentDisplayName()` / `isBetaAgent()`)
 5. Add context window default to `src/shared/agentConstants.ts` → `DEFAULT_CONTEXT_WINDOWS`
-6. Sync `AgentCapabilities` interface in renderer: `useAgentCapabilities.ts`, `types/index.ts`, `global.d.ts`
-7. (If `supportsJsonOutput`) Create output parser in `src/main/parsers/{agent}-output-parser.ts`, register in `src/main/parsers/index.ts`
-8. (If `supportsSessionStorage`) Create session storage extending `BaseSessionStorage` in `src/main/storage/`
-9. (Optional) Add error patterns to `src/main/parsers/error-patterns.ts`
+6. **Register it in the pickers**: add an entry to `AGENT_PICKER_META` in `src/shared/agentMetadata.ts`, or `null` to withhold it. This is what makes the provider appear in the New Agent modal, the wizard tile strip, and the Group Chat moderator dropdown
+7. Add a re-auth command to `AGENT_LOGIN_COMMANDS` in `src/shared/agentMetadata.ts`
+8. Draw the tile logo: a `case` in `AgentSelectionScreen/components/AgentLogo.tsx`, plus a glyph in `src/renderer/constants/agentIcons.ts`
+9. Add install locations to `src/main/agents/path-prober.ts` if the binary does not always land on `$PATH`
+10. Sync `AgentCapabilities` interface in renderer: `useAgentCapabilities.ts`, `types/index.ts`, `global.d.ts`
+11. (If `supportsJsonOutput`) Create output parser in `src/main/parsers/{agent}-output-parser.ts`, register in `src/main/parsers/index.ts`
+12. (If `supportsSessionStorage`) Create session storage extending `BaseSessionStorage` in `src/main/storage/`
+13. (Optional) Add error patterns to `src/main/parsers/error-patterns.ts`
 
 The `agent-completeness.test.ts` CI test will fail if required steps are missed. See [AGENT_SUPPORT.md](AGENT_SUPPORT.md) for comprehensive integration documentation.

--- a/CLAUDE-AGENTS.md
+++ b/CLAUDE-AGENTS.md
@@ -170,6 +170,6 @@ To add support for a new agent:
 10. Sync `AgentCapabilities` interface in renderer: `useAgentCapabilities.ts`, `types/index.ts`, `global.d.ts`
 11. (If `supportsJsonOutput`) Create output parser in `src/main/parsers/{agent}-output-parser.ts`, register in `src/main/parsers/index.ts`
 12. (If `supportsSessionStorage`) Create session storage extending `BaseSessionStorage` in `src/main/storage/`
-13. (Optional) Add error patterns to `src/main/parsers/error-patterns.ts`
+13. (If the agent has an output parser) Add error patterns to `src/main/parsers/error-patterns.ts` - required, not optional: `agent-completeness.test.ts` fails CI when a registered parser has no patterns
 
 The `agent-completeness.test.ts` CI test will fail if required steps are missed. See [AGENT_SUPPORT.md](AGENT_SUPPORT.md) for comprehensive integration documentation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ Grep-verified 2026-04-10. Import from these canonical locations:
 - **Long-press gesture:** `useLongPress()` in `src/renderer/hooks/utils/useLongPress.ts` (scroll-aware touch long-press that opens right-click affordances like context menus and tab overlays; do NOT hand-roll `setTimeout` + `touchmove`)
 - **Color math and contrast:** `readableTextOn()`, `isReadableOn()`, `contrastRatio()`, `relativeLuminance()`, `blendColors()`, `transparentize()`, `adjustBrightness()`, `hexToRgb()` in `src/shared/colorContrast.ts`. Whenever a foreground and its background are BOTH derived from theme colors (diagram fills, chart labels, badges, generated SVG), run the foreground through `readableTextOn(preferred, backgrounds)` so a theme whose accent sits near its text color can't paint near-identical colors on top of each other. It returns the preferred color untouched when it already clears WCAG AA and nudges the theme's own color otherwise, so nothing snaps to hard-coded black/white.
 - **Agent display name:** `getAgentDisplayName()` in `src/shared/agentMetadata.ts`
+- **Which providers a user can pick:** `AGENT_PICKER_META` / `PICKABLE_AGENT_IDS` / `getAgentPickerMeta()` in `src/shared/agentMetadata.ts`. ONE registry feeds all three provider pickers: the New Agent modal (`SUPPORTED_AGENTS` re-exports it), the New Agent Wizard's tile strip (`AGENT_TILES` is derived from it), and the Group Chat moderator dropdown (the same tiles, filtered by what detection found). Do NOT hand-write a fourth list of agent ids for a new picker: the three used to be written by hand, and Grok and Qwen3 Coder shipped selectable in the New Agent modal while being absent from the wizard and un-pickable as a moderator. The record is keyed by `AgentId`, so a new id fails to compile until it is either given metadata or explicitly set to `null` (internal or unshipped). Adding a provider also means a `case` in `AgentLogo` and a glyph in `AGENT_ICONS`, or the tile draws a blank fallback ring. Full checklist: [AGENT_SUPPORT.md → Step 2.6](AGENT_SUPPORT.md#step-26-register-the-provider-in-the-pickers).
 - **SSH remote lookup:** `getSshRemoteById()` in `src/main/stores/getters.ts`
 - **Toast notifications:** `notifyToast({ color, title, message, dismissible? })` in `src/renderer/stores/notificationStore.ts`. Use for async results, errors, and persistent/dismissable messages. Same five-color design language as Center Flash: `green | yellow | orange | red | theme` (default `theme`). Set `dismissible: true` (or pass `--dismissible` from `maestro-cli notify toast`) when the user MUST acknowledge - disables auto-dismiss, requires click to close, and emphasizes the X button. Cannot combine `dismissible` with `duration`/`--timeout`. External CLI cap: 60 seconds (use `--dismissible` for sticky). **Click actions** (data-driven, survive the IPC bridge): pass `clickAction: { kind: 'jump-session', sessionId, tabId? } | { kind: 'open-file', sessionId, path } | { kind: 'open-url', url }` for what should happen when the toast body is clicked, or use the legacy `sessionId`/`tabId` fields for plain agent jump. From the CLI: `--agent` (+ optional `--tab`), `--open-file <path>` (requires `--agent`), `--open-url <url>` (mutually exclusive with `--open-file`). `--action-url` / `--action-label` render an inline link button beneath the message and are independent of the body click. **Source-agent label:** pass `sourceAgent` (CLI `--source-agent <label>`) to stamp which agent/pipeline fired the toast in the header strip. It's store-independent, so it shows even when the agent isn't loaded in the Left Bar (the name resolved from `--agent`/`sessionId` only renders when that agent is in the desktop store) - use it for cron/watchdog toasts. The explicit label wins over the resolved name for display; pair it with `--agent` to also get click-to-jump. Do NOT pass renderer-only callbacks across the bridge - use `clickAction` instead.
 - **Center flash (rapid acks):** `notifyCenterFlash({ message, color, detail?, duration? })` in `src/renderer/stores/centerFlashStore.ts`; clipboard helper `flashCopiedToClipboard()` in `src/renderer/utils/flashCopiedToClipboard.ts`. Use for momentary "I did the thing" confirmations of user-initiated actions. Five-color design language: `green | yellow | orange | red | theme` - default `theme` matches the active Maestro theme. External integrations can fire flashes via `maestro-cli notify flash <message> --color <color>`. Do NOT roll your own center-screen overlay, useState+setTimeout flash, add a sixth color, or use a Toast for clipboard acks. Single visible flash at a time, themed frosted-glass card mounted once in `App.tsx`. Full decision rules, color palette, and design language: [UI-PATTERNS.md → Center Flash System](docs/agent-guides/UI-PATTERNS.md#center-flash-system-rapid-temporary-notifications).
@@ -222,27 +223,24 @@ Maestro is an Electron desktop app for managing multiple AI coding assistants si
 
 ### Supported Agents
 
-<<<<<<< HEAD
-| ID              | Name          | Status     |
-| --------------- | ------------- | ---------- |
-| `claude-code`   | Claude Code   | **Active** |
-| `codex`         | OpenAI Codex  | **Active** |
-| `opencode`      | OpenCode      | **Active** |
-| `factory-droid` | Factory Droid | **Active** |
-| `copilot-cli`   | Copilot-CLI   | **Beta**   |
-| `grok`          | Grok CLI      | **Beta**   |
-| `terminal`      | Terminal      | Internal   |
-=======
 | ID              | Name            | Status     |
 | --------------- | --------------- | ---------- |
 | `claude-code`   | Claude Code     | **Active** |
 | `codex`         | OpenAI Codex    | **Active** |
-| `opencode`      | OpenCode        | **Active** |
-| `factory-droid` | Factory Droid   | **Active** |
-| `copilot-cli`   | Copilot-CLI     | **Beta**   |
 | `antigravity`   | Antigravity CLI | **Beta**   |
+| `opencode`      | OpenCode        | **Beta**   |
+| `factory-droid` | Factory Droid   | **Beta**   |
+| `copilot-cli`   | Copilot-CLI     | **Beta**   |
+| `grok`          | Grok CLI        | **Beta**   |
+| `qwen3-coder`   | Qwen3 Coder     | **Beta**   |
+| `hermes`        | Hermes          | **Beta**   |
+| `pi`            | Pi              | **Beta**   |
+| `omp`           | Oh My Pi        | **Beta**   |
 | `terminal`      | Terminal        | Internal   |
->>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
+
+Rows are in picker order and mirror `AGENT_PICKER_META` in
+`src/shared/agentMetadata.ts`, which is the one registry all three provider
+pickers read.
 
 See [[CLAUDE-AGENTS.md]] for capabilities and integration details.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,7 @@ Maestro is an Electron desktop app for managing multiple AI coding assistants si
 
 ### Supported Agents
 
+<<<<<<< HEAD
 | ID              | Name          | Status     |
 | --------------- | ------------- | ---------- |
 | `claude-code`   | Claude Code   | **Active** |
@@ -231,6 +232,17 @@ Maestro is an Electron desktop app for managing multiple AI coding assistants si
 | `copilot-cli`   | Copilot-CLI   | **Beta**   |
 | `grok`          | Grok CLI      | **Beta**   |
 | `terminal`      | Terminal      | Internal   |
+=======
+| ID              | Name            | Status     |
+| --------------- | --------------- | ---------- |
+| `claude-code`   | Claude Code     | **Active** |
+| `codex`         | OpenAI Codex    | **Active** |
+| `opencode`      | OpenCode        | **Active** |
+| `factory-droid` | Factory Droid   | **Active** |
+| `copilot-cli`   | Copilot-CLI     | **Beta**   |
+| `antigravity`   | Antigravity CLI | **Beta**   |
+| `terminal`      | Terminal        | Internal   |
+>>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 
 See [[CLAUDE-AGENTS.md]] for capabilities and integration details.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,14 +195,15 @@ Maestro is an Electron desktop app for managing multiple AI coding assistants si
 
 ### Supported Agents
 
-| ID              | Name          | Status     |
-| --------------- | ------------- | ---------- |
-| `claude-code`   | Claude Code   | **Active** |
-| `codex`         | OpenAI Codex  | **Active** |
-| `opencode`      | OpenCode      | **Active** |
-| `factory-droid` | Factory Droid | **Active** |
-| `copilot-cli`   | Copilot-CLI   | **Beta**   |
-| `terminal`      | Terminal      | Internal   |
+| ID              | Name            | Status     |
+| --------------- | --------------- | ---------- |
+| `claude-code`   | Claude Code     | **Active** |
+| `codex`         | OpenAI Codex    | **Active** |
+| `opencode`      | OpenCode        | **Active** |
+| `factory-droid` | Factory Droid   | **Active** |
+| `copilot-cli`   | Copilot-CLI     | **Beta**   |
+| `antigravity`   | Antigravity CLI | **Beta**   |
+| `terminal`      | Terminal        | Internal   |
 
 See [[CLAUDE-AGENTS.md]] for capabilities and integration details.
 

--- a/docs/agent-guides/AGENT-INFRA.md
+++ b/docs/agent-guides/AGENT-INFRA.md
@@ -16,7 +16,12 @@ Complete reference for Maestro's agent registration system: agent IDs, definitio
 5. Output Parsers    src/main/parsers/                 JSON output normalization per agent
 6. Error Patterns    src/main/parsers/error-patterns.ts  Regex patterns for error detection
 7. Session Storage   src/main/storage/                 Per-agent session file reading
+8. Picker Registry   src/shared/agentMetadata.ts       Whether and how the user can choose it
 ```
+
+Steps 1-7 make an agent work. Step 8 is what makes it reachable: an agent that
+is defined, capable, and detected is still invisible in the UI until it has a
+`AGENT_PICKER_META` entry.
 
 ---
 
@@ -45,13 +50,33 @@ export type AgentId = (typeof AGENT_IDS)[number];
 ### Related Metadata (`src/shared/agentMetadata.ts`)
 
 ```typescript
-AGENT_DISPLAY_NAMES: Record<AgentId, string>  // Human-readable names
-BETA_AGENTS: ReadonlySet<AgentId>              // Agents showing "(Beta)" badge
-getAgentDisplayName(agentId): string           // Get name with fallback
-isBetaAgent(agentId): boolean                  // Check beta status
-getAgentLoginCommand(agentId, customPath?)     // Re-auth command, or null
-formatAgentLoginCommand(login): string         // Render it as a shell line
+AGENT_DISPLAY_NAMES: Record<AgentId, string>       // Human-readable names
+BETA_AGENTS: ReadonlySet<AgentId>                  // Agents showing "(Beta)" badge
+AGENT_PICKER_META: Record<AgentId, Meta | null>    // Picker presentation, null = never offered
+PICKABLE_AGENT_IDS: readonly AgentId[]             // Picker order, derived from the record
+getAgentDisplayName(agentId): string               // Get name with fallback
+isBetaAgent(agentId): boolean                      // Check beta status
+getAgentPickerMeta(agentId): Meta | null           // Description + brand color, or null
+getAgentLoginCommand(agentId, customPath?)         // Re-auth command, or null
+formatAgentLoginCommand(login): string             // Render it as a shell line
 ```
+
+**Provider pickers** all read `AGENT_PICKER_META`. The New Agent modal's
+`SUPPORTED_AGENTS` re-exports `PICKABLE_AGENT_IDS`; the New Agent Wizard's
+`AGENT_TILES` is derived from the record (name from `getAgentDisplayName`, pitch
+and brand color from the entry); the Group Chat moderator dropdown renders those
+same tiles filtered by what detection found installed. `null` withholds an agent
+from all three - correct for `terminal` (internal) and `gemini-cli` (kept for
+type and back-compat only). Because the record is keyed by `AgentId`, a new id
+does not compile until that decision is made. Do NOT add a fourth hand-written
+list of agent ids for a new picker; the three used to be hand-written, and Grok
+and Qwen3 Coder shipped selectable in one of them and missing from the other two.
+
+Registering a provider also means drawing it: a `case` in `AgentLogo`
+(`src/renderer/components/Wizard/screens/AgentSelectionScreen/components/AgentLogo.tsx`)
+and a glyph in `AGENT_ICONS` (`src/renderer/constants/agentIcons.ts`). Without
+the logo case the tile renders a blank fallback ring, and a test in
+`AgentSelectionScreen/components.test.tsx` fails.
 
 **Re-authentication commands** are keyed by `AgentId`, so adding an agent forces a decision about how it logs in. An entry carries `binary` + `args` (the line Maestro types into the re-authentication terminal) and an optional `followUp` for providers whose login only exists as a slash command inside their TUI (`gemini-cli`, `qwen3-coder`, `factory-droid`). `null` means the agent has no login flow of its own. `getAgentLoginCommand` returns `null` for unknown ids rather than guessing, because the result is executed in a shell. The consumer is `ReauthModal` (`src/renderer/components/ReauthModal.tsx`); do not hand-roll a second login-command table.
 

--- a/docs/agent-guides/UI-PATTERNS.md
+++ b/docs/agent-guides/UI-PATTERNS.md
@@ -411,6 +411,19 @@ It returns `0` until the first measurement lands, so gate width-dependent childr
 
 This matters for any resizable modal that draws a chart: a hard-coded SVG width silently stops matching the frame the moment the user drags it.
 
+### Horizontally Scrolling Strips (`useHorizontalScroll`)
+
+`useHorizontalScroll(ref, resetKey?)` (`hooks/ui/useHorizontalScroll.ts`) returns `{ canScrollLeft, canScrollRight, scrollByPage }` for a row that overflows sideways. Reach for it whenever a set that keeps growing has to stay one row tall: the New Agent Wizard's provider strip is the first consumer, because a wrapping grid pushed the Continue button below the fold once the provider count passed eight.
+
+Two things a bare `overflow-x-auto` gets wrong, and this hook fixes:
+
+- **Silence at the edge.** Nothing tells the user more content exists past the right edge. Use the flags to render an honest affordance - a gradient fade plus an arrow button. Do not render the arrows unconditionally: an arrow that cannot move is worse than no arrow.
+- **A swallowed wheel gesture.** A strip has no vertical overflow of its own, so a mouse wheel or trackpad flick over it scrolls an ancestor or does nothing. The hook maps vertical deltas onto the horizontal axis.
+
+Keep the arrow buttons out of the tab order (`tabIndex={-1}`) when the strip's items are already reachable with the arrow keys - otherwise they become dead ends in the middle of the keyboard path. Focusing an item scrolls it into view for free, so keyboard navigation needs no extra scrolling code.
+
+It no-ops without `ResizeObserver`, so jsdom component tests render without a polyfill (and both flags read `false`, since jsdom reports zero for every measurement).
+
 ### Entity Tiles in the Usage Dashboard (`<EntityTile>`)
 
 The Usage Dashboard's card grids (the agent grid in `AgentOverviewCards`, the per-tab grid in `TabBreakdown`) all render the same tile: status dot, truncating title, badges, corner age, optional subtitle, a row of labeled stats, and a corner sparkline. That chrome lives once in `src/renderer/components/UsageDashboard/EntityTile.tsx` - border states (default / dashed / hovered / selected), the staggered `card-enter` animation, the clickable-button affordance, and the highlighted-stat accent coloring.

--- a/src/__tests__/main/agents/agent-completeness.test.ts
+++ b/src/__tests__/main/agents/agent-completeness.test.ts
@@ -188,13 +188,40 @@ describe('Agent Completeness', () => {
 			}
 		});
 
+		// Providers that hold no credentials of their own, so `null` from
+		// getAgentLoginCommand is the correct answer rather than a missing entry.
+		// Pi and Oh My Pi are harnesses over a provider the user configures
+		// elsewhere; Hermes ships no login flow. Adding an id here is a deliberate
+		// claim that the agent cannot be logged in to, not a way to silence a gap.
+		const CREDENTIALLESS_AGENTS = new Set(['hermes', 'pi', 'omp']);
+
 		it('every pickable agent can be re-authenticated from the UI', () => {
-			// A provider offered in a picker whose auth expires needs a way back in;
-			// null is only correct for agents that carry no credentials of their own.
+			// A provider offered in a picker whose auth expires needs a way back in.
+			// An earlier version of this test skipped a null command outright, which
+			// let a genuinely missing entry pass as if it were credentialless.
 			for (const agentId of PICKABLE_AGENT_IDS) {
 				const login = getAgentLoginCommand(agentId);
-				if (login === null) continue;
-				expect(login.binary, `Agent "${agentId}" has an empty login binary`).toBeTruthy();
+
+				if (CREDENTIALLESS_AGENTS.has(agentId)) {
+					expect(
+						login,
+						`Agent "${agentId}" is listed as credentialless but declares a login command. ` +
+							'Remove it from CREDENTIALLESS_AGENTS.'
+					).toBeNull();
+					continue;
+				}
+
+				expect(
+					login,
+					`Agent "${agentId}" is pickable but has no login command. Add one to ` +
+						'AGENT_LOGIN_COMMANDS, or add the id to CREDENTIALLESS_AGENTS if it ' +
+						'genuinely carries no credentials.'
+				).not.toBeNull();
+				expect(login?.binary?.trim(), `Agent "${agentId}" has an empty login binary`).toBeTruthy();
+				expect(
+					typeof login?.args,
+					`Agent "${agentId}" must declare args (empty string when the bare binary is the flow)`
+				).toBe('string');
 			}
 		});
 	});

--- a/src/__tests__/main/agents/agent-completeness.test.ts
+++ b/src/__tests__/main/agents/agent-completeness.test.ts
@@ -27,6 +27,11 @@ import { initializeOutputParsers, getOutputParser, getErrorPatterns } from '../.
 import { getSessionStorage, clearStorageRegistry } from '../../../main/agents/session-storage';
 import { initializeSessionStorages } from '../../../main/storage';
 import { AGENT_IDS } from '../../../shared/agentIds';
+import {
+	AGENT_PICKER_META,
+	PICKABLE_AGENT_IDS,
+	getAgentLoginCommand,
+} from '../../../shared/agentMetadata';
 import { createAgentRegistry } from '../../../shared/plugins/agent-registry';
 
 beforeAll(() => {
@@ -162,6 +167,36 @@ describe('Agent Completeness', () => {
 				});
 			});
 		}
+	});
+
+	describe('provider picker registration', () => {
+		it('every agent id has a picker decision, shown or explicitly withheld', () => {
+			for (const agentId of AGENT_IDS) {
+				expect(
+					Object.prototype.hasOwnProperty.call(AGENT_PICKER_META, agentId),
+					`Agent "${agentId}" has no entry in AGENT_PICKER_META. Add presentation ` +
+						'metadata to offer it in the pickers, or null to withhold it.'
+				).toBe(true);
+			}
+		});
+
+		it('every pickable agent is a real, non-hidden definition', () => {
+			for (const agentId of PICKABLE_AGENT_IDS) {
+				const def = AGENT_DEFINITIONS.find((d) => d.id === agentId);
+				expect(def, `Pickable agent "${agentId}" has no definition`).toBeDefined();
+				expect(def?.hidden, `Pickable agent "${agentId}" is hidden`).toBeFalsy();
+			}
+		});
+
+		it('every pickable agent can be re-authenticated from the UI', () => {
+			// A provider offered in a picker whose auth expires needs a way back in;
+			// null is only correct for agents that carry no credentials of their own.
+			for (const agentId of PICKABLE_AGENT_IDS) {
+				const login = getAgentLoginCommand(agentId);
+				if (login === null) continue;
+				expect(login.binary, `Agent "${agentId}" has an empty login binary`).toBeTruthy();
+			}
+		});
 	});
 
 	describe('no orphaned capabilities', () => {

--- a/src/__tests__/main/agents/detector.test.ts
+++ b/src/__tests__/main/agents/detector.test.ts
@@ -339,12 +339,7 @@ describe('agent-detector', () => {
 
 			const agents = await detector.detectAgents();
 
-<<<<<<< HEAD
 			expect(agents.length).toBe(getAgentIds().length);
-=======
-			// Should have all 9 agents (terminal, claude-code, codex, gemini-cli, antigravity, qwen3-coder, opencode, factory-droid, copilot-cli)
-			expect(agents.length).toBe(9);
->>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 
 			const agentIds = agents.map((a) => a.id);
 			expect(agentIds).toContain('terminal');
@@ -1082,13 +1077,8 @@ describe('agent-detector', () => {
 
 			const result = await detectPromise;
 			expect(result).toBeDefined();
-<<<<<<< HEAD
 			// Should stay aligned with the live agent catalog, even as new agents are added.
 			expect(result.length).toBe(getAgentIds().length);
-=======
-			// Should have all 9 agents (terminal, claude-code, codex, gemini-cli, antigravity, qwen3-coder, opencode, factory-droid, copilot-cli)
-			expect(result.length).toBe(9);
->>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 		});
 
 		it('should handle very long PATH', async () => {

--- a/src/__tests__/main/agents/detector.test.ts
+++ b/src/__tests__/main/agents/detector.test.ts
@@ -339,13 +339,19 @@ describe('agent-detector', () => {
 
 			const agents = await detector.detectAgents();
 
+<<<<<<< HEAD
 			expect(agents.length).toBe(getAgentIds().length);
+=======
+			// Should have all 9 agents (terminal, claude-code, codex, gemini-cli, antigravity, qwen3-coder, opencode, factory-droid, copilot-cli)
+			expect(agents.length).toBe(9);
+>>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 
 			const agentIds = agents.map((a) => a.id);
 			expect(agentIds).toContain('terminal');
 			expect(agentIds).toContain('claude-code');
 			expect(agentIds).toContain('codex');
 			expect(agentIds).toContain('gemini-cli');
+			expect(agentIds).toContain('antigravity');
 			expect(agentIds).toContain('qwen3-coder');
 			expect(agentIds).toContain('hermes');
 			expect(agentIds).toContain('pi');
@@ -1076,8 +1082,13 @@ describe('agent-detector', () => {
 
 			const result = await detectPromise;
 			expect(result).toBeDefined();
+<<<<<<< HEAD
 			// Should stay aligned with the live agent catalog, even as new agents are added.
 			expect(result.length).toBe(getAgentIds().length);
+=======
+			// Should have all 9 agents (terminal, claude-code, codex, gemini-cli, antigravity, qwen3-coder, opencode, factory-droid, copilot-cli)
+			expect(result.length).toBe(9);
+>>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 		});
 
 		it('should handle very long PATH', async () => {

--- a/src/__tests__/main/agents/detector.test.ts
+++ b/src/__tests__/main/agents/detector.test.ts
@@ -322,14 +322,15 @@ describe('agent-detector', () => {
 
 			const agents = await detector.detectAgents();
 
-			// Should have all 8 agents (terminal, claude-code, codex, gemini-cli, qwen3-coder, opencode, factory-droid, copilot-cli)
-			expect(agents.length).toBe(8);
+			// Should have all 9 agents (terminal, claude-code, codex, gemini-cli, antigravity, qwen3-coder, opencode, factory-droid, copilot-cli)
+			expect(agents.length).toBe(9);
 
 			const agentIds = agents.map((a) => a.id);
 			expect(agentIds).toContain('terminal');
 			expect(agentIds).toContain('claude-code');
 			expect(agentIds).toContain('codex');
 			expect(agentIds).toContain('gemini-cli');
+			expect(agentIds).toContain('antigravity');
 			expect(agentIds).toContain('qwen3-coder');
 			expect(agentIds).toContain('opencode');
 			expect(agentIds).toContain('factory-droid');
@@ -968,8 +969,8 @@ describe('agent-detector', () => {
 
 			const result = await detectPromise;
 			expect(result).toBeDefined();
-			// Should have all 8 agents (terminal, claude-code, codex, gemini-cli, qwen3-coder, opencode, factory-droid, copilot-cli)
-			expect(result.length).toBe(8);
+			// Should have all 9 agents (terminal, claude-code, codex, gemini-cli, antigravity, qwen3-coder, opencode, factory-droid, copilot-cli)
+			expect(result.length).toBe(9);
 		});
 
 		it('should handle very long PATH', async () => {

--- a/src/__tests__/main/parsers/antigravity-output-parser.test.ts
+++ b/src/__tests__/main/parsers/antigravity-output-parser.test.ts
@@ -27,8 +27,20 @@ describe('AntigravityOutputParser', () => {
 				raw: expect.objectContaining({ cwd: '/tmp/project' }),
 			})
 		);
-		// init carries no conversation_id; that first appears on step_update.
+		// The documented init payload carries no conversation_id.
 		expect(event && parser.extractSessionId(event)).toBeNull();
+	});
+
+	it('keeps a top-level conversation id on init so an immediate failure stays resumable', () => {
+		const parser = new AntigravityOutputParser();
+
+		const event = parser.parseJsonObject({
+			event: 'init',
+			conversation_id: 'conv-early',
+			init: { cwd: '/tmp/project' },
+		});
+
+		expect(event && parser.extractSessionId(event)).toBe('conv-early');
 	});
 
 	it('emits assistant text deltas as partial text carrying the conversation id', () => {
@@ -160,8 +172,10 @@ describe('AntigravityOutputParser', () => {
 				sessionId: 'conv-2',
 			})
 		);
-		// A failed result must not be reported as a successful completion.
-		expect(event && parser.isResultMessage(event)).toBe(true);
+		// A failed envelope must NOT answer isResultMessage. ExitHandler's
+		// end-of-stream flush emits event.text as the agent's answer for anything
+		// that does, which would surface the failure text as a normal response.
+		expect(event && parser.isResultMessage(event)).toBe(false);
 	});
 
 	it('classifies a failed result against the registered error patterns', () => {

--- a/src/__tests__/main/parsers/antigravity-output-parser.test.ts
+++ b/src/__tests__/main/parsers/antigravity-output-parser.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { AntigravityOutputParser } from '../../../main/parsers/antigravity-output-parser';
+import { initializeOutputParsers } from '../../../main/parsers';
+
+beforeAll(() => {
+	// detectErrorFromParsed / detectErrorFromExit consult the error-pattern registry.
+	initializeOutputParsers();
+});
+
+describe('AntigravityOutputParser', () => {
+	it('parses the init event without inventing a conversation id', () => {
+		const parser = new AntigravityOutputParser();
+
+		const event = parser.parseJsonObject({
+			event: 'init',
+			init: {
+				cwd: '/tmp/project',
+				tools: ['read_file', 'run_command'],
+				permission_mode: 'skip',
+				model: 'gemini-3.6-flash-high',
+			},
+		});
+
+		expect(event).toEqual(
+			expect.objectContaining({
+				type: 'init',
+				raw: expect.objectContaining({ cwd: '/tmp/project' }),
+			})
+		);
+		// init carries no conversation_id; that first appears on step_update.
+		expect(event && parser.extractSessionId(event)).toBeNull();
+	});
+
+	it('emits assistant text deltas as partial text carrying the conversation id', () => {
+		const parser = new AntigravityOutputParser();
+
+		const event = parser.parseJsonObject({
+			event: 'step_update',
+			step_update: {
+				conversation_id: '055a398f-db14-4c5f-abbb-1bf03f8120a7',
+				step_index: 2,
+				state: 'ACTIVE',
+				step_type: 'agent_response',
+				text_delta: 'Hello',
+			},
+		});
+
+		expect(event).toEqual(
+			expect.objectContaining({
+				type: 'text',
+				text: 'Hello',
+				isPartial: true,
+				sessionId: '055a398f-db14-4c5f-abbb-1bf03f8120a7',
+			})
+		);
+	});
+
+	it('maps tool steps to tool_use with the tool name and lifecycle state', () => {
+		const parser = new AntigravityOutputParser();
+
+		const event = parser.parseJsonObject({
+			event: 'step_update',
+			step_update: {
+				conversation_id: 'conv-1',
+				step_index: 3,
+				state: 'DONE',
+				step_type: 'tool',
+				tool_name: 'run_command',
+				tool_info: { name: 'run_command', parameters: { cmd: 'ls' }, output: 'a\nb' },
+			},
+		});
+
+		expect(event).toEqual(
+			expect.objectContaining({
+				type: 'tool_use',
+				toolName: 'run_command',
+				toolCallId: '3',
+				toolState: 'DONE',
+				sessionId: 'conv-1',
+			})
+		);
+	});
+
+	it('treats bookkeeping steps as non-user-facing system events', () => {
+		const parser = new AntigravityOutputParser();
+
+		const event = parser.parseJsonObject({
+			event: 'step_update',
+			step_update: { conversation_id: 'conv-1', step_type: 'checkpoint', state: 'DONE' },
+		});
+
+		expect(event).toEqual(expect.objectContaining({ type: 'system', sessionId: 'conv-1' }));
+	});
+
+	it('parses the terminal result envelope and normalizes snake_case usage', () => {
+		const parser = new AntigravityOutputParser();
+
+		const event = parser.parseJsonObject({
+			event: 'result',
+			result: {
+				conversation_id: 'conv-9',
+				status: 'success',
+				response: 'All done.',
+				duration_seconds: 12.5,
+				num_turns: 1,
+				usage: {
+					input_tokens: 1200,
+					output_tokens: 300,
+					thinking_tokens: 80,
+					cache_read_tokens: 500,
+					total_tokens: 2080,
+				},
+			},
+		});
+
+		expect(event).toEqual(
+			expect.objectContaining({
+				type: 'result',
+				text: 'All done.',
+				sessionId: 'conv-9',
+			})
+		);
+		expect(event && parser.isResultMessage(event)).toBe(true);
+		expect(event && parser.extractUsage(event)).toEqual({
+			inputTokens: 1200,
+			outputTokens: 300,
+			cacheReadTokens: 500,
+			reasoningTokens: 80,
+		});
+	});
+
+	it('leaves contextWindow unset so the configured window drives the meter', () => {
+		const parser = new AntigravityOutputParser();
+
+		const event = parser.parseJsonObject({
+			event: 'result',
+			result: { conversation_id: 'c', response: 'ok', usage: { input_tokens: 1 } },
+		});
+
+		expect(event?.usage).not.toHaveProperty('contextWindow');
+	});
+
+	it('reclassifies a result carrying an error as an error event', () => {
+		const parser = new AntigravityOutputParser();
+
+		const event = parser.parseJsonObject({
+			event: 'result',
+			result: {
+				conversation_id: 'conv-2',
+				status: 'failed',
+				response: '',
+				error: 'RESOURCE_EXHAUSTED: quota exceeded for this project',
+			},
+		});
+
+		expect(event).toEqual(
+			expect.objectContaining({
+				type: 'error',
+				text: 'RESOURCE_EXHAUSTED: quota exceeded for this project',
+				sessionId: 'conv-2',
+			})
+		);
+		// A failed result must not be reported as a successful completion.
+		expect(event && parser.isResultMessage(event)).toBe(true);
+	});
+
+	it('classifies a failed result against the registered error patterns', () => {
+		const parser = new AntigravityOutputParser();
+
+		const error = parser.detectErrorFromParsed({
+			event: 'result',
+			result: { status: 'failed', error: 'RESOURCE_EXHAUSTED: quota exceeded' },
+		});
+
+		expect(error).toEqual(
+			expect.objectContaining({ type: 'rate_limited', agentId: 'antigravity', recoverable: true })
+		);
+	});
+
+	it('does not report an error for a successful result', () => {
+		const parser = new AntigravityOutputParser();
+
+		expect(
+			parser.detectErrorFromParsed({
+				event: 'result',
+				result: { status: 'success', response: 'fine' },
+			})
+		).toBeNull();
+	});
+
+	it('ignores foreign JSON objects in parseJsonObject', () => {
+		const parser = new AntigravityOutputParser();
+
+		expect(parser.parseJsonObject({ type: 'assistant', message: {} })).toBeNull();
+		expect(parser.parseJsonObject(null)).toBeNull();
+	});
+
+	it('surfaces non-JSON output as raw partial text rather than dropping it', () => {
+		const parser = new AntigravityOutputParser();
+
+		expect(parser.parseJsonLine('warning: something happened')).toEqual(
+			expect.objectContaining({ type: 'text', text: 'warning: something happened' })
+		);
+		expect(parser.parseJsonLine('   ')).toBeNull();
+	});
+
+	it('maps a headless timeout on a non-zero exit to a recoverable network error', () => {
+		const parser = new AntigravityOutputParser();
+
+		const error = parser.detectErrorFromExit(1, 'print-timeout of 5m0s exceeded', '');
+
+		expect(error).toEqual(
+			expect.objectContaining({ type: 'network_error', recoverable: true, agentId: 'antigravity' })
+		);
+	});
+
+	it('reports an unrecognized non-zero exit as a crash and stays silent on success', () => {
+		const parser = new AntigravityOutputParser();
+
+		expect(parser.detectErrorFromExit(3, 'something inscrutable', '')).toEqual(
+			expect.objectContaining({ type: 'agent_crashed', agentId: 'antigravity' })
+		);
+		expect(parser.detectErrorFromExit(0, '', '')).toBeNull();
+	});
+});

--- a/src/__tests__/main/parsers/antigravity-output-parser.test.ts
+++ b/src/__tests__/main/parsers/antigravity-output-parser.test.ts
@@ -16,7 +16,7 @@ describe('AntigravityOutputParser', () => {
 			init: {
 				cwd: '/tmp/project',
 				tools: ['read_file', 'run_command'],
-				permission_mode: 'skip',
+				permission_mode: 'always-proceed',
 				model: 'gemini-3.6-flash-high',
 			},
 		});
@@ -111,7 +111,7 @@ describe('AntigravityOutputParser', () => {
 			event: 'result',
 			result: {
 				conversation_id: 'conv-9',
-				status: 'success',
+				status: 'SUCCESS',
 				response: 'All done.',
 				duration_seconds: 12.5,
 				num_turns: 1,
@@ -159,7 +159,7 @@ describe('AntigravityOutputParser', () => {
 			event: 'result',
 			result: {
 				conversation_id: 'conv-2',
-				status: 'failed',
+				status: 'ERROR',
 				response: '',
 				error: 'RESOURCE_EXHAUSTED: quota exceeded for this project',
 			},
@@ -183,7 +183,7 @@ describe('AntigravityOutputParser', () => {
 
 		const error = parser.detectErrorFromParsed({
 			event: 'result',
-			result: { status: 'failed', error: 'RESOURCE_EXHAUSTED: quota exceeded' },
+			result: { status: 'ERROR', error: 'RESOURCE_EXHAUSTED: quota exceeded' },
 		});
 
 		expect(error).toEqual(
@@ -197,9 +197,45 @@ describe('AntigravityOutputParser', () => {
 		expect(
 			parser.detectErrorFromParsed({
 				event: 'result',
-				result: { status: 'success', response: 'fine' },
+				result: { status: 'SUCCESS', response: 'fine' },
 			})
 		).toBeNull();
+	});
+
+	it('keys off `error`, not `status`, when deciding a result failed', () => {
+		const parser = new AntigravityOutputParser();
+
+		// `status` is a free-form string the docs never enumerate exhaustively, so
+		// the parser must not read it. Both envelopes below contradict their own
+		// status; the presence or absence of `error` is what has to win.
+		expect(
+			parser.detectErrorFromParsed({
+				event: 'result',
+				result: { status: 'SUCCESS', error: 'RESOURCE_EXHAUSTED: quota exceeded' },
+			})
+		).toEqual(expect.objectContaining({ type: 'rate_limited' }));
+
+		expect(
+			parser.detectErrorFromParsed({
+				event: 'result',
+				result: { status: 'ERROR', response: 'fine' },
+			})
+		).toBeNull();
+	});
+
+	it('keeps the conversation id on a structured error so a retry can resume it', () => {
+		const parser = new AntigravityOutputParser();
+
+		const error = parser.detectErrorFromParsed({
+			event: 'result',
+			result: {
+				status: 'ERROR',
+				conversation_id: '055a398f-db14-4c5f-abbb-1bf03f8120a7',
+				error: 'RESOURCE_EXHAUSTED: quota exceeded',
+			},
+		});
+
+		expect(error?.sessionId).toBe('055a398f-db14-4c5f-abbb-1bf03f8120a7');
 	});
 
 	it('ignores foreign JSON objects in parseJsonObject', () => {

--- a/src/__tests__/main/parsers/index.test.ts
+++ b/src/__tests__/main/parsers/index.test.ts
@@ -61,7 +61,6 @@ describe('parsers/index', () => {
 			expect(hasOutputParser('copilot-cli')).toBe(true);
 		});
 
-<<<<<<< HEAD
 		it('should register Pi parser', () => {
 			expect(hasOutputParser('pi')).toBe(false);
 
@@ -94,36 +93,29 @@ describe('parsers/index', () => {
 			expect(hasOutputParser('grok')).toBe(true);
 		});
 
-		it('should register exactly 9 parsers', () => {
+		it('should register Antigravity parser', () => {
+			expect(hasOutputParser('antigravity')).toBe(false);
+
+			initializeOutputParsers();
+
+			expect(hasOutputParser('antigravity')).toBe(true);
+		});
+
+		it('should register exactly 10 parsers', () => {
 			initializeOutputParsers();
 
 			const parsers = getAllOutputParsers();
-			expect(parsers.length).toBe(9);
-=======
-		it('should register exactly 6 parsers', () => {
-			initializeOutputParsers();
-
-			const parsers = getAllOutputParsers();
-			expect(parsers.length).toBe(6); // Claude, OpenCode, Codex, Factory Droid, Copilot, Antigravity
->>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
+			expect(parsers.length).toBe(10);
 		});
 
 		it('should clear existing parsers before registering', () => {
 			// First initialization
 			initializeOutputParsers();
-<<<<<<< HEAD
-			expect(getAllOutputParsers().length).toBe(9);
+			expect(getAllOutputParsers().length).toBe(10);
 
-			// Second initialization should still have exactly 9
+			// Second initialization should still have exactly 10
 			initializeOutputParsers();
-			expect(getAllOutputParsers().length).toBe(9);
-=======
-			expect(getAllOutputParsers().length).toBe(6);
-
-			// Second initialization should still have exactly 6
-			initializeOutputParsers();
-			expect(getAllOutputParsers().length).toBe(6);
->>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
+			expect(getAllOutputParsers().length).toBe(10);
 		});
 	});
 

--- a/src/__tests__/main/parsers/index.test.ts
+++ b/src/__tests__/main/parsers/index.test.ts
@@ -61,6 +61,7 @@ describe('parsers/index', () => {
 			expect(hasOutputParser('copilot-cli')).toBe(true);
 		});
 
+<<<<<<< HEAD
 		it('should register Pi parser', () => {
 			expect(hasOutputParser('pi')).toBe(false);
 
@@ -98,16 +99,31 @@ describe('parsers/index', () => {
 
 			const parsers = getAllOutputParsers();
 			expect(parsers.length).toBe(9);
+=======
+		it('should register exactly 6 parsers', () => {
+			initializeOutputParsers();
+
+			const parsers = getAllOutputParsers();
+			expect(parsers.length).toBe(6); // Claude, OpenCode, Codex, Factory Droid, Copilot, Antigravity
+>>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 		});
 
 		it('should clear existing parsers before registering', () => {
 			// First initialization
 			initializeOutputParsers();
+<<<<<<< HEAD
 			expect(getAllOutputParsers().length).toBe(9);
 
 			// Second initialization should still have exactly 9
 			initializeOutputParsers();
 			expect(getAllOutputParsers().length).toBe(9);
+=======
+			expect(getAllOutputParsers().length).toBe(6);
+
+			// Second initialization should still have exactly 6
+			initializeOutputParsers();
+			expect(getAllOutputParsers().length).toBe(6);
+>>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 		});
 	});
 

--- a/src/__tests__/main/parsers/index.test.ts
+++ b/src/__tests__/main/parsers/index.test.ts
@@ -57,21 +57,21 @@ describe('parsers/index', () => {
 			expect(hasOutputParser('copilot-cli')).toBe(true);
 		});
 
-		it('should register exactly 5 parsers', () => {
+		it('should register exactly 6 parsers', () => {
 			initializeOutputParsers();
 
 			const parsers = getAllOutputParsers();
-			expect(parsers.length).toBe(5); // Claude, OpenCode, Codex, Factory Droid, Copilot
+			expect(parsers.length).toBe(6); // Claude, OpenCode, Codex, Factory Droid, Copilot, Antigravity
 		});
 
 		it('should clear existing parsers before registering', () => {
 			// First initialization
 			initializeOutputParsers();
-			expect(getAllOutputParsers().length).toBe(5);
+			expect(getAllOutputParsers().length).toBe(6);
 
-			// Second initialization should still have exactly 5
+			// Second initialization should still have exactly 6
 			initializeOutputParsers();
-			expect(getAllOutputParsers().length).toBe(5);
+			expect(getAllOutputParsers().length).toBe(6);
 		});
 	});
 

--- a/src/__tests__/main/process-manager/handlers/ExitHandler.test.ts
+++ b/src/__tests__/main/process-manager/handlers/ExitHandler.test.ts
@@ -188,6 +188,93 @@ describe('ExitHandler', () => {
 			expect(dataEvents).toContain('Auth Bug Fix');
 		});
 
+		it('emits an error, not data, when the trailing envelope reports a failure', async () => {
+			// A CLI that reports its failure in-band and then exits 0 used to settle
+			// the turn with nothing at all: isResultMessage rejects the error event,
+			// and detectErrorFromExit returns null on exit code 0.
+			const errorJson = '{"event":"result","result":{"error":"quota exhausted"}}';
+			const raw = JSON.parse(errorJson);
+			const agentError = {
+				type: 'rate_limited',
+				message: 'quota exhausted',
+				recoverable: true,
+				agentId: 'antigravity',
+				timestamp: 0,
+			};
+			const mockParser = createMockOutputParser({
+				parseJsonLine: vi.fn(() => ({
+					type: 'error',
+					text: 'quota exhausted',
+					raw,
+				})) as unknown as AgentOutputParser['parseJsonLine'],
+				isResultMessage: vi.fn(() => false) as unknown as AgentOutputParser['isResultMessage'],
+				detectErrorFromParsed: vi.fn(
+					() => agentError
+				) as unknown as AgentOutputParser['detectErrorFromParsed'],
+			});
+
+			const proc = createMockProcess({
+				isStreamJsonMode: true,
+				isBatchMode: true,
+				jsonBuffer: errorJson,
+				outputParser: mockParser,
+			});
+			processes.set('test-session', proc);
+
+			const dataEvents: string[] = [];
+			const errorEvents: unknown[] = [];
+			emitter.on('data', (_sid: string, data: string) => dataEvents.push(data));
+			emitter.on('agent-error', (_sid: string, err: unknown) => errorEvents.push(err));
+
+			await exitHandler.handleExit('test-session', 0);
+
+			expect(mockParser.detectErrorFromParsed).toHaveBeenCalledWith(raw);
+			expect(errorEvents).toHaveLength(1);
+			expect(errorEvents[0]).toMatchObject({
+				type: 'rate_limited',
+				sessionId: 'test-session',
+			});
+			// The failure text must never reach the user as the agent's answer.
+			expect(dataEvents).not.toContain('quota exhausted');
+			expect(proc.errorEmitted).toBe(true);
+		});
+
+		it('does not double-report a trailing error already emitted from stdout', async () => {
+			const errorJson = '{"event":"result","result":{"error":"quota exhausted"}}';
+			const mockParser = createMockOutputParser({
+				parseJsonLine: vi.fn(() => ({
+					type: 'error',
+					text: 'quota exhausted',
+					raw: JSON.parse(errorJson),
+				})) as unknown as AgentOutputParser['parseJsonLine'],
+				isResultMessage: vi.fn(() => false) as unknown as AgentOutputParser['isResultMessage'],
+				detectErrorFromParsed: vi.fn(() => ({
+					type: 'rate_limited',
+					message: 'quota exhausted',
+					recoverable: true,
+					agentId: 'antigravity',
+					timestamp: 0,
+				})) as unknown as AgentOutputParser['detectErrorFromParsed'],
+			});
+
+			const proc = createMockProcess({
+				isStreamJsonMode: true,
+				isBatchMode: true,
+				jsonBuffer: errorJson,
+				outputParser: mockParser,
+			});
+			proc.errorEmitted = true;
+			processes.set('test-session', proc);
+
+			const errorEvents: unknown[] = [];
+			emitter.on('agent-error', (_sid: string, err: unknown) => errorEvents.push(err));
+
+			await exitHandler.handleExit('test-session', 0);
+
+			expect(mockParser.detectErrorFromParsed).not.toHaveBeenCalled();
+			expect(errorEvents).toHaveLength(0);
+		});
+
 		it('should not process jsonBuffer if already empty', async () => {
 			const mockParser = createMockOutputParser();
 

--- a/src/__tests__/main/process-manager/handlers/ExitHandler.test.ts
+++ b/src/__tests__/main/process-manager/handlers/ExitHandler.test.ts
@@ -239,6 +239,66 @@ describe('ExitHandler', () => {
 			expect(proc.errorEmitted).toBe(true);
 		});
 
+		it('does not leak the raw envelope as data when classification throws', async () => {
+			// The catch around this flush exists for ONE expected condition - a
+			// malformed last line - and its fallback is to emit that line raw. If it
+			// also wrapped classification, a defect in detectErrorFromParsed would be
+			// swallowed and the failed envelope's JSON would be printed to the user as
+			// though it were the agent's answer.
+			const errorJson = '{"event":"result","result":{"error":"quota exhausted"}}';
+			const boom = new Error('classifier blew up');
+			const mockParser = createMockOutputParser({
+				parseJsonLine: vi.fn(() => ({
+					type: 'error',
+					text: 'quota exhausted',
+					raw: JSON.parse(errorJson),
+				})) as unknown as AgentOutputParser['parseJsonLine'],
+				isResultMessage: vi.fn(() => false) as unknown as AgentOutputParser['isResultMessage'],
+				detectErrorFromParsed: vi.fn(() => {
+					throw boom;
+				}) as unknown as AgentOutputParser['detectErrorFromParsed'],
+			});
+
+			const proc = createMockProcess({
+				isStreamJsonMode: true,
+				isBatchMode: true,
+				jsonBuffer: errorJson,
+				outputParser: mockParser,
+			});
+			processes.set('test-session', proc);
+
+			const dataEvents: string[] = [];
+			emitter.on('data', (_sid: string, data: string) => dataEvents.push(data));
+
+			await expect(exitHandler.handleExit('test-session', 0)).rejects.toThrow('classifier blew up');
+
+			expect(dataEvents).not.toContain(errorJson);
+		});
+
+		it('still emits a malformed trailing line as raw data', async () => {
+			const malformed = '{"event":"result","result":{ truncated';
+			const mockParser = createMockOutputParser({
+				parseJsonLine: vi.fn(() => {
+					throw new SyntaxError('Unexpected end of JSON input');
+				}) as unknown as AgentOutputParser['parseJsonLine'],
+			});
+
+			const proc = createMockProcess({
+				isStreamJsonMode: true,
+				isBatchMode: true,
+				jsonBuffer: malformed,
+				outputParser: mockParser,
+			});
+			processes.set('test-session', proc);
+
+			const dataEvents: string[] = [];
+			emitter.on('data', (_sid: string, data: string) => dataEvents.push(data));
+
+			await exitHandler.handleExit('test-session', 0);
+
+			expect(dataEvents).toContain(malformed);
+		});
+
 		it('does not double-report a trailing error already emitted from stdout', async () => {
 			const errorJson = '{"event":"result","result":{"error":"quota exhausted"}}';
 			const mockParser = createMockOutputParser({

--- a/src/__tests__/main/process-manager/handlers/ExitHandler.test.ts
+++ b/src/__tests__/main/process-manager/handlers/ExitHandler.test.ts
@@ -239,6 +239,123 @@ describe('ExitHandler', () => {
 			expect(proc.errorEmitted).toBe(true);
 		});
 
+		it('captures the provider session id from a failed trailing envelope', async () => {
+			// When the flushed line is the only event of the run, this is the sole
+			// chance to record the id. Losing it means a retry of a RECOVERABLE error
+			// starts a fresh conversation instead of resuming the failed one.
+			const errorJson =
+				'{"event":"result","result":{"conversation_id":"conv-42","error":"quota exhausted"}}';
+			const mockParser = createMockOutputParser({
+				parseJsonLine: vi.fn(() => ({
+					type: 'error',
+					text: 'quota exhausted',
+					raw: JSON.parse(errorJson),
+				})) as unknown as AgentOutputParser['parseJsonLine'],
+				isResultMessage: vi.fn(() => false) as unknown as AgentOutputParser['isResultMessage'],
+				extractSessionId: vi.fn(
+					() => 'conv-42'
+				) as unknown as AgentOutputParser['extractSessionId'],
+				detectErrorFromParsed: vi.fn(() => ({
+					type: 'rate_limited',
+					message: 'quota exhausted',
+					recoverable: true,
+					agentId: 'antigravity',
+					timestamp: 0,
+				})) as unknown as AgentOutputParser['detectErrorFromParsed'],
+			});
+
+			const proc = createMockProcess({
+				isStreamJsonMode: true,
+				isBatchMode: true,
+				jsonBuffer: errorJson,
+				outputParser: mockParser,
+			});
+			processes.set('test-session', proc);
+
+			const sessionIdEvents: string[] = [];
+			emitter.on('session-id', (_sid: string, agentSessionId: string) =>
+				sessionIdEvents.push(agentSessionId)
+			);
+
+			await exitHandler.handleExit('test-session', 0);
+
+			expect(sessionIdEvents).toEqual(['conv-42']);
+			expect(proc.agentSessionId).toBe('conv-42');
+		});
+
+		it('captures the provider session id from a successful trailing envelope', async () => {
+			const resultJson = '{"event":"result","result":{"conversation_id":"conv-7","response":"hi"}}';
+			const mockParser = createMockOutputParser({
+				parseJsonLine: vi.fn(() => ({
+					type: 'result',
+					text: 'hi',
+					raw: JSON.parse(resultJson),
+				})) as unknown as AgentOutputParser['parseJsonLine'],
+				isResultMessage: vi.fn(() => true) as unknown as AgentOutputParser['isResultMessage'],
+				extractSessionId: vi.fn(() => 'conv-7') as unknown as AgentOutputParser['extractSessionId'],
+			});
+
+			const proc = createMockProcess({
+				isStreamJsonMode: true,
+				isBatchMode: true,
+				jsonBuffer: resultJson,
+				outputParser: mockParser,
+			});
+			processes.set('test-session', proc);
+
+			const sessionIdEvents: string[] = [];
+			emitter.on('session-id', (_sid: string, agentSessionId: string) =>
+				sessionIdEvents.push(agentSessionId)
+			);
+
+			await exitHandler.handleExit('test-session', 0);
+
+			expect(sessionIdEvents).toEqual(['conv-7']);
+		});
+
+		it('does not re-emit a session id already reported mid-stream', async () => {
+			const errorJson =
+				'{"event":"result","result":{"conversation_id":"conv-42","error":"quota exhausted"}}';
+			const mockParser = createMockOutputParser({
+				parseJsonLine: vi.fn(() => ({
+					type: 'error',
+					text: 'quota exhausted',
+					raw: JSON.parse(errorJson),
+				})) as unknown as AgentOutputParser['parseJsonLine'],
+				isResultMessage: vi.fn(() => false) as unknown as AgentOutputParser['isResultMessage'],
+				extractSessionId: vi.fn(
+					() => 'conv-42'
+				) as unknown as AgentOutputParser['extractSessionId'],
+				detectErrorFromParsed: vi.fn(() => ({
+					type: 'rate_limited',
+					message: 'quota exhausted',
+					recoverable: true,
+					agentId: 'antigravity',
+					timestamp: 0,
+				})) as unknown as AgentOutputParser['detectErrorFromParsed'],
+			});
+
+			const proc = createMockProcess({
+				isStreamJsonMode: true,
+				isBatchMode: true,
+				jsonBuffer: errorJson,
+				outputParser: mockParser,
+			});
+			proc.sessionIdEmitted = true;
+			processes.set('test-session', proc);
+
+			const sessionIdEvents: string[] = [];
+			emitter.on('session-id', (_sid: string, agentSessionId: string) =>
+				sessionIdEvents.push(agentSessionId)
+			);
+
+			await exitHandler.handleExit('test-session', 0);
+
+			expect(sessionIdEvents).toEqual([]);
+			// Still recorded on the process, matching emitSessionIdIfNeeded.
+			expect(proc.agentSessionId).toBe('conv-42');
+		});
+
 		it('does not leak the raw envelope as data when classification throws', async () => {
 			// The catch around this flush exists for ONE expected condition - a
 			// malformed last line - and its fallback is to emit that line raw. If it

--- a/src/__tests__/main/utils/agent-args.test.ts
+++ b/src/__tests__/main/utils/agent-args.test.ts
@@ -12,11 +12,7 @@ import {
 } from '../../../main/utils/agent-args';
 import { AGENT_DEFINITIONS } from '../../../main/agents/definitions';
 import type { AgentConfig } from '../../../main/agents';
-<<<<<<< HEAD
 import { getAgentDefinition } from '../../../main/agents/definitions';
-=======
-import { AGENT_DEFINITIONS } from '../../../main/agents';
->>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 
 vi.mock('../../../main/utils/logger', () => ({
 	logger: {
@@ -1464,7 +1460,6 @@ describe('getContextWindowValue', () => {
 });
 
 // ---------------------------------------------------------------------------
-<<<<<<< HEAD
 // Additional Directories -> native provider grant flags
 // ---------------------------------------------------------------------------
 describe('buildAgentArgs: additionalDirectories', () => {
@@ -1518,13 +1513,16 @@ describe('buildAgentArgs: additionalDirectories', () => {
 
 		expect(args).toEqual(['--print', '--add-dir', '/shared/src']);
 		expect(args[args.length - 1]).not.toMatch(/^-/);
-=======
+	});
+});
+
+// ---------------------------------------------------------------------------
 // Antigravity CLI (`agy`) - real definition wiring
 // ---------------------------------------------------------------------------
 describe('buildAgentArgs with the Antigravity definition', () => {
 	const antigravity = () =>
 		({
-			...AGENT_DEFINITIONS.find((d) => d.id === 'antigravity'),
+			...getAgentDefinition('antigravity'),
 			available: true,
 			capabilities: {} as AgentConfig['capabilities'],
 		}) as AgentConfig;
@@ -1576,6 +1574,5 @@ describe('buildAgentArgs with the Antigravity definition', () => {
 			'--print-timeout',
 			'30m',
 		]);
->>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 	});
 });

--- a/src/__tests__/main/utils/agent-args.test.ts
+++ b/src/__tests__/main/utils/agent-args.test.ts
@@ -12,7 +12,11 @@ import {
 } from '../../../main/utils/agent-args';
 import { AGENT_DEFINITIONS } from '../../../main/agents/definitions';
 import type { AgentConfig } from '../../../main/agents';
+<<<<<<< HEAD
 import { getAgentDefinition } from '../../../main/agents/definitions';
+=======
+import { AGENT_DEFINITIONS } from '../../../main/agents';
+>>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 
 vi.mock('../../../main/utils/logger', () => ({
 	logger: {
@@ -1460,6 +1464,7 @@ describe('getContextWindowValue', () => {
 });
 
 // ---------------------------------------------------------------------------
+<<<<<<< HEAD
 // Additional Directories -> native provider grant flags
 // ---------------------------------------------------------------------------
 describe('buildAgentArgs: additionalDirectories', () => {
@@ -1513,5 +1518,64 @@ describe('buildAgentArgs: additionalDirectories', () => {
 
 		expect(args).toEqual(['--print', '--add-dir', '/shared/src']);
 		expect(args[args.length - 1]).not.toMatch(/^-/);
+=======
+// Antigravity CLI (`agy`) - real definition wiring
+// ---------------------------------------------------------------------------
+describe('buildAgentArgs with the Antigravity definition', () => {
+	const antigravity = () =>
+		({
+			...AGENT_DEFINITIONS.find((d) => d.id === 'antigravity'),
+			available: true,
+			capabilities: {} as AgentConfig['capabilities'],
+		}) as AgentConfig;
+
+	it('composes a headless run that auto-approves tools and streams JSON', () => {
+		const result = buildAgentArgs(antigravity(), { baseArgs: [], prompt: 'hi' });
+
+		expect(result).toEqual(['--dangerously-skip-permissions', '--output-format', 'stream-json']);
+	});
+
+	it('resumes a specific conversation by id', () => {
+		const result = buildAgentArgs(antigravity(), {
+			baseArgs: [],
+			prompt: 'follow up',
+			agentSessionId: '055a398f-db14-4c5f-abbb-1bf03f8120a7',
+		});
+
+		expect(result).toContain('--conversation');
+		expect(result).toContain('055a398f-db14-4c5f-abbb-1bf03f8120a7');
+	});
+
+	it('drops the permission-skip flag in read-only mode and sandboxes the terminal instead', () => {
+		const result = buildAgentArgs(antigravity(), {
+			baseArgs: [],
+			prompt: 'read only please',
+			readOnlyMode: true,
+		});
+
+		expect(result).not.toContain('--dangerously-skip-permissions');
+		expect(result).toContain('--sandbox');
+	});
+
+	it('raises the headless timeout past the 5m CLI default without any user config', () => {
+		const { args } = applyAgentConfigOverrides(antigravity(), [], {});
+
+		expect(args).toEqual(['--print-timeout', '30m']);
+	});
+
+	it('adds model and effort flags only once the user sets them', () => {
+		const { args } = applyAgentConfigOverrides(antigravity(), [], {
+			agentConfigValues: { model: 'gemini-3.6-flash-high', effort: 'high' },
+		});
+
+		expect(args).toEqual([
+			'--model',
+			'gemini-3.6-flash-high',
+			'--effort',
+			'high',
+			'--print-timeout',
+			'30m',
+		]);
+>>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 	});
 });

--- a/src/__tests__/main/utils/agent-args.test.ts
+++ b/src/__tests__/main/utils/agent-args.test.ts
@@ -11,6 +11,7 @@ import {
 	getContextWindowValue,
 } from '../../../main/utils/agent-args';
 import type { AgentConfig } from '../../../main/agents';
+import { AGENT_DEFINITIONS } from '../../../main/agents';
 
 vi.mock('../../../main/utils/logger', () => ({
 	logger: {
@@ -950,5 +951,66 @@ describe('getContextWindowValue', () => {
 
 		const result = getContextWindowValue(agent, { contextWindow: 50000 }, undefined);
 		expect(result).toBe(50000);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Antigravity CLI (`agy`) - real definition wiring
+// ---------------------------------------------------------------------------
+describe('buildAgentArgs with the Antigravity definition', () => {
+	const antigravity = () =>
+		({
+			...AGENT_DEFINITIONS.find((d) => d.id === 'antigravity'),
+			available: true,
+			capabilities: {} as AgentConfig['capabilities'],
+		}) as AgentConfig;
+
+	it('composes a headless run that auto-approves tools and streams JSON', () => {
+		const result = buildAgentArgs(antigravity(), { baseArgs: [], prompt: 'hi' });
+
+		expect(result).toEqual(['--dangerously-skip-permissions', '--output-format', 'stream-json']);
+	});
+
+	it('resumes a specific conversation by id', () => {
+		const result = buildAgentArgs(antigravity(), {
+			baseArgs: [],
+			prompt: 'follow up',
+			agentSessionId: '055a398f-db14-4c5f-abbb-1bf03f8120a7',
+		});
+
+		expect(result).toContain('--conversation');
+		expect(result).toContain('055a398f-db14-4c5f-abbb-1bf03f8120a7');
+	});
+
+	it('drops the permission-skip flag in read-only mode and sandboxes the terminal instead', () => {
+		const result = buildAgentArgs(antigravity(), {
+			baseArgs: [],
+			prompt: 'read only please',
+			readOnlyMode: true,
+		});
+
+		expect(result).not.toContain('--dangerously-skip-permissions');
+		expect(result).toContain('--sandbox');
+	});
+
+	it('raises the headless timeout past the 5m CLI default without any user config', () => {
+		const { args } = applyAgentConfigOverrides(antigravity(), [], {});
+
+		expect(args).toEqual(['--print-timeout', '30m']);
+	});
+
+	it('adds model and effort flags only once the user sets them', () => {
+		const { args } = applyAgentConfigOverrides(antigravity(), [], {
+			agentConfigValues: { model: 'gemini-3.6-flash-high', effort: 'high' },
+		});
+
+		expect(args).toEqual([
+			'--model',
+			'gemini-3.6-flash-high',
+			'--effort',
+			'high',
+			'--print-timeout',
+			'30m',
+		]);
 	});
 });

--- a/src/__tests__/renderer/components/Wizard/WizardIntegration.test.tsx
+++ b/src/__tests__/renderer/components/Wizard/WizardIntegration.test.tsx
@@ -62,6 +62,9 @@ vi.mock('lucide-react', () => ({
 	ChevronDown: ({ className, style }: { className?: string; style?: React.CSSProperties }) => (
 		<svg data-testid="chevron-down-icon" className={className} style={style} />
 	),
+	ChevronLeft: ({ className, style }: { className?: string; style?: React.CSSProperties }) => (
+		<svg data-testid="chevron-left-icon" className={className} style={style} />
+	),
 	ChevronRight: ({ className, style }: { className?: string; style?: React.CSSProperties }) => (
 		<svg data-testid="chevron-right-icon" className={className} style={style} />
 	),

--- a/src/__tests__/renderer/components/Wizard/WizardKeyboardNavigation.test.tsx
+++ b/src/__tests__/renderer/components/Wizard/WizardKeyboardNavigation.test.tsx
@@ -52,6 +52,9 @@ vi.mock('lucide-react', () => ({
 	ChevronDown: ({ className, style }: { className?: string; style?: React.CSSProperties }) => (
 		<svg data-testid="chevron-down-icon" className={className} style={style} />
 	),
+	ChevronLeft: ({ className, style }: { className?: string; style?: React.CSSProperties }) => (
+		<svg data-testid="chevron-left-icon" className={className} style={style} />
+	),
 	ChevronRight: ({ className, style }: { className?: string; style?: React.CSSProperties }) => (
 		<svg data-testid="chevron-right-icon" className={className} style={style} />
 	),

--- a/src/__tests__/renderer/components/Wizard/WizardThemeStyles.test.tsx
+++ b/src/__tests__/renderer/components/Wizard/WizardThemeStyles.test.tsx
@@ -54,6 +54,9 @@ vi.mock('lucide-react', () => ({
 	ChevronDown: ({ className, style }: { className?: string; style?: React.CSSProperties }) => (
 		<svg data-testid="chevron-down-icon" className={className} style={style} />
 	),
+	ChevronLeft: ({ className, style }: { className?: string; style?: React.CSSProperties }) => (
+		<svg data-testid="chevron-left-icon" className={className} style={style} />
+	),
 	ChevronRight: ({ className, style }: { className?: string; style?: React.CSSProperties }) => (
 		<svg data-testid="chevron-right-icon" className={className} style={style} />
 	),

--- a/src/__tests__/renderer/components/Wizard/screens/AgentSelectionScreen/components.test.tsx
+++ b/src/__tests__/renderer/components/Wizard/screens/AgentSelectionScreen/components.test.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../../../../../renderer/components/Wizard/screens/AgentSelectionScreen/components';
 import { AGENT_TILES } from '../../../../../../renderer/components/Wizard/screens/AgentSelectionScreen';
 import { PICKABLE_AGENT_IDS } from '../../../../../../shared/agentMetadata';
+import { AGENT_LOGO_FALLBACK_TESTID } from '../../../../../../renderer/components/Wizard/screens/AgentSelectionScreen/components/AgentLogo';
 
 vi.mock('../../../../../../renderer/components/shared/AgentConfigPanel', () => ({
 	AgentConfigPanel: (props: any) => (
@@ -55,15 +56,29 @@ describe('AgentSelectionScreen components', () => {
 	});
 
 	it('draws a real mark for every provider a user can pick', () => {
-		// The fallback is an empty circle. A provider that reaches a picker without
-		// a mark of its own renders as that blank ring, which reads as a bug.
+		// A provider that reaches a picker without a mark of its own renders as the
+		// blank fallback ring, which reads as a bug. Assert on the fallback's own
+		// marker rather than "some svg rendered": the fallback is a div today, but
+		// were it ever redrawn as an svg, a presence check would start passing for
+		// exactly the providers this test exists to catch.
 		for (const agentId of PICKABLE_AGENT_IDS) {
-			const { container, unmount } = render(
+			const { queryByTestId, unmount } = render(
 				<AgentLogo agentId={agentId} supported detected theme={mockTheme} />
 			);
-			expect(container.querySelector('svg'), `${agentId} has no logo`).toBeInTheDocument();
+			expect(
+				queryByTestId(AGENT_LOGO_FALLBACK_TESTID),
+				`${agentId} has no logo of its own and fell through to the fallback`
+			).toBeNull();
 			unmount();
 		}
+	});
+
+	it('marks the fallback so the coverage test above cannot pass vacuously', () => {
+		const { queryByTestId } = render(
+			<AgentLogo agentId="not-a-real-provider" supported detected theme={mockTheme} />
+		);
+
+		expect(queryByTestId(AGENT_LOGO_FALLBACK_TESTID)).toBeInTheDocument();
 	});
 
 	it('renders tile states, beta badges, disabled unavailable agents, and customize actions', () => {

--- a/src/__tests__/renderer/components/Wizard/screens/AgentSelectionScreen/components.test.tsx
+++ b/src/__tests__/renderer/components/Wizard/screens/AgentSelectionScreen/components.test.tsx
@@ -14,6 +14,7 @@ import {
 	SshConnectionErrorPanel,
 } from '../../../../../../renderer/components/Wizard/screens/AgentSelectionScreen/components';
 import { AGENT_TILES } from '../../../../../../renderer/components/Wizard/screens/AgentSelectionScreen';
+import { PICKABLE_AGENT_IDS } from '../../../../../../shared/agentMetadata';
 
 vi.mock('../../../../../../renderer/components/shared/AgentConfigPanel', () => ({
 	AgentConfigPanel: (props: any) => (
@@ -51,6 +52,18 @@ describe('AgentSelectionScreen components', () => {
 		rerender(<AgentLogo agentId="unknown" supported={false} detected={false} theme={mockTheme} />);
 
 		expect(container.querySelector('div')).toHaveClass('rounded-full');
+	});
+
+	it('draws a real mark for every provider a user can pick', () => {
+		// The fallback is an empty circle. A provider that reaches a picker without
+		// a mark of its own renders as that blank ring, which reads as a bug.
+		for (const agentId of PICKABLE_AGENT_IDS) {
+			const { container, unmount } = render(
+				<AgentLogo agentId={agentId} supported detected theme={mockTheme} />
+			);
+			expect(container.querySelector('svg'), `${agentId} has no logo`).toBeInTheDocument();
+			unmount();
+		}
 	});
 
 	it('renders tile states, beta badges, disabled unavailable agents, and customize actions', () => {

--- a/src/__tests__/renderer/components/Wizard/screens/AgentSelectionScreen/utils.test.ts
+++ b/src/__tests__/renderer/components/Wizard/screens/AgentSelectionScreen/utils.test.ts
@@ -22,12 +22,9 @@ import {
 	AGENT_TILES,
 	type AgentTile,
 } from '../../../../../../renderer/components/Wizard/screens/AgentSelectionScreen';
-import {
-	getAgentTileColSpanClass,
-	getNextAgentTileIndex,
-	LAST_ROW_COL_START_CLASS,
-	LAST_ROW_START_INDEX,
-} from '../../../../../../renderer/components/Wizard/screens/AgentSelectionScreen/utils/agentGrid';
+import { PICKABLE_AGENT_IDS } from '../../../../../../shared/agentMetadata';
+import { SUPPORTED_AGENTS } from '../../../../../../renderer/components/NewInstanceModal/types';
+import { getNextAgentTileIndex } from '../../../../../../renderer/components/Wizard/screens/AgentSelectionScreen/utils/agentGrid';
 import {
 	getInitialSshRemoteConfig,
 	getSshRemoteIdForDetection,
@@ -106,15 +103,26 @@ describe('AgentSelectionScreen utils', () => {
 		).toBe('Agent detection complete on remote host. 2 of 3 agents available.');
 	});
 
-	it('computes grid movement boundaries and last-row centering classes', () => {
-		// Grid is GRID_COLS (4) wide: ArrowDown moves +4, ArrowUp moves -4.
+	it('steps along the single-row strip and clamps at both ends', () => {
 		expect(getNextAgentTileIndex(0, 'ArrowLeft')).toBe(0);
 		expect(getNextAgentTileIndex(0, 'ArrowRight')).toBe(1);
-		expect(getNextAgentTileIndex(0, 'ArrowDown')).toBe(4);
-		expect(getNextAgentTileIndex(4, 'ArrowDown')).toBe(4);
-		expect(getNextAgentTileIndex(4, 'ArrowUp')).toBe(0);
-		expect(getAgentTileColSpanClass(0)).toBe('col-span-2');
-		expect(getAgentTileColSpanClass(LAST_ROW_START_INDEX)).toContain(LAST_ROW_COL_START_CLASS);
+		expect(getNextAgentTileIndex(1, 'ArrowLeft')).toBe(0);
+		expect(getNextAgentTileIndex(AGENT_TILES.length - 1, 'ArrowRight')).toBe(
+			AGENT_TILES.length - 1
+		);
+		// The strip is one row, so vertical movement has nowhere to go.
+		expect(getNextAgentTileIndex(0, 'ArrowDown')).toBe(0);
+		expect(getNextAgentTileIndex(1, 'ArrowUp')).toBe(1);
+	});
+
+	it('offers every pickable provider, in the shared registry order', () => {
+		expect(AGENT_TILES.map((tile) => tile.id)).toEqual([...PICKABLE_AGENT_IDS]);
+		expect(AGENT_TILES.every((tile) => tile.supported)).toBe(true);
+		// Regression: Grok and Qwen3 Coder were selectable in the New Agent modal
+		// yet absent from the wizard and un-pickable as a group chat moderator.
+		expect(AGENT_TILES.map((tile) => tile.id)).toEqual(
+			expect.arrayContaining([...SUPPORTED_AGENTS])
+		);
 	});
 
 	it('normalizes wizard config fields and env var edits', () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -804,7 +804,7 @@ program
 	.requiredOption('-d, --cwd <path>', 'Working directory for the agent')
 	.option(
 		'-t, --type <type>',
-		'Agent type (claude-code, codex, opencode, factory-droid, copilot-cli, gemini-cli, qwen3-coder)',
+		'Agent type (claude-code, codex, opencode, factory-droid, copilot-cli, antigravity, gemini-cli, qwen3-coder)',
 		'claude-code'
 	)
 	.option('-g, --group <id>', 'Group ID to assign the agent to')

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -533,7 +533,7 @@ program
 	.requiredOption('-d, --cwd <path>', 'Working directory for the agent')
 	.option(
 		'-t, --type <type>',
-		'Agent type (claude-code, codex, opencode, factory-droid, copilot-cli, gemini-cli, qwen3-coder)',
+		'Agent type (claude-code, codex, opencode, factory-droid, copilot-cli, antigravity, gemini-cli, qwen3-coder)',
 		'claude-code'
 	)
 	.option('-g, --group <id>', 'Group ID to assign the agent to')

--- a/src/main/agents/capabilities.ts
+++ b/src/main/agents/capabilities.ts
@@ -175,9 +175,6 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 	},
 
 	/**
-<<<<<<< HEAD
-	 * Qwen3 Coder - Alibaba's Qwen coding agent (Qwen Code CLI)
-=======
 	 * Antigravity CLI (`agy`) - Google's terminal coding agent, the CLI surface of
 	 * Antigravity and the successor to the Gemini CLI effort above.
 	 *
@@ -212,11 +209,12 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 		usesCombinedContextWindow: false, // Gemini reports input and output separately
 		supportsAppendSystemPrompt: false,
 		supportsProjectMemory: false,
+		supportsPromptViaStdin: false, // Docs give the prompt as `-p "<text>"`; stdin delivery is unstated
+		supportsAdditionalDirectories: false, // No documented flag for extra workspace roots
 	},
 
 	/**
-	 * Qwen3 Coder - Alibaba's Qwen coding model
->>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
+	 * Qwen3 Coder - Alibaba's Qwen coding agent (Qwen Code CLI)
 	 *
 	 * Qwen Code is a Gemini CLI fork that exposes the same stream-json headless
 	 * interface. Capabilities mirror the Gemini/Claude stream-json integration.

--- a/src/main/agents/capabilities.ts
+++ b/src/main/agents/capabilities.ts
@@ -175,7 +175,48 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 	},
 
 	/**
+<<<<<<< HEAD
 	 * Qwen3 Coder - Alibaba's Qwen coding agent (Qwen Code CLI)
+=======
+	 * Antigravity CLI (`agy`) - Google's terminal coding agent, the CLI surface of
+	 * Antigravity and the successor to the Gemini CLI effort above.
+	 *
+	 * Capabilities below are derived from the published headless-mode contract
+	 * (https://antigravity.google/docs/cli/headless) rather than from a live run,
+	 * so the agent ships as beta. Anything the docs do not state outright is left
+	 * false rather than guessed at.
+	 */
+	antigravity: {
+		supportsResume: true, // --conversation <id>
+		supportsReadOnlyMode: false, // No flag makes it read-only; workspace writes stay auto-allowed
+		supportsJsonOutput: true, // --output-format stream-json
+		supportsSessionId: true, // conversation_id on init/step_update/result
+		supportsImageInput: false, // No documented attachment flag
+		supportsImageInputOnResume: false,
+		supportsSlashCommands: false, // Slash commands are TUI-only, not exposed to headless runs
+		supportsSessionStorage: false, // On-disk conversation format is undocumented
+		supportsCostTracking: false, // usage reports tokens only, no cost
+		supportsUsageStats: true, // usage: input/output/thinking/cache_read/total tokens
+		supportsBatchMode: true, // -p / --print / --prompt
+		requiresPromptToStart: true, // Headless runs require -p; there is no idle non-interactive mode
+		supportsStreaming: true, // stream-json emits step_update deltas
+		supportsResultMessages: true, // Terminal `result` event
+		supportsModelSelection: true, // --model <slug>
+		supportsStreamJsonInput: false, // No stdin stream-json input format
+		supportsThinkingDisplay: false, // thinking_tokens are counted, but no reasoning text step type is documented
+		supportsContextMerge: true, // Context can be delivered through the prompt
+		supportsContextExport: false, // Requires session storage
+		supportsWizard: false, // Structured-output wizard flow unverified against a live CLI
+		supportsGroupChatModeration: false, // Unverified
+		usesJsonLineOutput: true, // stream-json is newline-delimited JSON
+		usesCombinedContextWindow: false, // Gemini reports input and output separately
+		supportsAppendSystemPrompt: false,
+		supportsProjectMemory: false,
+	},
+
+	/**
+	 * Qwen3 Coder - Alibaba's Qwen coding model
+>>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 	 *
 	 * Qwen Code is a Gemini CLI fork that exposes the same stream-json headless
 	 * interface. Capabilities mirror the Gemini/Claude stream-json integration.

--- a/src/main/agents/capabilities.ts
+++ b/src/main/agents/capabilities.ts
@@ -166,6 +166,43 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 	},
 
 	/**
+	 * Antigravity CLI (`agy`) - Google's terminal coding agent, the CLI surface of
+	 * Antigravity and the successor to the Gemini CLI effort above.
+	 *
+	 * Capabilities below are derived from the published headless-mode contract
+	 * (https://antigravity.google/docs/cli/headless) rather than from a live run,
+	 * so the agent ships as beta. Anything the docs do not state outright is left
+	 * false rather than guessed at.
+	 */
+	antigravity: {
+		supportsResume: true, // --conversation <id>
+		supportsReadOnlyMode: false, // No flag makes it read-only; workspace writes stay auto-allowed
+		supportsJsonOutput: true, // --output-format stream-json
+		supportsSessionId: true, // conversation_id on init/step_update/result
+		supportsImageInput: false, // No documented attachment flag
+		supportsImageInputOnResume: false,
+		supportsSlashCommands: false, // Slash commands are TUI-only, not exposed to headless runs
+		supportsSessionStorage: false, // On-disk conversation format is undocumented
+		supportsCostTracking: false, // usage reports tokens only, no cost
+		supportsUsageStats: true, // usage: input/output/thinking/cache_read/total tokens
+		supportsBatchMode: true, // -p / --print / --prompt
+		requiresPromptToStart: true, // Headless runs require -p; there is no idle non-interactive mode
+		supportsStreaming: true, // stream-json emits step_update deltas
+		supportsResultMessages: true, // Terminal `result` event
+		supportsModelSelection: true, // --model <slug>
+		supportsStreamJsonInput: false, // No stdin stream-json input format
+		supportsThinkingDisplay: false, // thinking_tokens are counted, but no reasoning text step type is documented
+		supportsContextMerge: true, // Context can be delivered through the prompt
+		supportsContextExport: false, // Requires session storage
+		supportsWizard: false, // Structured-output wizard flow unverified against a live CLI
+		supportsGroupChatModeration: false, // Unverified
+		usesJsonLineOutput: true, // stream-json is newline-delimited JSON
+		usesCombinedContextWindow: false, // Gemini reports input and output separately
+		supportsAppendSystemPrompt: false,
+		supportsProjectMemory: false,
+	},
+
+	/**
 	 * Qwen3 Coder - Alibaba's Qwen coding model
 	 *
 	 * PLACEHOLDER: Most capabilities set to false until Qwen3 Coder CLI is available

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -391,6 +391,12 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		// writing files inside the active workspace stays auto-allowed in headless
 		// mode. There is no CLI flag that makes the agent truly read-only, hence
 		// readOnlyCliEnforced: false and supportsReadOnlyMode: false.
+		//
+		// Consequence worth knowing: tab naming spawns with readOnlyMode: true and
+		// relies on `noToolsArgs` to keep a task-like first message from turning into
+		// a real agentic run. The CLI exposes no tool-disabling flag, so there is
+		// nothing to put in `noToolsArgs` and a naming run can still touch workspace
+		// files. Wire `noToolsArgs` here the moment such a flag ships.
 		readOnlyArgs: ['--sandbox'],
 		readOnlyCliEnforced: false,
 		yoloModeArgs: ['--dangerously-skip-permissions'],

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -372,6 +372,73 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		],
 	},
 	{
+		id: 'antigravity',
+		name: 'Antigravity CLI',
+		binaryName: 'agy',
+		command: 'agy',
+		args: [],
+		batchModePrefix: [],
+		// Headless mode soft-denies anything that would normally prompt (shell commands
+		// default to "Ask"), so a batch run without this flag stalls out on its first
+		// terminal tool call instead of failing loudly.
+		// https://antigravity.google/docs/cli/headless
+		batchModeArgs: ['--dangerously-skip-permissions'],
+		jsonOutputArgs: ['--output-format', 'stream-json'],
+		// `agy -p "..." --conversation <id>` resumes a specific conversation. The id
+		// comes back as `conversation_id` on every stream-json event.
+		resumeArgs: (sessionId: string) => ['--conversation', sessionId],
+		// Best-effort only: `--sandbox` restricts terminal commands, but reading AND
+		// writing files inside the active workspace stays auto-allowed in headless
+		// mode. There is no CLI flag that makes the agent truly read-only, hence
+		// readOnlyCliEnforced: false and supportsReadOnlyMode: false.
+		readOnlyArgs: ['--sandbox'],
+		readOnlyCliEnforced: false,
+		yoloModeArgs: ['--dangerously-skip-permissions'],
+		// No working-directory flag; the CLI takes its workspace from the spawn cwd
+		// (echoed back as `init.cwd`). No documented image attachment flag either.
+		workingDirArgs: undefined,
+		imageArgs: undefined,
+		modelArgs: (modelId: string) => ['--model', modelId],
+		promptArgs: (prompt: string) => ['-p', prompt],
+		configOptions: [
+			{
+				key: 'model',
+				type: 'text',
+				label: 'Model',
+				description:
+					'Model slug override (e.g., gemini-3.6-flash-high). Leave empty to use the CLI default. Run `agy --help` for the slugs your account can reach.',
+				default: '',
+				argBuilder: (value: string) => (value && value.trim() ? ['--model', value.trim()] : []),
+			},
+			{
+				key: 'effort',
+				type: 'select',
+				label: 'Reasoning Effort',
+				description: 'How much the model should reason before responding.',
+				options: ['', 'low', 'medium', 'high'],
+				default: '',
+				argBuilder: (value: string) => (value && value.trim() ? ['--effort', value.trim()] : []),
+			},
+			{
+				key: 'printTimeout',
+				type: 'text',
+				label: 'Headless Timeout',
+				description:
+					'Maximum time a single headless run may take (Go duration, e.g. 30m, 2h). The CLI default of 5m cuts off longer agent runs.',
+				default: '30m',
+				argBuilder: (value: string) =>
+					value && value.trim() ? ['--print-timeout', value.trim()] : [],
+			},
+			{
+				key: 'contextWindow',
+				type: 'number',
+				label: 'Context Window Size',
+				description: 'Maximum context window size in tokens. Gemini 3.x models expose a 1M window.',
+				default: 1048576,
+			},
+		],
+	},
+	{
 		id: 'qwen3-coder',
 		name: 'Qwen3 Coder',
 		binaryName: 'qwen',

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -347,6 +347,73 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		],
 	},
 	{
+		id: 'antigravity',
+		name: 'Antigravity CLI',
+		binaryName: 'agy',
+		command: 'agy',
+		args: [],
+		batchModePrefix: [],
+		// Headless mode soft-denies anything that would normally prompt (shell commands
+		// default to "Ask"), so a batch run without this flag stalls out on its first
+		// terminal tool call instead of failing loudly.
+		// https://antigravity.google/docs/cli/headless
+		batchModeArgs: ['--dangerously-skip-permissions'],
+		jsonOutputArgs: ['--output-format', 'stream-json'],
+		// `agy -p "..." --conversation <id>` resumes a specific conversation. The id
+		// comes back as `conversation_id` on every stream-json event.
+		resumeArgs: (sessionId: string) => ['--conversation', sessionId],
+		// Best-effort only: `--sandbox` restricts terminal commands, but reading AND
+		// writing files inside the active workspace stays auto-allowed in headless
+		// mode. There is no CLI flag that makes the agent truly read-only, hence
+		// readOnlyCliEnforced: false and supportsReadOnlyMode: false.
+		readOnlyArgs: ['--sandbox'],
+		readOnlyCliEnforced: false,
+		yoloModeArgs: ['--dangerously-skip-permissions'],
+		// No working-directory flag; the CLI takes its workspace from the spawn cwd
+		// (echoed back as `init.cwd`). No documented image attachment flag either.
+		workingDirArgs: undefined,
+		imageArgs: undefined,
+		modelArgs: (modelId: string) => ['--model', modelId],
+		promptArgs: (prompt: string) => ['-p', prompt],
+		configOptions: [
+			{
+				key: 'model',
+				type: 'text',
+				label: 'Model',
+				description:
+					'Model slug override (e.g., gemini-3.6-flash-high). Leave empty to use the CLI default. Run `agy --help` for the slugs your account can reach.',
+				default: '',
+				argBuilder: (value: string) => (value && value.trim() ? ['--model', value.trim()] : []),
+			},
+			{
+				key: 'effort',
+				type: 'select',
+				label: 'Reasoning Effort',
+				description: 'How much the model should reason before responding.',
+				options: ['', 'low', 'medium', 'high'],
+				default: '',
+				argBuilder: (value: string) => (value && value.trim() ? ['--effort', value.trim()] : []),
+			},
+			{
+				key: 'printTimeout',
+				type: 'text',
+				label: 'Headless Timeout',
+				description:
+					'Maximum time a single headless run may take (Go duration, e.g. 30m, 2h). The CLI default of 5m cuts off longer agent runs.',
+				default: '30m',
+				argBuilder: (value: string) =>
+					value && value.trim() ? ['--print-timeout', value.trim()] : [],
+			},
+			{
+				key: 'contextWindow',
+				type: 'number',
+				label: 'Context Window Size',
+				description: 'Maximum context window size in tokens. Gemini 3.x models expose a 1M window.',
+				default: 1048576,
+			},
+		],
+	},
+	{
 		id: 'qwen3-coder',
 		name: 'Qwen3 Coder',
 		hidden: true, // Not shipping. Kept for type/back-compat, hidden from UI.

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -366,6 +366,12 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		// writing files inside the active workspace stays auto-allowed in headless
 		// mode. There is no CLI flag that makes the agent truly read-only, hence
 		// readOnlyCliEnforced: false and supportsReadOnlyMode: false.
+		//
+		// Consequence worth knowing: tab naming spawns with readOnlyMode: true and
+		// relies on `noToolsArgs` to keep a task-like first message from turning into
+		// a real agentic run. The CLI exposes no tool-disabling flag, so there is
+		// nothing to put in `noToolsArgs` and a naming run can still touch workspace
+		// files. Wire `noToolsArgs` here the moment such a flag ships.
 		readOnlyArgs: ['--sandbox'],
 		readOnlyCliEnforced: false,
 		yoloModeArgs: ['--dangerously-skip-permissions'],

--- a/src/main/agents/path-prober.ts
+++ b/src/main/agents/path-prober.ts
@@ -411,7 +411,6 @@ function getWindowsKnownPaths(binaryName: string): string[] {
 			// npm global installation
 			...npmGlobal('gemini'),
 		],
-<<<<<<< HEAD
 		hermes: [
 			// Python/pipx and standalone installations
 			...localBin('hermes'),
@@ -429,13 +428,12 @@ function getWindowsKnownPaths(binaryName: string): string[] {
 			// npm global installation
 			...npmGlobal('omp'),
 			...localBin('omp'),
-=======
+		],
 		agy: [
 			// Official install.ps1 / install.cmd target
 			path.join(localAppData, 'agy', 'bin', 'agy.exe'),
 			// Some shells resolve the installer's shim from the user local bin
 			...localBin('agy'),
->>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 		],
 		gh: [
 			// GitHub CLI official installer (MSI)
@@ -580,7 +578,6 @@ function getUnixKnownPaths(binaryName: string): string[] {
 			// Node version managers (nvm, fnm, volta, etc.)
 			...nodeVersionManagers('gemini'),
 		],
-<<<<<<< HEAD
 		hermes: [
 			// Python/pipx and standalone installations
 			...localBin('hermes'),
@@ -603,7 +600,7 @@ function getUnixKnownPaths(binaryName: string): string[] {
 			...npmGlobal('omp'),
 			path.join(home, 'bin', 'omp'),
 			...nodeVersionManagers('omp'),
-=======
+		],
 		agy: [
 			// Official install.sh target on macOS/Linux
 			...localBin('agy'),
@@ -611,7 +608,6 @@ function getUnixKnownPaths(binaryName: string): string[] {
 			path.join(home, 'bin', 'agy'),
 			// Homebrew, should a formula land later
 			...homebrew('agy'),
->>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 		],
 		gh: [
 			// Homebrew (Apple Silicon + Intel)

--- a/src/main/agents/path-prober.ts
+++ b/src/main/agents/path-prober.ts
@@ -411,6 +411,7 @@ function getWindowsKnownPaths(binaryName: string): string[] {
 			// npm global installation
 			...npmGlobal('gemini'),
 		],
+<<<<<<< HEAD
 		hermes: [
 			// Python/pipx and standalone installations
 			...localBin('hermes'),
@@ -428,6 +429,13 @@ function getWindowsKnownPaths(binaryName: string): string[] {
 			// npm global installation
 			...npmGlobal('omp'),
 			...localBin('omp'),
+=======
+		agy: [
+			// Official install.ps1 / install.cmd target
+			path.join(localAppData, 'agy', 'bin', 'agy.exe'),
+			// Some shells resolve the installer's shim from the user local bin
+			...localBin('agy'),
+>>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 		],
 		gh: [
 			// GitHub CLI official installer (MSI)
@@ -572,6 +580,7 @@ function getUnixKnownPaths(binaryName: string): string[] {
 			// Node version managers (nvm, fnm, volta, etc.)
 			...nodeVersionManagers('gemini'),
 		],
+<<<<<<< HEAD
 		hermes: [
 			// Python/pipx and standalone installations
 			...localBin('hermes'),
@@ -594,6 +603,15 @@ function getUnixKnownPaths(binaryName: string): string[] {
 			...npmGlobal('omp'),
 			path.join(home, 'bin', 'omp'),
 			...nodeVersionManagers('omp'),
+=======
+		agy: [
+			// Official install.sh target on macOS/Linux
+			...localBin('agy'),
+			// User bin directory
+			path.join(home, 'bin', 'agy'),
+			// Homebrew, should a formula land later
+			...homebrew('agy'),
+>>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 		],
 		gh: [
 			// Homebrew (Apple Silicon + Intel)

--- a/src/main/agents/path-prober.ts
+++ b/src/main/agents/path-prober.ts
@@ -338,6 +338,12 @@ function getWindowsKnownPaths(binaryName: string): string[] {
 			// npm global installation
 			...npmGlobal('gemini'),
 		],
+		agy: [
+			// Official install.ps1 / install.cmd target
+			path.join(localAppData, 'agy', 'bin', 'agy.exe'),
+			// Some shells resolve the installer's shim from the user local bin
+			...localBin('agy'),
+		],
 		gh: [
 			// GitHub CLI official installer (MSI)
 			path.join(programFiles, 'GitHub CLI', 'gh.exe'),
@@ -465,6 +471,14 @@ function getUnixKnownPaths(binaryName: string): string[] {
 			...homebrew('gemini'),
 			// Node version managers (nvm, fnm, volta, etc.)
 			...nodeVersionManagers('gemini'),
+		],
+		agy: [
+			// Official install.sh target on macOS/Linux
+			...localBin('agy'),
+			// User bin directory
+			path.join(home, 'bin', 'agy'),
+			// Homebrew, should a formula land later
+			...homebrew('agy'),
 		],
 		gh: [
 			// Homebrew (Apple Silicon + Intel)

--- a/src/main/parsers/antigravity-output-parser.ts
+++ b/src/main/parsers/antigravity-output-parser.ts
@@ -1,0 +1,352 @@
+/**
+ * Antigravity CLI Output Parser
+ *
+ * Parses the newline-delimited JSON emitted by `agy -p "..." --output-format stream-json`.
+ *
+ * Unlike the Claude-family agents, Antigravity discriminates on an `event` key and
+ * nests the payload under a property of the same name:
+ *
+ * 1. Init event (once, at start):
+ *    {"event":"init","init":{"cwd":"...","tools":[...],"permission_mode":"...","model":"...","agent":"..."}}
+ *
+ * 2. Step update (many, during execution):
+ *    {"event":"step_update","step_update":{"conversation_id":"...","step_index":0,"state":"ACTIVE",
+ *      "step_type":"agent_response","text_delta":"...","tool_name":"...","tool_info":{...},"usage":{...}}}
+ *
+ * 3. Result (once, terminal) - same shape as the `--output-format json` envelope:
+ *    {"event":"result","result":{"conversation_id":"...","status":"...","response":"...","error":"...",
+ *      "duration_seconds":1.2,"num_turns":1,"usage":{...}}}
+ *
+ * Derived from the published headless-mode contract, not from a captured live run.
+ * @see https://antigravity.google/docs/cli/headless
+ */
+
+import type { ToolType, AgentError } from '../../shared/types';
+import type { AgentOutputParser, ParsedEvent } from './agent-output-parser';
+import { getErrorPatterns, matchErrorPattern } from './error-patterns';
+
+/** Token metrics reported on step_update and on the terminal result envelope. */
+interface AntigravityUsage {
+	input_tokens?: number;
+	output_tokens?: number;
+	thinking_tokens?: number;
+	cache_read_tokens?: number;
+	total_tokens?: number;
+}
+
+/** The `result` payload, also used verbatim as the `--output-format json` envelope. */
+interface AntigravityResult {
+	conversation_id?: string;
+	status?: string;
+	response?: string;
+	/** Present only on failure. */
+	error?: string;
+	duration_seconds?: number;
+	num_turns?: number;
+	usage?: AntigravityUsage;
+	structured_output?: unknown;
+}
+
+interface AntigravityStepUpdate {
+	conversation_id?: string;
+	step_index?: number;
+	/** 'ACTIVE' while the step runs, 'DONE' once it settles. */
+	state?: string;
+	/** e.g. 'user_input' | 'agent_response' | 'tool' | 'checkpoint'. */
+	step_type?: string;
+	tool_name?: string;
+	text_delta?: string;
+	duration_seconds?: number;
+	usage?: AntigravityUsage;
+	tool_info?: {
+		name?: string;
+		parameters?: unknown;
+		output?: string;
+		error?: { type?: string; message?: string };
+	};
+	subagent_info?: unknown;
+}
+
+interface AntigravityInit {
+	cwd?: string;
+	tools?: string[];
+	permission_mode?: string;
+	model?: string;
+	agent?: string;
+	json_schema?: unknown;
+}
+
+interface AntigravityStreamMessage {
+	event: 'init' | 'step_update' | 'result';
+	init?: AntigravityInit;
+	step_update?: AntigravityStepUpdate;
+	result?: AntigravityResult;
+}
+
+const STREAM_EVENTS = ['init', 'step_update', 'result'];
+
+/** Narrow an unknown payload to an Antigravity stream-json envelope. */
+function isAntigravityStreamMessage(data: unknown): data is AntigravityStreamMessage {
+	if (typeof data !== 'object' || data === null) {
+		return false;
+	}
+	const obj = data as Record<string, unknown>;
+	return typeof obj.event === 'string' && STREAM_EVENTS.includes(obj.event);
+}
+
+/**
+ * Antigravity CLI Output Parser Implementation
+ *
+ * Transforms Antigravity's stream-json events into normalized ParsedEvents.
+ */
+export class AntigravityOutputParser implements AgentOutputParser {
+	readonly agentId: ToolType = 'antigravity';
+
+	parseJsonLine(line: string): ParsedEvent | null {
+		if (!line.trim()) {
+			return null;
+		}
+
+		try {
+			const parsed: unknown = JSON.parse(line);
+			// A JSON line that isn't an Antigravity envelope still carries information
+			// worth showing (e.g. a bare progress object), so fall through to raw text.
+			return (
+				this.parseJsonObject(parsed) ?? {
+					type: 'text' as const,
+					text: line,
+					isPartial: true,
+					raw: parsed,
+				}
+			);
+		} catch {
+			// Not JSON - surface the raw line so nothing is silently dropped.
+			return {
+				type: 'text',
+				text: line,
+				isPartial: true,
+				raw: line,
+			};
+		}
+	}
+
+	parseJsonObject(parsed: unknown): ParsedEvent | null {
+		if (!isAntigravityStreamMessage(parsed)) {
+			return null;
+		}
+
+		switch (parsed.event) {
+			case 'init':
+				return this.parseInitEvent(parsed.init);
+			case 'step_update':
+				return this.parseStepUpdate(parsed.step_update, parsed);
+			case 'result':
+				return this.parseResult(parsed.result, parsed);
+			default:
+				return { type: 'system', raw: parsed };
+		}
+	}
+
+	/**
+	 * Init carries the run's configuration (cwd, model, tools, permission mode).
+	 * It does NOT carry conversation_id - that first appears on step_update.
+	 */
+	private parseInitEvent(init: AntigravityInit | undefined): ParsedEvent {
+		return {
+			type: 'init',
+			raw: init ?? {},
+		};
+	}
+
+	private parseStepUpdate(
+		step: AntigravityStepUpdate | undefined,
+		raw: AntigravityStreamMessage
+	): ParsedEvent | null {
+		if (!step) {
+			return null;
+		}
+
+		const sessionId = step.conversation_id;
+		const usage = this.normalizeUsage(step.usage);
+
+		// Tool steps: surface the tool name and its lifecycle state so the UI can
+		// render an in-progress / settled tool card.
+		if (step.step_type === 'tool' || step.tool_name || step.tool_info) {
+			return {
+				type: 'tool_use',
+				sessionId,
+				toolName: step.tool_info?.name || step.tool_name || 'tool',
+				// step_index is stable for the life of a step, so it doubles as the call id.
+				toolCallId: typeof step.step_index === 'number' ? String(step.step_index) : undefined,
+				toolState: step.state,
+				usage,
+				raw,
+			};
+		}
+
+		// Assistant prose arrives as deltas; emit each one as partial text so the
+		// renderer appends rather than replaces.
+		if (step.text_delta) {
+			return {
+				type: 'text',
+				sessionId,
+				text: step.text_delta,
+				isPartial: true,
+				usage,
+				raw,
+			};
+		}
+
+		// Usage-only tick (no text, no tool) - keep the token counts, drop the noise.
+		if (usage) {
+			return { type: 'usage', sessionId, usage, raw };
+		}
+
+		// Bookkeeping steps (user_input echo, checkpoint) are not user-facing content.
+		return { type: 'system', sessionId, raw };
+	}
+
+	/**
+	 * The terminal envelope. `error` is documented as present only on failure, so
+	 * its presence - not the free-form `status` string - is what reclassifies the
+	 * result as an error event.
+	 */
+	private parseResult(
+		result: AntigravityResult | undefined,
+		raw: AntigravityStreamMessage
+	): ParsedEvent {
+		const errorText = this.extractErrorText(result);
+		if (errorText) {
+			return {
+				type: 'error',
+				sessionId: result?.conversation_id,
+				text: errorText,
+				usage: this.normalizeUsage(result?.usage),
+				raw,
+			};
+		}
+
+		return {
+			type: 'result',
+			sessionId: result?.conversation_id,
+			text: result?.response ?? '',
+			usage: this.normalizeUsage(result?.usage),
+			raw,
+		};
+	}
+
+	/** Map Antigravity's snake_case token metrics onto Maestro's usage shape. */
+	private normalizeUsage(usage: AntigravityUsage | undefined): ParsedEvent['usage'] | undefined {
+		if (!usage) {
+			return undefined;
+		}
+		return {
+			inputTokens: usage.input_tokens || 0,
+			outputTokens: usage.output_tokens || 0,
+			cacheReadTokens: usage.cache_read_tokens || 0,
+			reasoningTokens: usage.thinking_tokens || 0,
+			// No contextWindow is reported; leaving it unset lets the configured
+			// window (agentConstants / configOptions) drive the context meter.
+		};
+	}
+
+	/** Non-empty failure text from a result envelope, or null when it succeeded. */
+	private extractErrorText(result: AntigravityResult | undefined): string | null {
+		const error = result?.error;
+		return typeof error === 'string' && error.trim() ? error : null;
+	}
+
+	isResultMessage(event: ParsedEvent): boolean {
+		if (event.type === 'result') {
+			return true;
+		}
+		const raw = event.raw as AntigravityStreamMessage | undefined;
+		return raw?.event === 'result';
+	}
+
+	extractSessionId(event: ParsedEvent): string | null {
+		if (event.sessionId) {
+			return event.sessionId;
+		}
+		const raw = event.raw as AntigravityStreamMessage | undefined;
+		return raw?.step_update?.conversation_id || raw?.result?.conversation_id || null;
+	}
+
+	extractUsage(event: ParsedEvent): ParsedEvent['usage'] | null {
+		return event.usage || null;
+	}
+
+	/** Slash commands are a TUI affordance; headless runs never advertise them. */
+	extractSlashCommands(_event: ParsedEvent): string[] | null {
+		return null;
+	}
+
+	detectErrorFromLine(line: string): AgentError | null {
+		if (!line.trim()) {
+			return null;
+		}
+
+		try {
+			const error = this.detectErrorFromParsed(JSON.parse(line));
+			if (error) {
+				error.raw = { ...(error.raw as Record<string, unknown>), errorLine: line };
+			}
+			return error;
+		} catch {
+			// Not JSON - nothing structured to classify.
+			return null;
+		}
+	}
+
+	detectErrorFromParsed(parsed: unknown): AgentError | null {
+		if (!isAntigravityStreamMessage(parsed) || parsed.event !== 'result') {
+			return null;
+		}
+
+		const errorText = this.extractErrorText(parsed.result);
+		if (!errorText) {
+			return null;
+		}
+
+		const match = matchErrorPattern(getErrorPatterns(this.agentId), errorText);
+		return {
+			type: match?.type ?? 'unknown',
+			message: match?.message ?? errorText,
+			recoverable: match?.recoverable ?? true,
+			agentId: this.agentId,
+			timestamp: Date.now(),
+			parsedJson: parsed,
+		};
+	}
+
+	detectErrorFromExit(exitCode: number, stderr: string, stdout: string): AgentError | null {
+		if (exitCode === 0) {
+			return null;
+		}
+
+		const combined = `${stderr}\n${stdout}`;
+		const match = matchErrorPattern(getErrorPatterns(this.agentId), combined);
+		if (match) {
+			return {
+				type: match.type,
+				message: match.message,
+				recoverable: match.recoverable,
+				agentId: this.agentId,
+				timestamp: Date.now(),
+				raw: { exitCode, stderr, stdout },
+			};
+		}
+
+		const stderrPreview = stderr?.trim()
+			? `: ${stderr.trim().split('\n')[0].substring(0, 200)}`
+			: '';
+		return {
+			type: 'agent_crashed',
+			message: `Antigravity CLI exited with code ${exitCode}${stderrPreview}`,
+			recoverable: true,
+			agentId: this.agentId,
+			timestamp: Date.now(),
+			raw: { exitCode, stderr, stdout },
+		};
+	}
+}

--- a/src/main/parsers/antigravity-output-parser.ts
+++ b/src/main/parsers/antigravity-output-parser.ts
@@ -78,6 +78,13 @@ interface AntigravityInit {
 
 interface AntigravityStreamMessage {
 	event: 'init' | 'step_update' | 'result';
+	/**
+	 * Not in the documented envelope, but read defensively: the docs only show
+	 * conversation_id nested inside step_update/result, so a run that dies right
+	 * after init would otherwise strand the conversation with no resumable id.
+	 * If the CLI ever puts it at the top level, we pick it up for free.
+	 */
+	conversation_id?: string;
 	init?: AntigravityInit;
 	step_update?: AntigravityStepUpdate;
 	result?: AntigravityResult;
@@ -137,7 +144,7 @@ export class AntigravityOutputParser implements AgentOutputParser {
 
 		switch (parsed.event) {
 			case 'init':
-				return this.parseInitEvent(parsed.init);
+				return this.parseInitEvent(parsed);
 			case 'step_update':
 				return this.parseStepUpdate(parsed.step_update, parsed);
 			case 'result':
@@ -149,12 +156,15 @@ export class AntigravityOutputParser implements AgentOutputParser {
 
 	/**
 	 * Init carries the run's configuration (cwd, model, tools, permission mode).
-	 * It does NOT carry conversation_id - that first appears on step_update.
+	 * The documented payload has no conversation_id - that first appears on
+	 * step_update - but a top-level one is honored if the CLI provides it, so a run
+	 * that dies immediately after init still yields a resumable id.
 	 */
-	private parseInitEvent(init: AntigravityInit | undefined): ParsedEvent {
+	private parseInitEvent(raw: AntigravityStreamMessage): ParsedEvent {
 		return {
 			type: 'init',
-			raw: init ?? {},
+			sessionId: raw.conversation_id,
+			raw: raw.init ?? {},
 		};
 	}
 
@@ -256,12 +266,18 @@ export class AntigravityOutputParser implements AgentOutputParser {
 		return typeof error === 'string' && error.trim() ? error : null;
 	}
 
+	/**
+	 * Only a SUCCESSFUL terminal envelope counts as a result message.
+	 *
+	 * A failed `result` is reclassified to type 'error' by parseResult, and it must
+	 * not answer true here even though its raw payload is still `event: 'result'`.
+	 * StdoutHandler returns early on error events before emitting a result, but
+	 * ExitHandler's end-of-stream flush (for a last line with no trailing newline)
+	 * keys off isResultMessage alone - answering true there would emit the failure
+	 * text to the user as if it were the agent's answer.
+	 */
 	isResultMessage(event: ParsedEvent): boolean {
-		if (event.type === 'result') {
-			return true;
-		}
-		const raw = event.raw as AntigravityStreamMessage | undefined;
-		return raw?.event === 'result';
+		return event.type === 'result';
 	}
 
 	extractSessionId(event: ParsedEvent): string | null {
@@ -269,7 +285,12 @@ export class AntigravityOutputParser implements AgentOutputParser {
 			return event.sessionId;
 		}
 		const raw = event.raw as AntigravityStreamMessage | undefined;
-		return raw?.step_update?.conversation_id || raw?.result?.conversation_id || null;
+		return (
+			raw?.conversation_id ||
+			raw?.step_update?.conversation_id ||
+			raw?.result?.conversation_id ||
+			null
+		);
 	}
 
 	extractUsage(event: ParsedEvent): ParsedEvent['usage'] | null {

--- a/src/main/parsers/antigravity-output-parser.ts
+++ b/src/main/parsers/antigravity-output-parser.ts
@@ -336,6 +336,12 @@ export class AntigravityOutputParser implements AgentOutputParser {
 			recoverable: match?.recoverable ?? true,
 			agentId: this.agentId,
 			timestamp: Date.now(),
+			// Keep the conversation association on the failure. A recoverable error
+			// that loses its id cannot be retried with `--conversation`, so the retry
+			// would silently start a fresh conversation instead of resuming this one.
+			// The ExitHandler flush overwrites this with the Maestro session id, but
+			// mid-stream callers see the provider's id.
+			sessionId: parsed.result?.conversation_id,
 			parsedJson: parsed,
 		};
 	}

--- a/src/main/parsers/error-patterns.ts
+++ b/src/main/parsers/error-patterns.ts
@@ -1091,7 +1091,6 @@ const COPILOT_ERROR_PATTERNS: AgentErrorPatterns = {
 	],
 };
 
-<<<<<<< HEAD
 const PI_ERROR_PATTERNS: AgentErrorPatterns = {
 	auth_expired: [
 		{
@@ -1248,45 +1247,12 @@ const GROK_ERROR_PATTERNS: AgentErrorPatterns = {
 		{
 			pattern: /grok\s+login/i,
 			message: 'Login required. Please run "grok login" to authenticate.',
-=======
-/**
- * Antigravity CLI (`agy`) error patterns.
- *
- * Antigravity authenticates against a Google account and shares the Gemini
- * quota/credit system, so the auth and rate-limit wording below mirrors Google's
- * API surface. The headless-specific entries cover the two failure modes unique
- * to `-p` runs: the 5m default print timeout, and tool calls that get soft-denied
- * because the run was started without --dangerously-skip-permissions.
- */
-const ANTIGRAVITY_ERROR_PATTERNS: AgentErrorPatterns = {
-	auth_expired: [
-		{
-			pattern: /not (?:signed in|authenticated)/i,
-			message: 'Not signed in. Run "agy" once interactively to complete the Google sign-in.',
-			recoverable: true,
-		},
-		{
-			pattern: /(?:authentication|auth) (?:failed|required|expired)/i,
-			message: 'Antigravity authentication failed. Run "agy" interactively to re-authenticate.',
-			recoverable: true,
-		},
-		{
-			pattern: /credentials.*(?:expired|invalid|not found)/i,
-			message:
-				'Cached Antigravity credentials are no longer valid. Sign in again from an interactive "agy" session.',
-			recoverable: true,
-		},
-		{
-			pattern: /\b401\b|unauthenticated/i,
-			message: 'Unauthorized. Check the Google account signed in to Antigravity.',
->>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 			recoverable: true,
 		},
 	],
 
 	rate_limited: [
 		{
-<<<<<<< HEAD
 			pattern: /rate limit/i,
 			message: 'Rate limit exceeded. Please wait and try again.',
 			recoverable: true,
@@ -1323,27 +1289,12 @@ const ANTIGRAVITY_ERROR_PATTERNS: AgentErrorPatterns = {
 		{
 			pattern: /prompt.*too\s+long/i,
 			message: 'Prompt is too long. Try a shorter message or start a new session.',
-=======
-			pattern: /resource_exhausted/i,
-			message: 'Antigravity quota exhausted. Wait for the quota to reset and try again.',
-			recoverable: true,
-		},
-		{
-			pattern: /rate limit|too many requests|\b429\b/i,
-			message: 'Rate limited by Antigravity. Please wait and try again.',
-			recoverable: true,
-		},
-		{
-			pattern: /(?:quota|credits?).*(?:exceeded|exhausted|depleted)/i,
-			message: 'Out of AI credits. Resume when your Antigravity quota resets.',
->>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 			recoverable: true,
 		},
 	],
 
 	network_error: [
 		{
-<<<<<<< HEAD
 			pattern: /ECONNREFUSED|ETIMEDOUT|ENOTFOUND|ECONNRESET/,
 			message: 'Network error. Please check your connection.',
 			recoverable: true,
@@ -1360,35 +1311,16 @@ const ANTIGRAVITY_ERROR_PATTERNS: AgentErrorPatterns = {
 		},
 		{
 			pattern: /connection (failed|refused|reset)/i,
-=======
-			pattern: /print[- ]timeout|deadline exceeded/i,
-			message:
-				'The headless run exceeded its timeout. Raise the "Headless Timeout" option in the agent settings.',
-			recoverable: true,
-		},
-		{
-			pattern: /connection (?:refused|reset|failed)/i,
->>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 			message: 'Connection failed. Check your internet connection.',
 			recoverable: true,
 		},
 		{
-<<<<<<< HEAD
 			pattern: /timed?\s?out/i,
-=======
-			pattern: /network (?:error|unreachable)/i,
-			message: 'Network error. Please check your connection.',
-			recoverable: true,
-		},
-		{
-			pattern: /\btimed? ?out\b/i,
->>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 			message: 'Request timed out. Please try again.',
 			recoverable: true,
 		},
 	],
 
-<<<<<<< HEAD
 	agent_crashed: [
 		{
 			// Verified: `grok -p "hi" -m nonexistent-model-xyz` emits
@@ -1397,20 +1329,12 @@ const ANTIGRAVITY_ERROR_PATTERNS: AgentErrorPatterns = {
 			pattern: /couldn't set model|unknown model id/i,
 			message:
 				'Invalid model. Run "grok models" to see available models and check the model setting in configuration.',
-=======
-	permission_denied: [
-		{
-			pattern: /soft[- ]denied|permission (?:denied|required)|tool.*not allowed/i,
-			message:
-				'A tool call was denied. Headless runs deny shell commands unless permissions are skipped.',
->>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 			recoverable: true,
 		},
 	],
 
 	session_not_found: [
 		{
-<<<<<<< HEAD
 			// Verified: `grok -p "hi" --resume <bad-uuid> --output-format
 			// streaming-json` (grok v0.2.93) prints nothing on stdout and exits 1
 			// with stderr:
@@ -1429,7 +1353,98 @@ const ANTIGRAVITY_ERROR_PATTERNS: AgentErrorPatterns = {
 			// standalone in other output modes.
 			pattern: /session get failed/i,
 			message: 'Session not found. Starting fresh conversation.',
-=======
+			recoverable: true,
+		},
+	],
+};
+
+/**
+ * Antigravity CLI (`agy`) error patterns.
+ *
+ * Antigravity authenticates against a Google account and shares the Gemini
+ * quota/credit system, so the auth and rate-limit wording below mirrors Google's
+ * API surface. The headless-specific entries cover the two failure modes unique
+ * to `-p` runs: the 5m default print timeout, and tool calls that get soft-denied
+ * because the run was started without --dangerously-skip-permissions.
+ */
+const ANTIGRAVITY_ERROR_PATTERNS: AgentErrorPatterns = {
+	auth_expired: [
+		{
+			pattern: /not (?:signed in|authenticated)/i,
+			message: 'Not signed in. Run "agy" once interactively to complete the Google sign-in.',
+			recoverable: true,
+		},
+		{
+			pattern: /(?:authentication|auth) (?:failed|required|expired)/i,
+			message: 'Antigravity authentication failed. Run "agy" interactively to re-authenticate.',
+			recoverable: true,
+		},
+		{
+			pattern: /credentials.*(?:expired|invalid|not found)/i,
+			message:
+				'Cached Antigravity credentials are no longer valid. Sign in again from an interactive "agy" session.',
+			recoverable: true,
+		},
+		{
+			pattern: /\b401\b|unauthenticated/i,
+			message: 'Unauthorized. Check the Google account signed in to Antigravity.',
+			recoverable: true,
+		},
+	],
+
+	rate_limited: [
+		{
+			pattern: /resource_exhausted/i,
+			message: 'Antigravity quota exhausted. Wait for the quota to reset and try again.',
+			recoverable: true,
+		},
+		{
+			pattern: /rate limit|too many requests|\b429\b/i,
+			message: 'Rate limited by Antigravity. Please wait and try again.',
+			recoverable: true,
+		},
+		{
+			pattern: /(?:quota|credits?).*(?:exceeded|exhausted|depleted)/i,
+			message: 'Out of AI credits. Resume when your Antigravity quota resets.',
+			recoverable: true,
+		},
+	],
+
+	network_error: [
+		{
+			pattern: /print[- ]timeout|deadline exceeded/i,
+			message:
+				'The headless run exceeded its timeout. Raise the "Headless Timeout" option in the agent settings.',
+			recoverable: true,
+		},
+		{
+			pattern: /connection (?:refused|reset|failed)/i,
+			message: 'Connection failed. Check your internet connection.',
+			recoverable: true,
+		},
+		{
+			pattern: /network (?:error|unreachable)/i,
+			message: 'Network error. Please check your connection.',
+			recoverable: true,
+		},
+		{
+			pattern: /\btimed? ?out\b/i,
+			message: 'Request timed out. Please try again.',
+			recoverable: true,
+		},
+	],
+
+	permission_denied: [
+		{
+			pattern: /soft[- ]denied|permission (?:denied|required)|tool.*not allowed/i,
+			message:
+				'A tool call was denied. Headless runs deny shell commands unless permissions are skipped.',
+			recoverable: true,
+		},
+	],
+
+	session_not_found: [
+		{
 			pattern: /conversation.*not found|unknown conversation/i,
 			message: 'Conversation not found. Starting a fresh conversation.',
 			recoverable: true,
@@ -1463,7 +1478,6 @@ const ANTIGRAVITY_ERROR_PATTERNS: AgentErrorPatterns = {
 		{
 			pattern: /panic:|unexpected error/i,
 			message: 'The Antigravity CLI crashed unexpectedly.',
->>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 			recoverable: true,
 		},
 	],
@@ -1479,14 +1493,11 @@ const patternRegistry = new Map<ToolType, AgentErrorPatterns>([
 	['codex', CODEX_ERROR_PATTERNS],
 	['factory-droid', FACTORY_DROID_ERROR_PATTERNS],
 	['copilot-cli', COPILOT_ERROR_PATTERNS],
-<<<<<<< HEAD
 	['pi', PI_ERROR_PATTERNS],
 	['qwen3-coder', QWEN_ERROR_PATTERNS],
 	['omp', OMP_ERROR_PATTERNS],
 	['grok', GROK_ERROR_PATTERNS],
-=======
 	['antigravity', ANTIGRAVITY_ERROR_PATTERNS],
->>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 ]);
 
 /**

--- a/src/main/parsers/error-patterns.ts
+++ b/src/main/parsers/error-patterns.ts
@@ -1091,6 +1091,7 @@ const COPILOT_ERROR_PATTERNS: AgentErrorPatterns = {
 	],
 };
 
+<<<<<<< HEAD
 const PI_ERROR_PATTERNS: AgentErrorPatterns = {
 	auth_expired: [
 		{
@@ -1247,12 +1248,45 @@ const GROK_ERROR_PATTERNS: AgentErrorPatterns = {
 		{
 			pattern: /grok\s+login/i,
 			message: 'Login required. Please run "grok login" to authenticate.',
+=======
+/**
+ * Antigravity CLI (`agy`) error patterns.
+ *
+ * Antigravity authenticates against a Google account and shares the Gemini
+ * quota/credit system, so the auth and rate-limit wording below mirrors Google's
+ * API surface. The headless-specific entries cover the two failure modes unique
+ * to `-p` runs: the 5m default print timeout, and tool calls that get soft-denied
+ * because the run was started without --dangerously-skip-permissions.
+ */
+const ANTIGRAVITY_ERROR_PATTERNS: AgentErrorPatterns = {
+	auth_expired: [
+		{
+			pattern: /not (?:signed in|authenticated)/i,
+			message: 'Not signed in. Run "agy" once interactively to complete the Google sign-in.',
+			recoverable: true,
+		},
+		{
+			pattern: /(?:authentication|auth) (?:failed|required|expired)/i,
+			message: 'Antigravity authentication failed. Run "agy" interactively to re-authenticate.',
+			recoverable: true,
+		},
+		{
+			pattern: /credentials.*(?:expired|invalid|not found)/i,
+			message:
+				'Cached Antigravity credentials are no longer valid. Sign in again from an interactive "agy" session.',
+			recoverable: true,
+		},
+		{
+			pattern: /\b401\b|unauthenticated/i,
+			message: 'Unauthorized. Check the Google account signed in to Antigravity.',
+>>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 			recoverable: true,
 		},
 	],
 
 	rate_limited: [
 		{
+<<<<<<< HEAD
 			pattern: /rate limit/i,
 			message: 'Rate limit exceeded. Please wait and try again.',
 			recoverable: true,
@@ -1289,12 +1323,27 @@ const GROK_ERROR_PATTERNS: AgentErrorPatterns = {
 		{
 			pattern: /prompt.*too\s+long/i,
 			message: 'Prompt is too long. Try a shorter message or start a new session.',
+=======
+			pattern: /resource_exhausted/i,
+			message: 'Antigravity quota exhausted. Wait for the quota to reset and try again.',
+			recoverable: true,
+		},
+		{
+			pattern: /rate limit|too many requests|\b429\b/i,
+			message: 'Rate limited by Antigravity. Please wait and try again.',
+			recoverable: true,
+		},
+		{
+			pattern: /(?:quota|credits?).*(?:exceeded|exhausted|depleted)/i,
+			message: 'Out of AI credits. Resume when your Antigravity quota resets.',
+>>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 			recoverable: true,
 		},
 	],
 
 	network_error: [
 		{
+<<<<<<< HEAD
 			pattern: /ECONNREFUSED|ETIMEDOUT|ENOTFOUND|ECONNRESET/,
 			message: 'Network error. Please check your connection.',
 			recoverable: true,
@@ -1311,16 +1360,35 @@ const GROK_ERROR_PATTERNS: AgentErrorPatterns = {
 		},
 		{
 			pattern: /connection (failed|refused|reset)/i,
+=======
+			pattern: /print[- ]timeout|deadline exceeded/i,
+			message:
+				'The headless run exceeded its timeout. Raise the "Headless Timeout" option in the agent settings.',
+			recoverable: true,
+		},
+		{
+			pattern: /connection (?:refused|reset|failed)/i,
+>>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 			message: 'Connection failed. Check your internet connection.',
 			recoverable: true,
 		},
 		{
+<<<<<<< HEAD
 			pattern: /timed?\s?out/i,
+=======
+			pattern: /network (?:error|unreachable)/i,
+			message: 'Network error. Please check your connection.',
+			recoverable: true,
+		},
+		{
+			pattern: /\btimed? ?out\b/i,
+>>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 			message: 'Request timed out. Please try again.',
 			recoverable: true,
 		},
 	],
 
+<<<<<<< HEAD
 	agent_crashed: [
 		{
 			// Verified: `grok -p "hi" -m nonexistent-model-xyz` emits
@@ -1329,12 +1397,20 @@ const GROK_ERROR_PATTERNS: AgentErrorPatterns = {
 			pattern: /couldn't set model|unknown model id/i,
 			message:
 				'Invalid model. Run "grok models" to see available models and check the model setting in configuration.',
+=======
+	permission_denied: [
+		{
+			pattern: /soft[- ]denied|permission (?:denied|required)|tool.*not allowed/i,
+			message:
+				'A tool call was denied. Headless runs deny shell commands unless permissions are skipped.',
+>>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 			recoverable: true,
 		},
 	],
 
 	session_not_found: [
 		{
+<<<<<<< HEAD
 			// Verified: `grok -p "hi" --resume <bad-uuid> --output-format
 			// streaming-json` (grok v0.2.93) prints nothing on stdout and exits 1
 			// with stderr:
@@ -1353,6 +1429,41 @@ const GROK_ERROR_PATTERNS: AgentErrorPatterns = {
 			// standalone in other output modes.
 			pattern: /session get failed/i,
 			message: 'Session not found. Starting fresh conversation.',
+=======
+			pattern: /conversation.*not found|unknown conversation/i,
+			message: 'Conversation not found. Starting a fresh conversation.',
+			recoverable: true,
+		},
+	],
+
+	token_exhaustion: [
+		{
+			pattern: /context (?:window|length|limit).*(?:exceeded|too long)/i,
+			message: 'Context window exceeded. Start a new conversation.',
+			recoverable: true,
+		},
+		{
+			pattern: /(?:input|prompt).*too (?:long|large)/i,
+			message: 'The prompt is too large for the context window. Try a shorter message.',
+			recoverable: true,
+		},
+		{
+			pattern: /token limit|maximum.*tokens/i,
+			message: 'Token limit reached. Start a new conversation to continue.',
+			recoverable: true,
+		},
+	],
+
+	agent_crashed: [
+		{
+			pattern: /internal (?:error|server error)|\b50[0234]\b/i,
+			message: 'Antigravity returned an internal error. Please try again.',
+			recoverable: true,
+		},
+		{
+			pattern: /panic:|unexpected error/i,
+			message: 'The Antigravity CLI crashed unexpectedly.',
+>>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 			recoverable: true,
 		},
 	],
@@ -1368,10 +1479,14 @@ const patternRegistry = new Map<ToolType, AgentErrorPatterns>([
 	['codex', CODEX_ERROR_PATTERNS],
 	['factory-droid', FACTORY_DROID_ERROR_PATTERNS],
 	['copilot-cli', COPILOT_ERROR_PATTERNS],
+<<<<<<< HEAD
 	['pi', PI_ERROR_PATTERNS],
 	['qwen3-coder', QWEN_ERROR_PATTERNS],
 	['omp', OMP_ERROR_PATTERNS],
 	['grok', GROK_ERROR_PATTERNS],
+=======
+	['antigravity', ANTIGRAVITY_ERROR_PATTERNS],
+>>>>>>> c059267b8 (feat(agents): Antigravity CLI (agy) as a supported provider)
 ]);
 
 /**

--- a/src/main/parsers/error-patterns.ts
+++ b/src/main/parsers/error-patterns.ts
@@ -995,6 +995,131 @@ const COPILOT_ERROR_PATTERNS: AgentErrorPatterns = {
 	],
 };
 
+/**
+ * Antigravity CLI (`agy`) error patterns.
+ *
+ * Antigravity authenticates against a Google account and shares the Gemini
+ * quota/credit system, so the auth and rate-limit wording below mirrors Google's
+ * API surface. The headless-specific entries cover the two failure modes unique
+ * to `-p` runs: the 5m default print timeout, and tool calls that get soft-denied
+ * because the run was started without --dangerously-skip-permissions.
+ */
+const ANTIGRAVITY_ERROR_PATTERNS: AgentErrorPatterns = {
+	auth_expired: [
+		{
+			pattern: /not (?:signed in|authenticated)/i,
+			message: 'Not signed in. Run "agy" once interactively to complete the Google sign-in.',
+			recoverable: true,
+		},
+		{
+			pattern: /(?:authentication|auth) (?:failed|required|expired)/i,
+			message: 'Antigravity authentication failed. Run "agy" interactively to re-authenticate.',
+			recoverable: true,
+		},
+		{
+			pattern: /credentials.*(?:expired|invalid|not found)/i,
+			message:
+				'Cached Antigravity credentials are no longer valid. Sign in again from an interactive "agy" session.',
+			recoverable: true,
+		},
+		{
+			pattern: /\b401\b|unauthenticated/i,
+			message: 'Unauthorized. Check the Google account signed in to Antigravity.',
+			recoverable: true,
+		},
+	],
+
+	rate_limited: [
+		{
+			pattern: /resource_exhausted/i,
+			message: 'Antigravity quota exhausted. Wait for the quota to reset and try again.',
+			recoverable: true,
+		},
+		{
+			pattern: /rate limit|too many requests|\b429\b/i,
+			message: 'Rate limited by Antigravity. Please wait and try again.',
+			recoverable: true,
+		},
+		{
+			pattern: /(?:quota|credits?).*(?:exceeded|exhausted|depleted)/i,
+			message: 'Out of AI credits. Resume when your Antigravity quota resets.',
+			recoverable: true,
+		},
+	],
+
+	network_error: [
+		{
+			pattern: /print[- ]timeout|deadline exceeded/i,
+			message:
+				'The headless run exceeded its timeout. Raise the "Headless Timeout" option in the agent settings.',
+			recoverable: true,
+		},
+		{
+			pattern: /connection (?:refused|reset|failed)/i,
+			message: 'Connection failed. Check your internet connection.',
+			recoverable: true,
+		},
+		{
+			pattern: /network (?:error|unreachable)/i,
+			message: 'Network error. Please check your connection.',
+			recoverable: true,
+		},
+		{
+			pattern: /\btimed? ?out\b/i,
+			message: 'Request timed out. Please try again.',
+			recoverable: true,
+		},
+	],
+
+	permission_denied: [
+		{
+			pattern: /soft[- ]denied|permission (?:denied|required)|tool.*not allowed/i,
+			message:
+				'A tool call was denied. Headless runs deny shell commands unless permissions are skipped.',
+			recoverable: true,
+		},
+	],
+
+	session_not_found: [
+		{
+			pattern: /conversation.*not found|unknown conversation/i,
+			message: 'Conversation not found. Starting a fresh conversation.',
+			recoverable: true,
+		},
+	],
+
+	token_exhaustion: [
+		{
+			pattern: /context (?:window|length|limit).*(?:exceeded|too long)/i,
+			message: 'Context window exceeded. Start a new conversation.',
+			recoverable: true,
+		},
+		{
+			pattern: /(?:input|prompt).*too (?:long|large)/i,
+			message: 'The prompt is too large for the context window. Try a shorter message.',
+			recoverable: true,
+		},
+		{
+			pattern: /token limit|maximum.*tokens/i,
+			message: 'Token limit reached. Start a new conversation to continue.',
+			recoverable: true,
+		},
+	],
+
+	agent_crashed: [
+		{
+			pattern: /internal (?:error|server error)|\b50[0234]\b/i,
+			message: 'Antigravity returned an internal error. Please try again.',
+			recoverable: true,
+		},
+		{
+			pattern: /panic:|unexpected error/i,
+			message: 'The Antigravity CLI crashed unexpectedly.',
+			recoverable: true,
+		},
+	],
+};
+
 // ============================================================================
 // Pattern Registry
 // ============================================================================
@@ -1005,6 +1130,7 @@ const patternRegistry = new Map<ToolType, AgentErrorPatterns>([
 	['codex', CODEX_ERROR_PATTERNS],
 	['factory-droid', FACTORY_DROID_ERROR_PATTERNS],
 	['copilot-cli', COPILOT_ERROR_PATTERNS],
+	['antigravity', ANTIGRAVITY_ERROR_PATTERNS],
 ]);
 
 /**

--- a/src/main/parsers/index.ts
+++ b/src/main/parsers/index.ts
@@ -62,6 +62,7 @@ import { PiOutputParser } from './pi-output-parser';
 import { QwenOutputParser } from './qwen-output-parser';
 import { OmpOutputParser } from './omp-output-parser';
 import { GrokOutputParser } from './grok-output-parser';
+import { AntigravityOutputParser } from './antigravity-output-parser';
 import {
 	registerOutputParser,
 	clearParserRegistry,
@@ -79,6 +80,7 @@ export { PiOutputParser } from './pi-output-parser';
 export { QwenOutputParser } from './qwen-output-parser';
 export { OmpOutputParser } from './omp-output-parser';
 export { GrokOutputParser } from './grok-output-parser';
+export { AntigravityOutputParser } from './antigravity-output-parser';
 
 const LOG_CONTEXT = '[OutputParsers]';
 
@@ -100,6 +102,7 @@ export function initializeOutputParsers(): void {
 	registerOutputParser(new QwenOutputParser());
 	registerOutputParser(new OmpOutputParser());
 	registerOutputParser(new GrokOutputParser());
+	registerOutputParser(new AntigravityOutputParser());
 
 	// Log registered parsers for debugging
 	const registeredParsers = getAllOutputParsers().map((p) => p.agentId);

--- a/src/main/parsers/index.ts
+++ b/src/main/parsers/index.ts
@@ -58,6 +58,7 @@ import { OpenCodeOutputParser } from './opencode-output-parser';
 import { CodexOutputParser } from './codex-output-parser';
 import { FactoryDroidOutputParser } from './factory-droid-output-parser';
 import { CopilotOutputParser } from './copilot-output-parser';
+import { AntigravityOutputParser } from './antigravity-output-parser';
 import {
 	registerOutputParser,
 	clearParserRegistry,
@@ -71,6 +72,7 @@ export { OpenCodeOutputParser } from './opencode-output-parser';
 export { CodexOutputParser } from './codex-output-parser';
 export { FactoryDroidOutputParser } from './factory-droid-output-parser';
 export { CopilotOutputParser } from './copilot-output-parser';
+export { AntigravityOutputParser } from './antigravity-output-parser';
 
 const LOG_CONTEXT = '[OutputParsers]';
 
@@ -88,6 +90,7 @@ export function initializeOutputParsers(): void {
 	registerOutputParser(new CodexOutputParser());
 	registerOutputParser(new FactoryDroidOutputParser());
 	registerOutputParser(new CopilotOutputParser());
+	registerOutputParser(new AntigravityOutputParser());
 
 	// Log registered parsers for debugging
 	const registeredParsers = getAllOutputParsers().map((p) => p.agentId);

--- a/src/main/parsers/parser-factory.ts
+++ b/src/main/parsers/parser-factory.ts
@@ -21,6 +21,7 @@ import { PiOutputParser } from './pi-output-parser';
 import { QwenOutputParser } from './qwen-output-parser';
 import { OmpOutputParser } from './omp-output-parser';
 import { GrokOutputParser } from './grok-output-parser';
+import { AntigravityOutputParser } from './antigravity-output-parser';
 
 const PARSER_CONSTRUCTORS: Record<string, () => AgentOutputParser> = {
 	'claude-code': () => new ClaudeOutputParser(),
@@ -32,6 +33,7 @@ const PARSER_CONSTRUCTORS: Record<string, () => AgentOutputParser> = {
 	'qwen3-coder': () => new QwenOutputParser(),
 	omp: () => new OmpOutputParser(),
 	grok: () => new GrokOutputParser(),
+	antigravity: () => new AntigravityOutputParser(),
 };
 
 /**

--- a/src/main/parsers/parser-factory.ts
+++ b/src/main/parsers/parser-factory.ts
@@ -17,6 +17,7 @@ import { OpenCodeOutputParser } from './opencode-output-parser';
 import { CodexOutputParser } from './codex-output-parser';
 import { FactoryDroidOutputParser } from './factory-droid-output-parser';
 import { CopilotOutputParser } from './copilot-output-parser';
+import { AntigravityOutputParser } from './antigravity-output-parser';
 
 const PARSER_CONSTRUCTORS: Record<string, () => AgentOutputParser> = {
 	'claude-code': () => new ClaudeOutputParser(),
@@ -24,6 +25,7 @@ const PARSER_CONSTRUCTORS: Record<string, () => AgentOutputParser> = {
 	codex: () => new CodexOutputParser(),
 	'factory-droid': () => new FactoryDroidOutputParser(),
 	'copilot-cli': () => new CopilotOutputParser(),
+	antigravity: () => new AntigravityOutputParser(),
 };
 
 /**

--- a/src/main/process-manager/handlers/ExitHandler.ts
+++ b/src/main/process-manager/handlers/ExitHandler.ts
@@ -6,6 +6,7 @@ import { matchSshErrorPattern } from '../../parsers/error-patterns';
 import { aggregateModelUsage } from '../../parsers/usage-aggregator';
 import { cleanupTempFiles } from '../utils/imageUtils';
 import type { ManagedProcess, AgentError } from '../types';
+import type { ParsedEvent } from '../../parsers/agent-output-parser';
 import type { DataBufferManager } from './DataBufferManager';
 import type { SshRemoteConfig } from '../../../shared/types';
 import { captureException } from '../../utils/sentry';
@@ -135,35 +136,41 @@ export class ExitHandler {
 				remainingLineLength: remainingLine.length,
 				remainingLinePreview: remainingLine.substring(0, 200),
 			});
+			// Scoped to the parse alone. A malformed last line is an expected,
+			// recoverable condition with a defined fallback (emit it raw), but
+			// classifying and dispatching the event below is not - widening this
+			// catch around that work would swallow a real defect AND emit the failed
+			// envelope's JSON to the user as if it were the answer.
+			let event: ParsedEvent | null = null;
 			try {
-				const event = outputParser.parseJsonLine(remainingLine);
-				// A terminal envelope that reports a FAILURE has to leave through the
-				// error path, not the result path. Emitting its text as data would
-				// render a provider failure as the agent's answer, and dropping it
-				// silently is worse still: `detectErrorFromExit` below returns null on
-				// exit code 0, so a CLI that reports the failure in-band and then exits
-				// clean would settle the turn with no answer and no error at all - the
-				// tab just stops, and no retry or recovery handling ever fires.
-				if (event?.type === 'error' && !managedProcess.errorEmitted) {
-					const agentError = outputParser.detectErrorFromParsed((event.raw as unknown) ?? event);
-					if (agentError) {
-						managedProcess.errorEmitted = true;
-						agentError.sessionId = sessionId;
-						if (managedProcess.sshRemoteId) {
-							agentError.sshRemoteId = managedProcess.sshRemoteId;
-						}
-						this.emitter.emit('agent-error', sessionId, agentError);
-					}
-				} else if (event && outputParser.isResultMessage(event) && !managedProcess.resultEmitted) {
-					managedProcess.resultEmitted = true;
-					const resultText = event.text || managedProcess.streamedText || '';
-					if (resultText) {
-						this.bufferManager.emitDataBuffered(sessionId, resultText, managedProcess);
-					}
-				}
+				event = outputParser.parseJsonLine(remainingLine);
 			} catch {
-				// If parsing fails, emit the raw line as data
 				this.bufferManager.emitDataBuffered(sessionId, remainingLine, managedProcess);
+			}
+
+			// A terminal envelope that reports a FAILURE has to leave through the
+			// error path, not the result path. Emitting its text as data would render
+			// a provider failure as the agent's answer, and dropping it silently is
+			// worse still: `detectErrorFromExit` below returns null on exit code 0, so
+			// a CLI that reports the failure in-band and then exits clean would settle
+			// the turn with no answer and no error at all - the tab just stops, and no
+			// retry or recovery handling ever fires.
+			if (event?.type === 'error' && !managedProcess.errorEmitted) {
+				const agentError = outputParser.detectErrorFromParsed((event.raw as unknown) ?? event);
+				if (agentError) {
+					managedProcess.errorEmitted = true;
+					agentError.sessionId = sessionId;
+					if (managedProcess.sshRemoteId) {
+						agentError.sshRemoteId = managedProcess.sshRemoteId;
+					}
+					this.emitter.emit('agent-error', sessionId, agentError);
+				}
+			} else if (event && outputParser.isResultMessage(event) && !managedProcess.resultEmitted) {
+				managedProcess.resultEmitted = true;
+				const resultText = event.text || managedProcess.streamedText || '';
+				if (resultText) {
+					this.bufferManager.emitDataBuffered(sessionId, resultText, managedProcess);
+				}
 			}
 		}
 

--- a/src/main/process-manager/handlers/ExitHandler.ts
+++ b/src/main/process-manager/handlers/ExitHandler.ts
@@ -148,6 +148,25 @@ export class ExitHandler {
 				this.bufferManager.emitDataBuffered(sessionId, remainingLine, managedProcess);
 			}
 
+			// Capture the provider's session id BEFORE dispatching, and for a failed
+			// envelope as much as a successful one. When the flushed line is the first
+			// event to carry one - a short-lived run whose whole output is this single
+			// trailing envelope - this is the only chance to record it. Without it the
+			// tab has no id to resume from, so recovery from a *recoverable* error
+			// silently opens a fresh conversation and drops the context the retry was
+			// supposed to continue. StdoutHandler does this for mid-stream lines; the
+			// flush is the same event arriving without a trailing newline.
+			if (event) {
+				const eventSessionId = outputParser.extractSessionId(event);
+				if (eventSessionId) {
+					managedProcess.agentSessionId = eventSessionId;
+					if (!managedProcess.sessionIdEmitted) {
+						managedProcess.sessionIdEmitted = true;
+						this.emitter.emit('session-id', sessionId, eventSessionId);
+					}
+				}
+			}
+
 			// A terminal envelope that reports a FAILURE has to leave through the
 			// error path, not the result path. Emitting its text as data would render
 			// a provider failure as the agent's answer, and dropping it silently is

--- a/src/main/process-manager/handlers/ExitHandler.ts
+++ b/src/main/process-manager/handlers/ExitHandler.ts
@@ -137,7 +137,24 @@ export class ExitHandler {
 			});
 			try {
 				const event = outputParser.parseJsonLine(remainingLine);
-				if (event && outputParser.isResultMessage(event) && !managedProcess.resultEmitted) {
+				// A terminal envelope that reports a FAILURE has to leave through the
+				// error path, not the result path. Emitting its text as data would
+				// render a provider failure as the agent's answer, and dropping it
+				// silently is worse still: `detectErrorFromExit` below returns null on
+				// exit code 0, so a CLI that reports the failure in-band and then exits
+				// clean would settle the turn with no answer and no error at all - the
+				// tab just stops, and no retry or recovery handling ever fires.
+				if (event?.type === 'error' && !managedProcess.errorEmitted) {
+					const agentError = outputParser.detectErrorFromParsed((event.raw as unknown) ?? event);
+					if (agentError) {
+						managedProcess.errorEmitted = true;
+						agentError.sessionId = sessionId;
+						if (managedProcess.sshRemoteId) {
+							agentError.sshRemoteId = managedProcess.sshRemoteId;
+						}
+						this.emitter.emit('agent-error', sessionId, agentError);
+					}
+				} else if (event && outputParser.isResultMessage(event) && !managedProcess.resultEmitted) {
 					managedProcess.resultEmitted = true;
 					const resultText = event.text || managedProcess.streamedText || '';
 					if (resultText) {

--- a/src/renderer/components/NewInstanceModal/types.ts
+++ b/src/renderer/components/NewInstanceModal/types.ts
@@ -7,25 +7,20 @@ import type {
 	Theme,
 	FailoverConfig,
 } from '../../types';
+import { PICKABLE_AGENT_IDS } from '../../../shared/agentMetadata';
 
 // Maximum character length for nudge message and new session message
 export const NUDGE_MESSAGE_MAX_LENGTH = 1000;
 export const NEW_SESSION_MESSAGE_MAX_LENGTH = 5000;
 
-// Supported agents that are fully implemented
-export const SUPPORTED_AGENTS = [
-	'claude-code',
-	'opencode',
-	'codex',
-	'factory-droid',
-	'copilot-cli',
-	'qwen3-coder',
-	'omp',
-	'hermes',
-	'pi',
-	'grok',
-	'antigravity',
-];
+/**
+ * Providers a user may pick in the New Agent modal.
+ *
+ * Re-exported from the shared picker registry rather than hand-written, so this
+ * list cannot drift from the wizard's tile strip or the Group Chat moderator
+ * dropdown the way it did while Grok and Qwen3 Coder were listed only here.
+ */
+export const SUPPORTED_AGENTS: readonly string[] = PICKABLE_AGENT_IDS;
 
 export interface AgentDebugInfo {
 	agentId: string;

--- a/src/renderer/components/NewInstanceModal/types.ts
+++ b/src/renderer/components/NewInstanceModal/types.ts
@@ -24,6 +24,7 @@ export const SUPPORTED_AGENTS = [
 	'hermes',
 	'pi',
 	'grok',
+	'antigravity',
 ];
 
 export interface AgentDebugInfo {

--- a/src/renderer/components/NewInstanceModal/types.ts
+++ b/src/renderer/components/NewInstanceModal/types.ts
@@ -12,6 +12,7 @@ export const SUPPORTED_AGENTS = [
 	'codex',
 	'factory-droid',
 	'copilot-cli',
+	'antigravity',
 ];
 
 export interface AgentDebugInfo {

--- a/src/renderer/components/Wizard/screens/AgentSelectionScreen/components/AgentGrid.tsx
+++ b/src/renderer/components/Wizard/screens/AgentSelectionScreen/components/AgentGrid.tsx
@@ -1,7 +1,8 @@
-import type { RefObject } from 'react';
+import { useRef, type RefObject } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useHorizontalScroll } from '../../../../../hooks/ui';
 import type { AgentConfig, Theme } from '../../../../../types';
 import type { AgentTile } from '../types';
-import { getAgentTileColSpanClass } from '../utils/agentGrid';
 import { isAgentAvailable } from '../utils/agentAvailability';
 import { AgentTileButton } from './AgentTileButton';
 
@@ -19,6 +20,15 @@ interface AgentGridProps {
 	setIsNameFieldFocused: (focused: boolean) => void;
 }
 
+/**
+ * The provider strip: one horizontally scrolling row of tiles.
+ *
+ * A wrapping grid stopped working once the provider count passed eight - a
+ * third row pushed the Continue button below the fold. A single row keeps the
+ * screen's shape fixed no matter how many providers ship, at the cost of
+ * needing to say out loud that there is more past the right edge, which is what
+ * the edge fades and the arrow buttons are for.
+ */
 export function AgentGrid({
 	theme,
 	tiles,
@@ -32,39 +42,115 @@ export function AgentGrid({
 	setFocusedTileIndex,
 	setIsNameFieldFocused,
 }: AgentGridProps): JSX.Element {
+	const stripRef = useRef<HTMLDivElement>(null);
+	const { canScrollLeft, canScrollRight, scrollByPage } = useHorizontalScroll(
+		stripRef,
+		tiles.length
+	);
+
 	return (
-		<div className="flex flex-col items-center gap-4">
+		<div className="flex flex-col items-center gap-4 w-full min-w-0">
 			<p className="text-sm" style={{ color: theme.colors.textDim }}>
 				Select the provider that will power your agent.
 			</p>
-			<div className="grid grid-cols-8 gap-4 max-w-5xl">
-				{tiles.map((tile, index) => {
-					const isDetected = isAgentAvailable(detectedAgents, tile.id);
-					return (
-						<AgentTileButton
-							key={tile.id}
-							tile={tile}
-							index={index}
-							theme={theme}
-							isDetected={isDetected}
-							isSelected={selectedAgent === tile.id}
-							isFocused={focusedTileIndex === index && !isNameFieldFocused}
-							colSpanClass={getAgentTileColSpanClass(index)}
-							onTileClick={onTileClick}
-							onOpenConfig={onOpenConfig}
-							onFocusTile={(tileIndex) => {
-								setFocusedTileIndex(tileIndex);
-								setIsNameFieldFocused(false);
-							}}
-							setTileRef={(tileIndex, element) => {
-								if (tileRefs.current) {
-									tileRefs.current[tileIndex] = element;
-								}
-							}}
-						/>
-					);
-				})}
+
+			<div className="relative w-full max-w-5xl min-w-0">
+				<div
+					ref={stripRef}
+					className="flex gap-4 overflow-x-auto no-scrollbar scroll-smooth px-1 py-1"
+					role="group"
+					aria-label="Available providers"
+				>
+					{tiles.map((tile, index) => {
+						const isDetected = isAgentAvailable(detectedAgents, tile.id);
+						return (
+							<AgentTileButton
+								key={tile.id}
+								tile={tile}
+								index={index}
+								theme={theme}
+								isDetected={isDetected}
+								isSelected={selectedAgent === tile.id}
+								isFocused={focusedTileIndex === index && !isNameFieldFocused}
+								onTileClick={onTileClick}
+								onOpenConfig={onOpenConfig}
+								onFocusTile={(tileIndex) => {
+									setFocusedTileIndex(tileIndex);
+									setIsNameFieldFocused(false);
+								}}
+								setTileRef={(tileIndex, element) => {
+									if (tileRefs.current) {
+										tileRefs.current[tileIndex] = element;
+									}
+								}}
+							/>
+						);
+					})}
+				</div>
+
+				<StripEdge
+					theme={theme}
+					side="left"
+					visible={canScrollLeft}
+					onScroll={() => scrollByPage('left')}
+				/>
+				<StripEdge
+					theme={theme}
+					side="right"
+					visible={canScrollRight}
+					onScroll={() => scrollByPage('right')}
+				/>
 			</div>
+		</div>
+	);
+}
+
+/**
+ * Fade plus arrow button at one end of the strip.
+ *
+ * Kept out of the tab order: the strip is driven with the left/right arrow keys
+ * and Tab is already spoken for (it moves to the agent name field), so adding
+ * two more tab stops here would put dead ends in the middle of that path.
+ */
+function StripEdge({
+	theme,
+	side,
+	visible,
+	onScroll,
+}: {
+	theme: Theme;
+	side: 'left' | 'right';
+	visible: boolean;
+	onScroll: () => void;
+}): JSX.Element {
+	const isLeft = side === 'left';
+	const Icon = isLeft ? ChevronLeft : ChevronRight;
+
+	return (
+		<div
+			className={`absolute top-0 bottom-0 flex items-center transition-opacity duration-200 ${
+				isLeft ? 'left-0 pl-1 justify-start' : 'right-0 pr-1 justify-end'
+			} ${visible ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+			style={{
+				width: '4rem',
+				background: `linear-gradient(to ${isLeft ? 'right' : 'left'}, ${theme.colors.bgMain}, ${theme.colors.bgMain}00)`,
+			}}
+			aria-hidden="true"
+		>
+			<button
+				type="button"
+				tabIndex={-1}
+				onClick={onScroll}
+				className="flex items-center justify-center w-8 h-8 rounded-full border transition-colors hover:bg-white/10"
+				style={{
+					backgroundColor: theme.colors.bgSidebar,
+					borderColor: theme.colors.border,
+					color: theme.colors.textMain,
+				}}
+				title={isLeft ? 'Scroll left' : 'Scroll right'}
+			>
+				<Icon className="w-4 h-4" />
+			</button>
 		</div>
 	);
 }

--- a/src/renderer/components/Wizard/screens/AgentSelectionScreen/components/AgentLogo.tsx
+++ b/src/renderer/components/Wizard/screens/AgentSelectionScreen/components/AgentLogo.tsx
@@ -4,6 +4,9 @@ import type { Theme } from '../../../../../types';
 /** One place to resize every provider mark; they are drawn at one size only. */
 const LOGO_SIZE_CLASS = 'w-14 h-14';
 
+/** Identifies the "no mark for this provider" placeholder. See the default case. */
+export const AGENT_LOGO_FALLBACK_TESTID = 'agent-logo-fallback';
+
 export function AgentLogo({
 	agentId,
 	supported,
@@ -311,8 +314,13 @@ export function AgentLogo({
 			);
 
 		default:
+			// Marked so a test can prove a pickable provider draws a real mark rather
+			// than landing here. Asserting "an svg rendered" would not: this fallback
+			// is a div today, but nothing stops it becoming an svg later and quietly
+			// satisfying that assertion for every unregistered provider.
 			return (
 				<div
+					data-testid={AGENT_LOGO_FALLBACK_TESTID}
 					className={`${LOGO_SIZE_CLASS} rounded-full border-2`}
 					style={{ borderColor: color, opacity }}
 				/>

--- a/src/renderer/components/Wizard/screens/AgentSelectionScreen/components/AgentLogo.tsx
+++ b/src/renderer/components/Wizard/screens/AgentSelectionScreen/components/AgentLogo.tsx
@@ -1,4 +1,8 @@
+import { AA_LARGE_CONTRAST, readableTextOn } from '../../../../../../shared/colorContrast';
 import type { Theme } from '../../../../../types';
+
+/** One place to resize every provider mark; they are drawn at one size only. */
+const LOGO_SIZE_CLASS = 'w-14 h-14';
 
 export function AgentLogo({
 	agentId,
@@ -13,14 +17,19 @@ export function AgentLogo({
 	brandColor?: string;
 	theme: Theme;
 }): JSX.Element {
-	const color = supported && detected ? brandColor || theme.colors.accent : theme.colors.textDim;
+	// A brand color can sit almost on top of the tile background - GitHub's
+	// near-black #24292F on a dark theme all but disappears - so run it through
+	// the shared contrast helper. It returns the brand color untouched whenever
+	// it already clears WCAG AA, and only nudges it when it does not.
+	const rawColor = supported && detected ? brandColor || theme.colors.accent : theme.colors.textDim;
+	const color = readableTextOn(rawColor, [theme.colors.bgSidebar], AA_LARGE_CONTRAST);
 	const opacity = supported ? 1 : 0.35;
 
 	switch (agentId) {
 		case 'claude-code':
 			return (
 				<svg
-					className="w-12 h-12"
+					className={LOGO_SIZE_CLASS}
 					viewBox="0 0 48 48"
 					fill="none"
 					xmlns="http://www.w3.org/2000/svg"
@@ -37,7 +46,7 @@ export function AgentLogo({
 		case 'codex':
 			return (
 				<svg
-					className="w-12 h-12"
+					className={LOGO_SIZE_CLASS}
 					viewBox="0 0 48 48"
 					fill="none"
 					xmlns="http://www.w3.org/2000/svg"
@@ -51,7 +60,7 @@ export function AgentLogo({
 		case 'opencode':
 			return (
 				<svg
-					className="w-12 h-12"
+					className={LOGO_SIZE_CLASS}
 					viewBox="0 0 48 48"
 					fill="none"
 					xmlns="http://www.w3.org/2000/svg"
@@ -80,7 +89,7 @@ export function AgentLogo({
 		case 'factory-droid':
 			return (
 				<svg
-					className="w-12 h-12"
+					className={LOGO_SIZE_CLASS}
 					viewBox="0 0 48 48"
 					fill="none"
 					xmlns="http://www.w3.org/2000/svg"
@@ -132,7 +141,7 @@ export function AgentLogo({
 			// Official GitHub Copilot mark (Primer octicon `copilot-24`).
 			return (
 				<svg
-					className="w-12 h-12"
+					className={LOGO_SIZE_CLASS}
 					viewBox="0 0 24 24"
 					fill="none"
 					xmlns="http://www.w3.org/2000/svg"
@@ -151,7 +160,7 @@ export function AgentLogo({
 			// clean line-art rendering of Hermes' iconography.
 			return (
 				<svg
-					className="w-12 h-12"
+					className={LOGO_SIZE_CLASS}
 					viewBox="0 0 48 48"
 					fill="none"
 					xmlns="http://www.w3.org/2000/svg"
@@ -194,7 +203,7 @@ export function AgentLogo({
 			// Official pi.dev mark (their favicon glyph, viewBox 0 0 800 800).
 			return (
 				<svg
-					className="w-12 h-12"
+					className={LOGO_SIZE_CLASS}
 					viewBox="0 0 800 800"
 					fill="none"
 					xmlns="http://www.w3.org/2000/svg"
@@ -214,7 +223,7 @@ export function AgentLogo({
 			// Official Oh My Pi mark (omp.sh favicon glyph, viewBox 0 0 64 64).
 			return (
 				<svg
-					className="w-12 h-12"
+					className={LOGO_SIZE_CLASS}
 					viewBox="0 0 64 64"
 					fill="none"
 					xmlns="http://www.w3.org/2000/svg"
@@ -224,9 +233,89 @@ export function AgentLogo({
 				</svg>
 			);
 
+		case 'antigravity':
+			// Google publishes Antigravity's mark only as a multi-color raster, so
+			// this is a monochrome line-art reading of the name: a ringed body with
+			// something leaving it upward.
+			return (
+				<svg
+					className={LOGO_SIZE_CLASS}
+					viewBox="0 0 48 48"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+					style={{ opacity }}
+				>
+					<circle cx="24" cy="27" r="9" stroke={color} strokeWidth="2" />
+					<ellipse
+						cx="24"
+						cy="27"
+						rx="18"
+						ry="5.5"
+						stroke={color}
+						strokeWidth="2"
+						transform="rotate(-20 24 27)"
+					/>
+					<path
+						d="M24 21V8m0 0l-4.5 4.5M24 8l4.5 4.5"
+						stroke={color}
+						strokeWidth="2"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+					/>
+				</svg>
+			);
+
+		case 'grok':
+			// xAI ships a wordmark rather than a redistributable glyph; this is its
+			// slashed X - one unbroken diagonal crossed by a second that breaks
+			// around it.
+			return (
+				<svg
+					className={LOGO_SIZE_CLASS}
+					viewBox="0 0 48 48"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+					style={{ opacity }}
+				>
+					<path d="M12 10L36 38" stroke={color} strokeWidth="5" />
+					<path d="M36 10L27.5 20" stroke={color} strokeWidth="5" />
+					<path d="M20.5 28L12 38" stroke={color} strokeWidth="5" />
+				</svg>
+			);
+
+		case 'qwen3-coder':
+			// Qwen's mark is a geometric knot inside a hex silhouette; this keeps the
+			// hex and reads the knot as two interlocking chevrons.
+			return (
+				<svg
+					className={LOGO_SIZE_CLASS}
+					viewBox="0 0 48 48"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+					style={{ opacity }}
+				>
+					<path
+						d="M24 5l16.5 9.5v19L24 43 7.5 33.5v-19L24 5z"
+						stroke={color}
+						strokeWidth="2"
+						strokeLinejoin="round"
+					/>
+					<path
+						d="M15 21l9-5 9 5M15 30l9 5 9-5"
+						stroke={color}
+						strokeWidth="2"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+					/>
+				</svg>
+			);
+
 		default:
 			return (
-				<div className="w-12 h-12 rounded-full border-2" style={{ borderColor: color, opacity }} />
+				<div
+					className={`${LOGO_SIZE_CLASS} rounded-full border-2`}
+					style={{ borderColor: color, opacity }}
+				/>
 			);
 	}
 }

--- a/src/renderer/components/Wizard/screens/AgentSelectionScreen/components/AgentTileButton.tsx
+++ b/src/renderer/components/Wizard/screens/AgentSelectionScreen/components/AgentTileButton.tsx
@@ -11,7 +11,6 @@ interface AgentTileButtonProps {
 	isDetected: boolean;
 	isSelected: boolean;
 	isFocused: boolean;
-	colSpanClass: string;
 	onTileClick: (tile: AgentTile, index: number) => void;
 	onOpenConfig: (agentId: string) => void;
 	onFocusTile: (index: number) => void;
@@ -25,7 +24,6 @@ export function AgentTileButton({
 	isDetected,
 	isSelected,
 	isFocused,
-	colSpanClass,
 	onTileClick,
 	onOpenConfig,
 	onFocusTile,
@@ -41,9 +39,8 @@ export function AgentTileButton({
 			onFocus={() => onFocusTile(index)}
 			disabled={!canSelect}
 			className={`
-				relative flex flex-col items-center justify-center pt-6 px-6 pb-10 rounded-xl
-				border-2 transition-all duration-200 outline-none min-w-[160px]
-				${colSpanClass}
+				relative flex flex-none flex-col items-center justify-center pt-7 px-6 pb-11 rounded-xl
+				border-2 transition-all duration-200 outline-none w-[220px]
 				${canSelect ? 'cursor-pointer' : 'cursor-not-allowed'}
 			`}
 			style={{

--- a/src/renderer/components/Wizard/screens/AgentSelectionScreen/utils/agentGrid.ts
+++ b/src/renderer/components/Wizard/screens/AgentSelectionScreen/utils/agentGrid.ts
@@ -1,51 +1,23 @@
 import { AGENT_TILES } from './agentTiles';
 
-export const GRID_COLS = 4;
-export const GRID_ROWS = Math.ceil(AGENT_TILES.length / GRID_COLS);
-
-// Tiles render into a grid that is GRID_COLS * 2 columns wide, each tile spanning
-// 2 columns. The extra multiplier lets a short final row start on a half-column so
-// it stays centered under the full rows above it.
-const TILES_IN_LAST_ROW = AGENT_TILES.length % GRID_COLS;
-export const LAST_ROW_START_INDEX =
-	TILES_IN_LAST_ROW === 0 ? -1 : AGENT_TILES.length - TILES_IN_LAST_ROW;
-export const LAST_ROW_COL_START_CLASS =
-	TILES_IN_LAST_ROW === 1
-		? 'col-start-4'
-		: TILES_IN_LAST_ROW === 2
-			? 'col-start-3'
-			: TILES_IN_LAST_ROW === 3
-				? 'col-start-2'
-				: '';
-
-export function getAgentTileColSpanClass(index: number): string {
-	return index === LAST_ROW_START_INDEX ? `col-span-2 ${LAST_ROW_COL_START_CLASS}` : 'col-span-2';
-}
-
+/**
+ * Keyboard movement across the provider strip.
+ *
+ * The strip is a single horizontally scrolling row, so left/right step one tile
+ * and up/down are no-ops. It used to be a wrapping 4-column grid, but the tile
+ * count now grows with every provider we add and a grid pushed the Continue
+ * button below the fold once it reached a third row.
+ *
+ * Movement is clamped rather than wrapped: running off the end should stop, not
+ * teleport the focus ring back to the far side of a row the user can't see.
+ */
 export function getNextAgentTileIndex(currentIndex: number, key: string): number {
-	const currentRow = Math.floor(currentIndex / GRID_COLS);
-	const currentCol = currentIndex % GRID_COLS;
-
 	switch (key) {
-		case 'ArrowUp':
-			if (currentRow > 0) {
-				return (currentRow - 1) * GRID_COLS + currentCol;
-			}
-			return currentIndex;
-
-		case 'ArrowDown': {
-			if (currentRow >= GRID_ROWS - 1) return currentIndex;
-			const newIndex = (currentRow + 1) * GRID_COLS + currentCol;
-			return newIndex < AGENT_TILES.length ? newIndex : currentIndex;
-		}
-
 		case 'ArrowLeft':
-			return currentCol > 0 ? currentIndex - 1 : currentIndex;
+			return currentIndex > 0 ? currentIndex - 1 : currentIndex;
 
 		case 'ArrowRight':
-			return currentCol < GRID_COLS - 1 && currentIndex + 1 < AGENT_TILES.length
-				? currentIndex + 1
-				: currentIndex;
+			return currentIndex + 1 < AGENT_TILES.length ? currentIndex + 1 : currentIndex;
 
 		default:
 			return currentIndex;

--- a/src/renderer/components/Wizard/screens/AgentSelectionScreen/utils/agentTiles.ts
+++ b/src/renderer/components/Wizard/screens/AgentSelectionScreen/utils/agentTiles.ts
@@ -1,60 +1,26 @@
+import {
+	AGENT_PICKER_META,
+	PICKABLE_AGENT_IDS,
+	getAgentDisplayName,
+} from '../../../../../../shared/agentMetadata';
 import type { AgentTile } from '../types';
 
-export const AGENT_TILES: AgentTile[] = [
-	{
-		id: 'claude-code',
-		name: 'Claude Code',
+/**
+ * Provider tiles for the wizard strip, derived from the shared picker registry
+ * so the wizard, the New Agent modal, and the Group Chat moderator dropdown
+ * always offer the same providers in the same order.
+ *
+ * `supported` stays on the tile because the strip still renders a dimmed
+ * "Coming soon" state for a provider that is announced but not wired yet.
+ * Everything derived here is wired, so it is always true.
+ */
+export const AGENT_TILES: AgentTile[] = PICKABLE_AGENT_IDS.map((id) => {
+	const meta = AGENT_PICKER_META[id]!;
+	return {
+		id,
+		name: getAgentDisplayName(id),
 		supported: true,
-		description: "Anthropic's AI coding assistant",
-		brandColor: '#D97757',
-	},
-	{
-		id: 'codex',
-		name: 'Codex',
-		supported: true,
-		description: "OpenAI's AI coding assistant",
-		brandColor: '#10A37F',
-	},
-	{
-		id: 'opencode',
-		name: 'OpenCode',
-		supported: true,
-		description: 'Open-source AI coding assistant',
-		brandColor: '#F97316',
-	},
-	{
-		id: 'factory-droid',
-		name: 'Factory Droid',
-		supported: true,
-		description: "Factory's AI coding assistant",
-		brandColor: '#3B82F6',
-	},
-	{
-		id: 'copilot-cli',
-		name: 'Copilot-CLI',
-		supported: true,
-		description: "GitHub's AI coding assistant",
-		brandColor: '#24292F',
-	},
-	{
-		id: 'hermes',
-		name: 'Hermes',
-		supported: true,
-		description: "Nous Research's AI coding assistant",
-		brandColor: '#2323FF',
-	},
-	{
-		id: 'pi',
-		name: 'Pi',
-		supported: true,
-		description: 'Your own agent harness',
-		brandColor: '#E4E4E7',
-	},
-	{
-		id: 'omp',
-		name: 'Oh My Pi',
-		supported: true,
-		description: 'Multi-model coding agent',
-		brandColor: '#9B4DFF',
-	},
-];
+		description: meta.description,
+		brandColor: meta.brandColor,
+	};
+});

--- a/src/renderer/constants/agentIcons.ts
+++ b/src/renderer/constants/agentIcons.ts
@@ -34,6 +34,8 @@ export const AGENT_ICONS: Record<string, string> = {
 	// Google family
 	'gemini-cli': '🔷',
 	gemini: '🔷',
+	antigravity: '🪐',
+	agy: '🪐',
 
 	// Alibaba family
 	'qwen3-coder': '⬡',

--- a/src/renderer/hooks/ui/index.ts
+++ b/src/renderer/hooks/ui/index.ts
@@ -29,6 +29,10 @@ export type {
 	ScrollMetrics,
 } from './useScrollPosition';
 
+// Horizontal strip scrolling (edge affordances + wheel-to-horizontal)
+export { useHorizontalScroll } from './useHorizontalScroll';
+export type { HorizontalScrollState } from './useHorizontalScroll';
+
 // Live CSS-grid column count (for arrow navigation over a responsive grid)
 export { useGridColumnCount } from './useGridColumnCount';
 

--- a/src/renderer/hooks/ui/useHorizontalScroll.ts
+++ b/src/renderer/hooks/ui/useHorizontalScroll.ts
@@ -17,6 +17,7 @@
  */
 
 import { useCallback, useEffect, useState, type RefObject } from 'react';
+import { useEventListener } from '../utils/useEventListener';
 
 /** Absorbs fractional scrollLeft values so an end-stop reads as "at the end". */
 const EDGE_SLACK_PX = 2;
@@ -38,47 +39,63 @@ export function useHorizontalScroll(
 	const [canScrollLeft, setCanScrollLeft] = useState(false);
 	const [canScrollRight, setCanScrollRight] = useState(false);
 
+	// `useEventListener` takes the element itself, not a ref, and a ref filling in
+	// does not re-render. Mirroring it into state gives the listeners a real
+	// target on the render after mount, instead of subscribing to null forever.
+	const [element, setElement] = useState<HTMLElement | null>(null);
 	useEffect(() => {
-		const element = ref.current;
+		setElement(ref.current);
+	}, [ref, resetKey]);
+
+	const measure = useCallback(() => {
 		if (!element) return;
+		const maxScrollLeft = element.scrollWidth - element.clientWidth;
+		setCanScrollLeft(element.scrollLeft > EDGE_SLACK_PX);
+		setCanScrollRight(element.scrollLeft < maxScrollLeft - EDGE_SLACK_PX);
+	}, [element]);
 
-		const measure = () => {
-			const maxScrollLeft = element.scrollWidth - element.clientWidth;
-			setCanScrollLeft(element.scrollLeft > EDGE_SLACK_PX);
-			setCanScrollRight(element.scrollLeft < maxScrollLeft - EDGE_SLACK_PX);
-		};
-		measure();
+	useEventListener('scroll', measure, { target: element, passive: true });
 
-		element.addEventListener('scroll', measure, { passive: true });
-
-		// A strip has no vertical overflow of its own, so a wheel gesture over it
-		// would otherwise scroll an ancestor (or nothing at all).
-		const onWheel = (event: WheelEvent) => {
-			const delta = Math.abs(event.deltaX) > Math.abs(event.deltaY) ? event.deltaX : event.deltaY;
+	// A strip has no vertical overflow of its own, so a wheel gesture over it
+	// would otherwise scroll an ancestor (or nothing at all).
+	useEventListener(
+		'wheel',
+		(event) => {
+			if (!element) return;
+			const wheel = event as WheelEvent;
+			const delta = Math.abs(wheel.deltaX) > Math.abs(wheel.deltaY) ? wheel.deltaX : wheel.deltaY;
 			if (delta === 0) return;
+
 			const maxScrollLeft = element.scrollWidth - element.clientWidth;
 			if (maxScrollLeft <= 0) return;
-			event.preventDefault();
-			element.scrollLeft = Math.max(0, Math.min(maxScrollLeft, element.scrollLeft + delta));
-		};
-		element.addEventListener('wheel', onWheel, { passive: false });
+
+			// Only claim the gesture when it actually moves this strip. At an end
+			// stop, a further scroll in that direction belongs to the surrounding
+			// page - swallowing it there traps the user's pointer over a strip that
+			// no longer responds while the wizard behind it refuses to scroll.
+			const target = Math.max(0, Math.min(maxScrollLeft, element.scrollLeft + delta));
+			if (target === element.scrollLeft) return;
+
+			wheel.preventDefault();
+			element.scrollLeft = target;
+		},
+		{ target: element, passive: false }
+	);
+
+	useEffect(() => {
+		if (!element) return;
+		measure();
 
 		// jsdom has no layout engine and no ResizeObserver by default; skip the
 		// observer rather than throwing so component tests render without a polyfill.
-		const observer =
-			typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(() => measure());
-		observer?.observe(element);
-
-		return () => {
-			element.removeEventListener('scroll', measure);
-			element.removeEventListener('wheel', onWheel);
-			observer?.disconnect();
-		};
-	}, [ref, resetKey]);
+		if (typeof ResizeObserver === 'undefined') return;
+		const observer = new ResizeObserver(() => measure());
+		observer.observe(element);
+		return () => observer.disconnect();
+	}, [element, measure, resetKey]);
 
 	const scrollByPage = useCallback(
 		(direction: 'left' | 'right') => {
-			const element = ref.current;
 			if (!element) return;
 			const distance = Math.max(element.clientWidth * 0.8, 1);
 			element.scrollBy({
@@ -86,7 +103,7 @@ export function useHorizontalScroll(
 				behavior: 'smooth',
 			});
 		},
-		[ref]
+		[element]
 	);
 
 	return { canScrollLeft, canScrollRight, scrollByPage };

--- a/src/renderer/hooks/ui/useHorizontalScroll.ts
+++ b/src/renderer/hooks/ui/useHorizontalScroll.ts
@@ -1,0 +1,93 @@
+/**
+ * useHorizontalScroll - drive a horizontally scrolling strip.
+ *
+ * Returns which directions still have content off-screen, so a strip can render
+ * an honest affordance (edge fade, arrow button) instead of leaving the user to
+ * guess that more exists past the edge, plus a `scrollByPage` that advances
+ * roughly one visible width at a time.
+ *
+ * It also maps vertical wheel deltas onto the horizontal axis, because a strip
+ * with no vertical overflow otherwise swallows the gesture and does nothing on
+ * a mouse wheel or a trackpad flick.
+ *
+ * ```tsx
+ * const ref = useRef<HTMLDivElement>(null);
+ * const { canScrollLeft, canScrollRight, scrollByPage } = useHorizontalScroll(ref);
+ * ```
+ */
+
+import { useCallback, useEffect, useState, type RefObject } from 'react';
+
+/** Absorbs fractional scrollLeft values so an end-stop reads as "at the end". */
+const EDGE_SLACK_PX = 2;
+
+export interface HorizontalScrollState {
+	/** Content exists to the left of the viewport. */
+	canScrollLeft: boolean;
+	/** Content exists to the right of the viewport. */
+	canScrollRight: boolean;
+	/** Scroll roughly one visible width in the given direction. */
+	scrollByPage: (direction: 'left' | 'right') => void;
+}
+
+export function useHorizontalScroll(
+	ref: RefObject<HTMLElement | null>,
+	/** Re-measure when this changes (item count, filter, etc.). */
+	resetKey?: unknown
+): HorizontalScrollState {
+	const [canScrollLeft, setCanScrollLeft] = useState(false);
+	const [canScrollRight, setCanScrollRight] = useState(false);
+
+	useEffect(() => {
+		const element = ref.current;
+		if (!element) return;
+
+		const measure = () => {
+			const maxScrollLeft = element.scrollWidth - element.clientWidth;
+			setCanScrollLeft(element.scrollLeft > EDGE_SLACK_PX);
+			setCanScrollRight(element.scrollLeft < maxScrollLeft - EDGE_SLACK_PX);
+		};
+		measure();
+
+		element.addEventListener('scroll', measure, { passive: true });
+
+		// A strip has no vertical overflow of its own, so a wheel gesture over it
+		// would otherwise scroll an ancestor (or nothing at all).
+		const onWheel = (event: WheelEvent) => {
+			const delta = Math.abs(event.deltaX) > Math.abs(event.deltaY) ? event.deltaX : event.deltaY;
+			if (delta === 0) return;
+			const maxScrollLeft = element.scrollWidth - element.clientWidth;
+			if (maxScrollLeft <= 0) return;
+			event.preventDefault();
+			element.scrollLeft = Math.max(0, Math.min(maxScrollLeft, element.scrollLeft + delta));
+		};
+		element.addEventListener('wheel', onWheel, { passive: false });
+
+		// jsdom has no layout engine and no ResizeObserver by default; skip the
+		// observer rather than throwing so component tests render without a polyfill.
+		const observer =
+			typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(() => measure());
+		observer?.observe(element);
+
+		return () => {
+			element.removeEventListener('scroll', measure);
+			element.removeEventListener('wheel', onWheel);
+			observer?.disconnect();
+		};
+	}, [ref, resetKey]);
+
+	const scrollByPage = useCallback(
+		(direction: 'left' | 'right') => {
+			const element = ref.current;
+			if (!element) return;
+			const distance = Math.max(element.clientWidth * 0.8, 1);
+			element.scrollBy({
+				left: direction === 'left' ? -distance : distance,
+				behavior: 'smooth',
+			});
+		},
+		[ref]
+	);
+
+	return { canScrollLeft, canScrollRight, scrollByPage };
+}

--- a/src/shared/agentConstants.ts
+++ b/src/shared/agentConstants.ts
@@ -25,6 +25,7 @@ export const DEFAULT_CONTEXT_WINDOWS: Partial<Record<AgentId, number>> = {
 	'qwen3-coder': 262144, // Qwen3-Coder native 256K context window
 	omp: 200000, // Oh My Pi (fallback until runtime-specific reporting lands)
 	grok: 500000, // Grok CLI (grok-4.5 default, per ~/.grok/models_cache.json)
+	antigravity: 1048576, // Antigravity CLI drives Gemini 3.x models (1M token window)
 	terminal: 0, // Terminal has no context window
 };
 

--- a/src/shared/agentConstants.ts
+++ b/src/shared/agentConstants.ts
@@ -20,6 +20,7 @@ export const DEFAULT_CONTEXT_WINDOWS: Partial<Record<AgentId, number>> = {
 	opencode: 128000, // OpenCode (depends on model, 128k is conservative default)
 	'factory-droid': 200000, // Factory Droid (varies by model, defaults to Claude Opus)
 	'copilot-cli': 200000, // Copilot-CLI (varies by model, defaults to Claude Sonnet)
+	antigravity: 1048576, // Antigravity CLI drives Gemini 3.x models (1M token window)
 	terminal: 0, // Terminal has no context window
 };
 

--- a/src/shared/agentIds.ts
+++ b/src/shared/agentIds.ts
@@ -18,6 +18,7 @@ export const AGENT_IDS = [
 	'claude-code',
 	'codex',
 	'gemini-cli',
+	'antigravity',
 	'qwen3-coder',
 	'opencode',
 	'factory-droid',

--- a/src/shared/agentMetadata.ts
+++ b/src/shared/agentMetadata.ts
@@ -152,6 +152,66 @@ export function isBetaAgent(agentId: AgentId | string): boolean {
 }
 
 /**
+ * Presentation metadata for the provider pickers.
+ */
+export interface AgentPickerMeta {
+	/** One-line pitch rendered under the provider name. */
+	description: string;
+	/** Provider brand color, used for the tile logo and the selection ring. */
+	brandColor: string;
+}
+
+/**
+ * Which providers a user may pick, in the order every picker renders them.
+ *
+ * This is the SINGLE source of truth behind all three provider pickers: the New
+ * Agent modal's list, the New Agent Wizard's tile strip, and the Group Chat
+ * moderator dropdown. They used to keep their own hand-written arrays, which is
+ * how Grok and Qwen3 Coder shipped selectable in the New Agent modal yet absent
+ * from the wizard and un-pickable as a moderator for months.
+ *
+ * `null` means the agent is never offered to the user: `terminal` is internal
+ * plumbing, and `gemini-cli` is retained only for type and back-compat reasons
+ * (superseded by Antigravity).
+ *
+ * The record is keyed by AgentId, so adding an id to AGENT_IDS does not compile
+ * until a decision is made here. Key order is picker order - the wizard and the
+ * moderator dropdown both auto-select the first entry that is installed.
+ */
+export const AGENT_PICKER_META: Record<AgentId, AgentPickerMeta | null> = {
+	'claude-code': { description: "Anthropic's AI coding assistant", brandColor: '#D97757' },
+	codex: { description: "OpenAI's AI coding assistant", brandColor: '#10A37F' },
+	antigravity: { description: "Google's agentic coding CLI", brandColor: '#4285F4' },
+	opencode: { description: 'Open-source AI coding assistant', brandColor: '#F97316' },
+	'factory-droid': { description: "Factory's AI coding assistant", brandColor: '#3B82F6' },
+	'copilot-cli': { description: "GitHub's AI coding assistant", brandColor: '#24292F' },
+	grok: { description: "xAI's AI coding assistant", brandColor: '#B4B8C0' },
+	'qwen3-coder': { description: "Alibaba's AI coding assistant", brandColor: '#615CED' },
+	hermes: { description: "Nous Research's AI coding assistant", brandColor: '#2323FF' },
+	pi: { description: 'Your own agent harness', brandColor: '#E4E4E7' },
+	omp: { description: 'Multi-model coding agent', brandColor: '#9B4DFF' },
+	terminal: null,
+	'gemini-cli': null,
+};
+
+/**
+ * Every agent a user may pick as a provider, in picker order.
+ * Derived from AGENT_PICKER_META so the two can never disagree.
+ */
+export const PICKABLE_AGENT_IDS: readonly AgentId[] = (
+	Object.keys(AGENT_PICKER_META) as AgentId[]
+).filter((id) => AGENT_PICKER_META[id] !== null);
+
+/**
+ * Picker metadata for an agent, or null when it is never offered (unknown ids
+ * included, so a stale persisted toolType can't crash a picker).
+ */
+export function getAgentPickerMeta(agentId: AgentId | string): AgentPickerMeta | null {
+	if (!Object.prototype.hasOwnProperty.call(AGENT_PICKER_META, agentId)) return null;
+	return AGENT_PICKER_META[agentId as AgentId];
+}
+
+/**
  * How a provider's CLI is re-authenticated.
  *
  * `binary` + `args` form the shell command Maestro runs in the reauthentication
@@ -183,6 +243,9 @@ const AGENT_LOGIN_COMMANDS: Record<AgentId, AgentLoginCommand | null> = {
 	opencode: { binary: 'opencode', args: 'auth login' },
 	'factory-droid': { binary: 'droid', args: '', followUp: '/login' },
 	'copilot-cli': { binary: 'copilot', args: 'login' },
+	// Antigravity has no login subcommand: headless runs reuse the credentials
+	// cached by one interactive sign-in, so the bare TUI is the whole flow.
+	antigravity: { binary: 'agy', args: '' },
 	grok: { binary: 'grok', args: 'login' },
 	hermes: null,
 	pi: null,

--- a/src/shared/agentMetadata.ts
+++ b/src/shared/agentMetadata.ts
@@ -19,6 +19,7 @@ export const AGENT_DISPLAY_NAMES: Record<AgentId, string> = {
 	'claude-code': 'Claude Code',
 	codex: 'Codex',
 	'gemini-cli': 'Gemini CLI',
+	antigravity: 'Antigravity CLI',
 	'qwen3-coder': 'Qwen3 Coder',
 	opencode: 'OpenCode',
 	'factory-droid': 'Factory Droid',
@@ -140,6 +141,7 @@ export const BETA_AGENTS: ReadonlySet<AgentId> = new Set<AgentId>([
 	'qwen3-coder',
 	'omp',
 	'grok',
+	'antigravity',
 ]);
 
 /**

--- a/src/shared/agentMetadata.ts
+++ b/src/shared/agentMetadata.ts
@@ -19,6 +19,7 @@ export const AGENT_DISPLAY_NAMES: Record<AgentId, string> = {
 	'claude-code': 'Claude Code',
 	codex: 'Codex',
 	'gemini-cli': 'Gemini CLI',
+	antigravity: 'Antigravity CLI',
 	'qwen3-coder': 'Qwen3 Coder',
 	opencode: 'OpenCode',
 	'factory-droid': 'Factory Droid',
@@ -72,6 +73,7 @@ export const BETA_AGENTS: ReadonlySet<AgentId> = new Set<AgentId>([
 	'opencode',
 	'factory-droid',
 	'copilot-cli',
+	'antigravity',
 ]);
 
 /**


### PR DESCRIPTION
Closes #1381

Adds Google's Antigravity CLI (`agy`) as a first-class agent provider. This also resolves the dangling `superseded by Antigravity` note that has sat on the hidden `gemini-cli` definition since May.

## What's wired

The full [AGENT_SUPPORT.md](https://github.com/RunMaestro/Maestro/blob/main/AGENT_SUPPORT.md) checklist: agent id, definition, capabilities, display name, beta flag, context window, binary path probing (macOS/Linux `~/.local/bin/agy`, Windows `%LOCALAPPDATA%\agy\bin\agy.exe`), icon, and the new-instance agent list.

| Aspect | Value |
| --- | --- |
| Binary | `agy` |
| Headless | `-p` |
| JSON output | `--output-format stream-json` |
| Resume | `--conversation <id>` |
| Session id field | `conversation_id` |
| Model / effort | `--model <slug>` / `--effort low\|medium\|high` |
| Auto-approve | `--dangerously-skip-permissions` |

## Why a bespoke parser

Antigravity doesn't follow the Claude-family `{"type":"assistant",...}` shape, so it can't be a `ClaudeOutputParser` subclass the way Qwen is. It discriminates on an `event` key and nests the payload under a property of the same name:

```json
{"event":"init","init":{"cwd":"...","model":"...","tools":[...]}}
{"event":"step_update","step_update":{"conversation_id":"...","state":"ACTIVE","step_type":"agent_response","text_delta":"..."}}
{"event":"result","result":{"conversation_id":"...","status":"...","response":"...","usage":{...}}}
```

`AntigravityOutputParser` maps `step_update` text deltas to partial text, tool steps to `tool_use`, and normalizes the snake_case token metrics (`input_tokens` / `output_tokens` / `thinking_tokens` / `cache_read_tokens`). A `result` envelope carrying `error` is reclassified as an error event: `error` is documented as present *only* on failure, which is a firmer signal than the free-form `status` string, so nothing is inferred from status values the docs never enumerate.

## Two headless footguns handled in the definition

- **Batch runs pass `--dangerously-skip-permissions`.** Without it the CLI soft-denies shell commands, so a run stalls on its first terminal tool call rather than failing loudly. `buildAgentArgs` already drops `batchModeArgs` in read-only mode, so read-only still gets `--sandbox` and no permission skip.
- **`--print-timeout` defaults to 5m**, which silently cuts off longer agent runs. Exposed as a "Headless Timeout" config option defaulting to 30m.

## Deliberately conservative capabilities

Anything the docs don't state outright is left `false` rather than guessed at:

- `supportsSessionStorage: false` - the on-disk conversation format is undocumented.
- `supportsImageInput: false` - no documented attachment flag.
- `supportsReadOnlyMode: false` - headless mode auto-allows reading **and writing** files inside the active workspace; `--sandbox` only restricts terminal commands. There is no flag that makes the agent truly read-only.
- `supportsSlashCommands: false` - slash commands are a TUI-only affordance.
- `supportsThinkingDisplay: false` - `thinking_tokens` are counted, but no reasoning-text step type is documented.

## Honest caveat

**This is built against the published headless contract, not a captured live run.** I don't have `agy` installed to verify byte-for-byte against real output, which is why it ships as beta (`BETA_AGENTS`). The event shape, flags, and usage field names all come from [antigravity.google/docs/cli/headless](https://antigravity.google/docs/cli/headless). If anything drifts, the parser and the definition are the two places to touch, and the schema is documented inline in both.

Auth note for testers: headless runs reuse cached credentials, so you need to sign in once from an interactive `agy` session on the machine first.

## Testing

- New: `src/__tests__/main/parsers/antigravity-output-parser.test.ts` (13 tests) covering each event type, usage normalization, failed-result reclassification, error-pattern classification, non-JSON passthrough, and exit-code handling.
- New: 5 cases in `agent-args.test.ts` asserting the composed command line off the real definition, including that read-only drops the permission skip and that the 30m timeout applies with no user config.
- Updated hardcoded agent/parser counts in `detector.test.ts` and `parsers/index.test.ts`.
- `npm run lint`, `npm run lint:eslint`, and the full suite (1170 files, 32,952 tests) pass locally on macOS. Both CI matrix legs still need to confirm.

## Docs

`AGENT_SUPPORT.md` gains a full Antigravity reference section (flags, event schema, limitations, sources); the stale "Gemini CLI Planned" section now points at it. `CLAUDE.md`'s supported-agents table gains the row.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added beta support for Antigravity CLI, including detection, conversation resumption, streaming output, model and reasoning controls, and usage metrics.
  * Added automatic discovery of Antigravity installations across supported platforms.
  * Centralized provider selection across the New Agent modal, wizard, and group-chat moderator controls.
  * Added a horizontally scrollable provider strip with navigation controls and new provider logos.
* **Bug Fixes**
  * Improved handling of authentication, quota, timeout, network, tool, and CLI errors.
  * Improved reporting of streaming command failures without duplicate or misleading results.
* **Documentation**
  * Added Antigravity setup, authentication, capabilities, limitations, and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->