### PR TITLE
fix(execfile): unambiguous options detection, forward env on stdin path

### DIFF
--- a/src/__tests__/main/utils/execFile.test.ts
+++ b/src/__tests__/main/utils/execFile.test.ts
@@ -92,6 +92,24 @@ describe('execFile.ts', () => {
 		// the child_process mock only replaces execFile, not spawn.
 		const NODE = process.execPath;
 
+		// A lone `{ input }` with no other fields is a real call shape (git.ts
+		// pipes gist content to `gh` this way) - the discriminator fix for the
+		// legacy-env-named-"input" collision must not break it.
+		it('treats a lone { input } as ExecOptions and delivers it to stdin', async () => {
+			const { execFileNoThrow } = await import('../../../main/utils/execFile');
+
+			const result = await execFileNoThrow(
+				NODE,
+				['-e', 'process.stdin.on("data", (d) => process.stdout.write(d))'],
+				undefined,
+				{
+					input: 'hello from stdin',
+				}
+			);
+
+			expect(result.stdout).toBe('hello from stdin');
+		});
+
 		// Regression: when `input` is set, execFileNoThrow hands off to
 		// execFileWithInput, which never received or forwarded `env` - a caller
 		// passing { input, env } silently got process.env in the child instead
@@ -310,6 +328,60 @@ describe('execFile.ts', () => {
 					'mycmd',
 					[],
 					expect.objectContaining({ env: { MY_VAR: 'value' }, timeout: 5000 }),
+					expect.any(Function)
+				);
+			});
+
+			// Regression (CodeRabbit, PR #1383): a lone `{ input: 'x' }` is a real
+			// ExecOptions call (git.ts uses exactly this shape to pipe gist content
+			// to stdin), but `{ input: 'x', PATH: '/bin' }` is a legacy env dict that
+			// happens to define a variable called `input` - the extra PATH key is
+			// what tells them apart. Getting this wrong would silently feed the
+			// caller's PATH override to the child's stdin instead of its environment.
+			it('treats a legacy env dict with a var literally named "input" as the whole environment, not stdin content', async () => {
+				mockExecFile.mockImplementation(
+					(_cmd: string, _args: readonly string[], _options: any, callback?: any) => {
+						callback?.(null, 'output', '');
+						return {} as any;
+					}
+				);
+
+				const { execFileNoThrow } = await import('../../../main/utils/execFile');
+				const legacyEnv = { input: 'not stdin content', PATH: '/custom/path' };
+				await execFileNoThrow('mycmd', [], '/cwd', legacyEnv);
+
+				// Legacy interpretation goes through execFileAsync (mocked here), not
+				// the spawn-based stdin path - if this were misread as ExecOptions.input,
+				// mockExecFile would never be called at all.
+				expect(mockExecFile).toHaveBeenCalledWith(
+					'mycmd',
+					[],
+					expect.objectContaining({ env: legacyEnv }),
+					expect.any(Function)
+				);
+			});
+
+			// Regression (Greptile, PR #1383): `{ timeout: undefined }` is valid
+			// ExecOptions (equivalent to omitting timeout), but the key is still
+			// present, so a value-type check alone can't tell it apart from "key
+			// absent". The all-keys-known check recognizes it regardless of value.
+			it('still recognizes ExecOptions when a known field is explicitly undefined', async () => {
+				mockExecFile.mockImplementation(
+					(_cmd: string, _args: readonly string[], _options: any, callback?: any) => {
+						callback?.(null, 'output', '');
+						return {} as any;
+					}
+				);
+
+				const { execFileNoThrow } = await import('../../../main/utils/execFile');
+				await execFileNoThrow('mycmd', [], '/cwd', { timeout: undefined });
+
+				// If misread as legacy, env would be the literal { timeout: undefined }
+				// object instead of undefined (inherit the parent environment).
+				expect(mockExecFile).toHaveBeenCalledWith(
+					'mycmd',
+					[],
+					expect.objectContaining({ env: undefined }),
 					expect.any(Function)
 				);
 			});

--- a/src/__tests__/main/utils/execFile.test.ts
+++ b/src/__tests__/main/utils/execFile.test.ts
@@ -87,6 +87,29 @@ describe('execFile.ts', () => {
 		});
 	});
 
+	describe('execFileNoThrow with input (stdin path)', () => {
+		// Spawns a real short-lived node process, same as execFileStreaming below -
+		// the child_process mock only replaces execFile, not spawn.
+		const NODE = process.execPath;
+
+		// Regression: when `input` is set, execFileNoThrow hands off to
+		// execFileWithInput, which never received or forwarded `env` - a caller
+		// passing { input, env } silently got process.env in the child instead
+		// of the environment it asked for.
+		it('passes env through to the spawned process', async () => {
+			const { execFileNoThrow } = await import('../../../main/utils/execFile');
+
+			const result = await execFileNoThrow(
+				NODE,
+				['-e', 'process.stdout.write(process.env.MAESTRO_TEST_VAR || "MISSING")'],
+				undefined,
+				{ input: 'unused stdin content', env: { MAESTRO_TEST_VAR: 'present' } }
+			);
+
+			expect(result.stdout).toBe('present');
+		});
+	});
+
 	describe('execFileStreaming', () => {
 		// These spawn real short-lived node processes: the child_process mock above
 		// only replaces execFile, so spawn is the genuine implementation.
@@ -219,6 +242,74 @@ describe('execFile.ts', () => {
 					expect.objectContaining({
 						env: customEnv,
 					}),
+					expect.any(Function)
+				);
+			});
+
+			// Regression: the legacy/ExecOptions discriminator used to check only
+			// whether a key named `input`/`timeout`/`env` was present, not its
+			// value's shape. A real environment variable can be named any of
+			// those, so a plain legacy env dict containing one got misread as the
+			// structured form and had its actual entries dropped or mangled.
+			it('treats a legacy env dict with a var literally named "timeout" as the whole environment', async () => {
+				mockExecFile.mockImplementation(
+					(_cmd: string, _args: readonly string[], _options: any, callback?: any) => {
+						callback?.(null, 'output', '');
+						return {} as any;
+					}
+				);
+
+				const { execFileNoThrow } = await import('../../../main/utils/execFile');
+				// A real env var's value is always a string, never the number
+				// ExecOptions.timeout expects.
+				const legacyEnv = { timeout: '30', PATH: '/custom/path' };
+				await execFileNoThrow('mycmd', [], '/cwd', legacyEnv);
+
+				expect(mockExecFile).toHaveBeenCalledWith(
+					'mycmd',
+					[],
+					expect.objectContaining({ env: legacyEnv, timeout: undefined }),
+					expect.any(Function)
+				);
+			});
+
+			it('treats a legacy env dict with a var literally named "env" as the whole environment', async () => {
+				mockExecFile.mockImplementation(
+					(_cmd: string, _args: readonly string[], _options: any, callback?: any) => {
+						callback?.(null, 'output', '');
+						return {} as any;
+					}
+				);
+
+				const { execFileNoThrow } = await import('../../../main/utils/execFile');
+				// A real env var's value is always a string, never the object
+				// ExecOptions.env expects.
+				const legacyEnv = { env: 'production', PATH: '/custom/path' };
+				await execFileNoThrow('mycmd', [], '/cwd', legacyEnv);
+
+				expect(mockExecFile).toHaveBeenCalledWith(
+					'mycmd',
+					[],
+					expect.objectContaining({ env: legacyEnv }),
+					expect.any(Function)
+				);
+			});
+
+			it('still recognizes the structured ExecOptions form when env is a real object', async () => {
+				mockExecFile.mockImplementation(
+					(_cmd: string, _args: readonly string[], _options: any, callback?: any) => {
+						callback?.(null, 'output', '');
+						return {} as any;
+					}
+				);
+
+				const { execFileNoThrow } = await import('../../../main/utils/execFile');
+				await execFileNoThrow('mycmd', [], '/cwd', { env: { MY_VAR: 'value' }, timeout: 5000 });
+
+				expect(mockExecFile).toHaveBeenCalledWith(
+					'mycmd',
+					[],
+					expect.objectContaining({ env: { MY_VAR: 'value' }, timeout: 5000 }),
 					expect.any(Function)
 				);
 			});

--- a/src/main/utils/execFile.ts
+++ b/src/main/utils/execFile.ts
@@ -81,16 +81,27 @@ export function needsWindowsShell(command: string): boolean {
 	return !hasExtension;
 }
 
+/** The only field names `ExecOptions` defines. */
+const EXEC_OPTIONS_FIELDS = new Set(['input', 'timeout', 'env']);
+
 /**
  * Distinguish the legacy `options: NodeJS.ProcessEnv` signature from the
  * structured `ExecOptions` form. Key presence alone is ambiguous - a real
- * environment variable can be named `input`, `timeout`, or `env` - so this
- * also checks the value has the shape ExecOptions actually uses: a number
- * for `timeout`, an object for `env`. `process.env` values are always
- * strings, so a legacy env dict can never satisfy either check, no matter
- * what its keys are named. `input` alone stays a presence+type check (both
- * a real ExecOptions.input and a same-named env var are strings), matching
- * the pre-existing behavior for that one case.
+ * environment variable can be named `input`, `timeout`, or `env` - and value
+ * type alone isn't enough either: a real ExecOptions.input and a same-named
+ * env var are both strings, and `{ timeout: undefined }` is valid
+ * ExecOptions that no type check can distinguish from "key absent".
+ *
+ * What actually is unambiguous: every real caller's legacy env dict carries
+ * other environment variables alongside anything that happens to collide
+ * with a reserved name (PATH, HOME, ... - checked against every call site in
+ * this codebase). So if literally every key present is one of the three
+ * ExecOptions fields, it cannot be a real environment - a lone `{ input:
+ * 'x' }` is ExecOptions, but `{ input: 'x', PATH: '/bin' }` is a legacy env
+ * dict that happens to define a var called `input`. Combined with the
+ * value-shape checks (which still catch the case where an ExecOptions value
+ * is typed but sits alongside a field this function doesn't know about) that
+ * closes the gap for both known collision shapes.
  */
 function resolveExecOptions(options: ExecOptions | NodeJS.ProcessEnv | undefined): {
 	env: NodeJS.ProcessEnv | undefined;
@@ -102,10 +113,13 @@ function resolveExecOptions(options: ExecOptions | NodeJS.ProcessEnv | undefined
 	}
 
 	const opts = options as ExecOptions;
+	const keys = Object.keys(opts);
+	const allKeysAreExecOptionsFields =
+		keys.length > 0 && keys.every((k) => EXEC_OPTIONS_FIELDS.has(k));
 	const isExecOptions =
+		allKeysAreExecOptionsFields ||
 		('timeout' in opts && typeof opts.timeout === 'number') ||
-		('env' in opts && opts.env !== null && typeof opts.env === 'object') ||
-		('input' in opts && typeof opts.input === 'string');
+		('env' in opts && opts.env !== null && typeof opts.env === 'object');
 
 	if (isExecOptions) {
 		return { env: opts.env, input: opts.input, timeout: opts.timeout };

--- a/src/main/utils/execFile.ts
+++ b/src/main/utils/execFile.ts
@@ -82,6 +82,39 @@ export function needsWindowsShell(command: string): boolean {
 }
 
 /**
+ * Distinguish the legacy `options: NodeJS.ProcessEnv` signature from the
+ * structured `ExecOptions` form. Key presence alone is ambiguous - a real
+ * environment variable can be named `input`, `timeout`, or `env` - so this
+ * also checks the value has the shape ExecOptions actually uses: a number
+ * for `timeout`, an object for `env`. `process.env` values are always
+ * strings, so a legacy env dict can never satisfy either check, no matter
+ * what its keys are named. `input` alone stays a presence+type check (both
+ * a real ExecOptions.input and a same-named env var are strings), matching
+ * the pre-existing behavior for that one case.
+ */
+function resolveExecOptions(options: ExecOptions | NodeJS.ProcessEnv | undefined): {
+	env: NodeJS.ProcessEnv | undefined;
+	input: string | undefined;
+	timeout: number | undefined;
+} {
+	if (!options) {
+		return { env: undefined, input: undefined, timeout: undefined };
+	}
+
+	const opts = options as ExecOptions;
+	const isExecOptions =
+		('timeout' in opts && typeof opts.timeout === 'number') ||
+		('env' in opts && opts.env !== null && typeof opts.env === 'object') ||
+		('input' in opts && typeof opts.input === 'string');
+
+	if (isExecOptions) {
+		return { env: opts.env, input: opts.input, timeout: opts.timeout };
+	}
+	// Legacy signature: the whole object is the env to use.
+	return { env: options as NodeJS.ProcessEnv, input: undefined, timeout: undefined };
+}
+
+/**
  * Safely execute a command without shell injection vulnerabilities
  * Uses execFile instead of exec to prevent shell interpretation
  *
@@ -99,23 +132,7 @@ export async function execFileNoThrow(
 	cwd?: string,
 	options?: ExecOptions | NodeJS.ProcessEnv
 ): Promise<ExecResult> {
-	// Handle backward compatibility: options can be env (old signature) or ExecOptions (new)
-	let env: NodeJS.ProcessEnv | undefined;
-	let input: string | undefined;
-	let timeout: number | undefined;
-
-	if (options) {
-		if ('input' in options || 'timeout' in options || 'env' in options) {
-			// New signature with ExecOptions
-			const execOpts = options as ExecOptions;
-			input = execOpts.input;
-			timeout = execOpts.timeout;
-			env = execOpts.env;
-		} else {
-			// Old signature with just env
-			env = options as NodeJS.ProcessEnv;
-		}
-	}
+	const { env, input, timeout } = resolveExecOptions(options);
 
 	// If input is provided, use spawn instead of execFile to write to stdin
 	if (input !== undefined) {

--- a/src/main/utils/execFile.ts
+++ b/src/main/utils/execFile.ts
@@ -81,8 +81,16 @@ export function needsWindowsShell(command: string): boolean {
 	return !hasExtension;
 }
 
-/** The only field names `ExecOptions` defines. */
-const EXEC_OPTIONS_FIELDS = new Set(['input', 'timeout', 'env']);
+/**
+ * Keyed by `keyof ExecOptions` so adding a field to the interface without
+ * listing it here is a compile error, not a silent misclassification.
+ */
+const EXEC_OPTIONS_FIELD_NAMES: Record<keyof ExecOptions, true> = {
+	input: true,
+	timeout: true,
+	env: true,
+};
+const EXEC_OPTIONS_FIELDS = new Set(Object.keys(EXEC_OPTIONS_FIELD_NAMES));
 
 /**
  * Distinguish the legacy `options: NodeJS.ProcessEnv` signature from the


### PR DESCRIPTION
## Problem

CodeRabbit flagged a bug in `execFile.ts`'s `execFileNoThrow` during review of [#1317](https://github.com/RunMaestro/Maestro/issues/1317) (already merged), which added an `env` field to `ExecOptions`:

- The legacy/`ExecOptions` signature discriminator only checked whether a key named `input`/`timeout`/`env` was present, not its value's shape. A real environment variable can be named any of those, so a legacy bare-env call containing one got misread as the structured form, and its actual entries got dropped or mangled.

Follow-up review also caught that `{ timeout: undefined }` (valid `ExecOptions`) was still misread as a legacy env dict when relying on value-type checks alone.

## What Changed

`resolveExecOptions()` extracts signature detection into a pure function. Key presence alone is ambiguous (a real env var can be named `input`/`timeout`/`env`), and value type alone isn't enough either (`{ timeout: undefined }` is valid `ExecOptions`). The discriminator treats "every key present is a known `ExecOptions` field" as structured options - a real legacy env dict always carries neighbours like `PATH`/`HOME` - and keeps value-shape checks as a secondary signal.

`EXEC_OPTIONS_FIELDS` is derived from `Record<keyof ExecOptions, true>` so adding a field to the interface without updating the set is a compile error, not a silent misclassification.

## Testing

* Added signature-discrimination regression tests (reserved-name collisions, `{ timeout: undefined }`, structured form validation).
* Kept a real-process stdin+env regression test as a guard on that existing path (not new behavior in this PR).
* Verified red against pre-fix code.
* Full test suite passing, `tsc` and `eslint` clean.