### PR TITLE
fix(symphony): close three path traversal issues at the IPC boundary

### DIFF
--- a/src/__tests__/integration/symphony.integration.test.ts
+++ b/src/__tests__/integration/symphony.integration.test.ts
@@ -23,6 +23,7 @@ import {
 	registerSymphonyHandlers,
 	SymphonyHandlerDependencies,
 } from '../../main/ipc/handlers/symphony';
+import { toSafeDocumentFileName } from '../../main/ipc/handlers/symphony/shared';
 import {
 	REGISTRY_CACHE_TTL_MS,
 	ISSUES_CACHE_TTL_MS,
@@ -2667,6 +2668,82 @@ error: failed to push some refs to 'https://github.com/owner/protected-repo.git'
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('GitHub');
+		});
+
+		// ----------------------------------------------------------------------
+		// contributionId is joined into the Symphony directory by startContribution
+		// and createDraftPR. The cases above only ever passed a clean ID, so these
+		// sinks had no coverage.
+		// ----------------------------------------------------------------------
+
+		it('should reject a contributionId containing traversal in startContribution', async () => {
+			const result = (await invokeHandler(handlers, 'symphony:startContribution', {
+				contributionId: '../../../evil',
+				sessionId: 'session-id-traversal',
+				repoSlug: 'owner/repo',
+				issueNumber: 1,
+				issueTitle: 'ID Traversal Test',
+				localPath: path.join(testTempDir, 'id-traversal-repo'),
+				documentPaths: [],
+			})) as { success: boolean; error?: string };
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Invalid contribution ID');
+		});
+
+		it('should reject a contributionId containing a separator in createDraftPR', async () => {
+			const result = (await invokeHandler(handlers, 'symphony:createDraftPR', {
+				contributionId: '../../etc/passwd',
+			})) as { success: boolean; error?: string };
+
+			expect(result.success).toBe(false);
+			// Asserting the specific message matters here: without validation this
+			// handler still fails, but with "metadata not found" after it has
+			// already built and read an out-of-tree path.
+			expect(result.error).toContain('Invalid contribution ID');
+		});
+
+		it('should accept the generated contribution ID formats', async () => {
+			// Positive control. A valid ID must pass validation and reach the real
+			// logic, otherwise the rejection tests above could pass simply because
+			// every ID is refused.
+			for (const id of ['contrib_abc123_def456', 'manual_42_1700000000000']) {
+				const result = (await invokeHandler(handlers, 'symphony:createDraftPR', {
+					contributionId: id,
+				})) as { success: boolean; error?: string };
+
+				expect(result.error).not.toContain('Invalid contribution ID');
+				expect(result.error).toContain('metadata not found');
+			}
+		});
+
+		// ----------------------------------------------------------------------
+		// doc.name is joined onto the documents cache directory when an external
+		// document is downloaded. validateContributionParams checks doc.path but
+		// never checked doc.name.
+		// ----------------------------------------------------------------------
+
+		// doc.name is the link text of a markdown link in the issue body, and it is
+		// joined onto the documents cache directory when an external document is
+		// downloaded. It is reduced to a bare file name at that join, so these
+		// exercise the reduction directly.
+		it('should reduce traversal in a document name to a bare file name', () => {
+			expect(toSafeDocumentFileName('../../../evil.json')).toBe('evil.json');
+			expect(toSafeDocumentFileName('..\\..\\evil.json')).toBe('evil.json');
+			expect(toSafeDocumentFileName('/etc/passwd')).toBe('passwd');
+			// Nothing usable is left, so the document is skipped rather than written.
+			expect(toSafeDocumentFileName('../../..')).toBeNull();
+			expect(toSafeDocumentFileName('.')).toBeNull();
+			expect(toSafeDocumentFileName('')).toBeNull();
+		});
+
+		it('should keep real issue-body document names working', () => {
+			// Regression guard. An ordinary markdown link such as
+			// [docs/architecture.md](https://...) yields a name with a separator,
+			// which must still resolve to a usable file name rather than be refused.
+			expect(toSafeDocumentFileName('docs/architecture.md')).toBe('architecture.md');
+			expect(toSafeDocumentFileName('My Design Doc.md')).toBe('My Design Doc.md');
+			expect(toSafeDocumentFileName('spec.md')).toBe('spec.md');
 		});
 	});
 

--- a/src/__tests__/integration/symphony.integration.test.ts
+++ b/src/__tests__/integration/symphony.integration.test.ts
@@ -23,7 +23,10 @@ import {
 	registerSymphonyHandlers,
 	SymphonyHandlerDependencies,
 } from '../../main/ipc/handlers/symphony';
-import { toSafeDocumentFileName } from '../../main/ipc/handlers/symphony/shared';
+import {
+	toSafeDocumentFileName,
+	uniqueDocumentFileName,
+} from '../../main/ipc/handlers/symphony/shared';
 import {
 	REGISTRY_CACHE_TTL_MS,
 	ISSUES_CACHE_TTL_MS,
@@ -2735,6 +2738,20 @@ error: failed to push some refs to 'https://github.com/owner/protected-repo.git'
 			expect(toSafeDocumentFileName('../../..')).toBeNull();
 			expect(toSafeDocumentFileName('.')).toBeNull();
 			expect(toSafeDocumentFileName('')).toBeNull();
+		});
+
+		it('should not let two references collide onto one file name', () => {
+			// docs/architecture.md and spec/architecture.md both reduce to
+			// architecture.md. Writing both would leave only the second.
+			const used = new Set<string>();
+			expect(uniqueDocumentFileName('architecture.md', used)).toBe('architecture.md');
+			expect(uniqueDocumentFileName('architecture.md', used)).toBe('architecture-2.md');
+			expect(uniqueDocumentFileName('architecture.md', used)).toBe('architecture-3.md');
+			// Matching is case-insensitive, since the destination may be too.
+			expect(uniqueDocumentFileName('ARCHITECTURE.MD', used)).toBe('ARCHITECTURE-4.MD');
+			// An extensionless name still disambiguates.
+			expect(uniqueDocumentFileName('README', used)).toBe('README');
+			expect(uniqueDocumentFileName('README', used)).toBe('README-2');
 		});
 
 		it('should keep real issue-body document names working', () => {

--- a/src/__tests__/main/ipc/handlers/symphony.test.ts
+++ b/src/__tests__/main/ipc/handlers/symphony.test.ts
@@ -3272,6 +3272,14 @@ describe('Symphony IPC handlers', () => {
 					JSON.stringify(createStateWithActiveContributions())
 				);
 				vi.mocked(fs.rm).mockResolvedValue(undefined);
+				// A real contribution path is a clone, so the directory has a .git
+				// entry and an origin pointing at the contribution's repository.
+				vi.mocked(fs.access).mockResolvedValue(undefined);
+				vi.mocked(execFileNoThrow).mockResolvedValue({
+					stdout: 'https://github.com/owner/repo.git',
+					stderr: '',
+					exitCode: 0,
+				} as never);
 
 				const handler = getCancelHandler();
 				await handler!({} as any, 'contrib_to_cancel', true);
@@ -3281,6 +3289,23 @@ describe('Symphony IPC handlers', () => {
 					recursive: true,
 					force: true,
 				});
+			});
+
+			it("should refuse to remove a path that is not this contribution's clone", async () => {
+				vi.mocked(fs.readFile).mockResolvedValue(
+					JSON.stringify(createStateWithActiveContributions())
+				);
+				vi.mocked(fs.rm).mockResolvedValue(undefined);
+				// No .git entry, so the stored path is an ordinary directory rather
+				// than a clone and must not be recursively removed.
+				vi.mocked(fs.access).mockRejectedValue(new Error('ENOENT'));
+
+				const handler = getCancelHandler();
+				const result = await handler!({} as any, 'contrib_to_cancel', true);
+
+				expect(fs.rm).not.toHaveBeenCalled();
+				// The contribution is still cancelled, only the deletion is skipped.
+				expect(result.cancelled).toBe(true);
 			});
 
 			it('should preserve local directory when cleanup=false', async () => {

--- a/src/__tests__/main/ipc/handlers/symphony.test.ts
+++ b/src/__tests__/main/ipc/handlers/symphony.test.ts
@@ -3308,6 +3308,60 @@ describe('Symphony IPC handlers', () => {
 				expect(result.cancelled).toBe(true);
 			});
 
+			// The stored contribution is owner/repo, so the origin's final segment
+			// must be exactly "repo". These origins all contain "repo" somewhere but
+			// point at a different checkout, and each one gates a recursive delete.
+			it.each([
+				['https://github.com/repo/some-other-project.git', 'owner is the repo name'],
+				['git@host:other/repo-tools.git', 'repo name is a prefix of another repo'],
+				['https://repo.example.com/other/thing.git', 'repo name appears in the host'],
+				['https://github.com/other/myrepo.git', 'repo name is a suffix of another repo'],
+			])('should not accept origin %s (%s)', async (origin) => {
+				vi.mocked(fs.readFile).mockResolvedValue(
+					JSON.stringify(createStateWithActiveContributions())
+				);
+				vi.mocked(fs.rm).mockResolvedValue(undefined);
+				vi.mocked(fs.access).mockResolvedValue(undefined);
+				vi.mocked(execFileNoThrow).mockResolvedValue({
+					stdout: origin,
+					stderr: '',
+					exitCode: 0,
+				} as never);
+
+				const handler = getCancelHandler();
+				const result = await handler!({} as any, 'contrib_to_cancel', true);
+
+				expect(fs.rm).not.toHaveBeenCalled();
+				expect(result.cancelled).toBe(true);
+			});
+
+			it.each([
+				'https://github.com/owner/repo.git',
+				'https://github.com/owner/repo',
+				'git@github.com:owner/repo.git',
+				// Fork setup rewrites origin to the contributor's own fork.
+				'https://github.com/contributor/repo.git',
+			])("should accept the contribution's own origin %s", async (origin) => {
+				vi.mocked(fs.readFile).mockResolvedValue(
+					JSON.stringify(createStateWithActiveContributions())
+				);
+				vi.mocked(fs.rm).mockResolvedValue(undefined);
+				vi.mocked(fs.access).mockResolvedValue(undefined);
+				vi.mocked(execFileNoThrow).mockResolvedValue({
+					stdout: origin,
+					stderr: '',
+					exitCode: 0,
+				} as never);
+
+				const handler = getCancelHandler();
+				await handler!({} as any, 'contrib_to_cancel', true);
+
+				expect(fs.rm).toHaveBeenCalledWith('/tmp/symphony/repos/repo-contrib_to_cancel', {
+					recursive: true,
+					force: true,
+				});
+			});
+
 			it('should preserve local directory when cleanup=false', async () => {
 				vi.mocked(fs.readFile).mockResolvedValue(
 					JSON.stringify(createStateWithActiveContributions())

--- a/src/__tests__/main/services/symphony-runner.test.ts
+++ b/src/__tests__/main/services/symphony-runner.test.ts
@@ -158,6 +158,33 @@ describe('Symphony Runner Service', () => {
 			]);
 		});
 
+		it('writes two references sharing a basename to separate files', async () => {
+			// docs/architecture.md and spec/architecture.md both reduce to
+			// architecture.md. Both must survive rather than the second
+			// overwriting the first.
+			mockSuccessfulWorkflow();
+
+			await startContribution({
+				contributionId: 'test-id',
+				repoSlug: 'owner/repo',
+				repoUrl: 'https://github.com/owner/repo',
+				issueNumber: 123,
+				issueTitle: 'Test Issue',
+				documentPaths: [
+					{ name: 'docs/architecture.md', path: 'docs/architecture.md', isExternal: false },
+					{ name: 'spec/architecture.md', path: 'spec/architecture.md', isExternal: false },
+				],
+				localPath: '/tmp/test-repo',
+				branchName: 'symphony/test-branch',
+			});
+
+			const destinations = vi.mocked(fs.copyFile).mock.calls.map((c) => c[1]);
+			expect(destinations).toHaveLength(2);
+			expect(new Set(destinations).size).toBe(2);
+			expect(destinations.some((d) => String(d).endsWith('architecture.md'))).toBe(true);
+			expect(destinations.some((d) => String(d).endsWith('architecture-2.md'))).toBe(true);
+		});
+
 		it('returns true on successful clone (exitCode 0)', async () => {
 			mockSuccessfulWorkflow();
 

--- a/src/main/ipc/handlers/symphony/contributionFinish.ts
+++ b/src/main/ipc/handlers/symphony/contributionFinish.ts
@@ -17,6 +17,7 @@ import {
 	checkGhAuthentication,
 	getDefaultBranch,
 	createDraftPR,
+	validateContributionId,
 	SymphonyHandlerDependencies,
 } from './shared';
 
@@ -48,6 +49,11 @@ export function registerContributionFinishHandlers({
 				error?: string;
 			}> => {
 				const { contributionId } = params;
+
+				const idValidation = validateContributionId(contributionId);
+				if (!idValidation.valid) {
+					return { success: false, error: idValidation.error };
+				}
 
 				// Read contribution metadata
 				const metadataPath = path.join(

--- a/src/main/ipc/handlers/symphony/contributionStart.ts
+++ b/src/main/ipc/handlers/symphony/contributionStart.ts
@@ -23,6 +23,8 @@ import {
 	checkGhAuthentication,
 	getDefaultBranch,
 	createDraftPR,
+	validateContributionId,
+	toSafeDocumentFileName,
 	SymphonyHandlerDependencies,
 } from './shared';
 
@@ -497,6 +499,11 @@ This PR will be updated automatically when the Auto Run completes.`;
 				} = params;
 
 				// Validate inputs
+				const idValidation = validateContributionId(contributionId);
+				if (!idValidation.valid) {
+					return { success: false, error: idValidation.error };
+				}
+
 				const slugValidation = validateRepoSlug(repoSlug);
 				if (!slugValidation.valid) {
 					return { success: false, error: slugValidation.error };
@@ -596,8 +603,17 @@ This PR will be updated automatically when the Auto Run completes.`;
 
 					for (const doc of documentPaths) {
 						if (doc.isExternal) {
-							// Download external file (GitHub attachment) to cache directory
-							const destPath = path.join(symphonyDocsDir, doc.name);
+							// Download external file (GitHub attachment) to cache directory.
+							// The name is link text from the issue body, so reduce it to a
+							// bare file name before joining it onto the cache directory.
+							const safeFileName = toSafeDocumentFileName(doc.name);
+							if (!safeFileName) {
+								logger.warn('Skipping document with unusable name', LOG_CONTEXT, {
+									name: doc.name,
+								});
+								continue;
+							}
+							const destPath = path.join(symphonyDocsDir, safeFileName);
 							try {
 								logger.info('Downloading external document', LOG_CONTEXT, {
 									name: doc.name,

--- a/src/main/ipc/handlers/symphony/contributionStart.ts
+++ b/src/main/ipc/handlers/symphony/contributionStart.ts
@@ -25,6 +25,7 @@ import {
 	createDraftPR,
 	validateContributionId,
 	toSafeDocumentFileName,
+	uniqueDocumentFileName,
 	SymphonyHandlerDependencies,
 } from './shared';
 
@@ -600,6 +601,9 @@ This PR will be updated automatically when the Auto Run completes.`;
 
 					// Track resolved document paths for Auto Run
 					const resolvedDocs: { name: string; path: string; isExternal: boolean }[] = [];
+					// Names already written in this batch, so two references that reduce
+					// to the same file name do not overwrite each other.
+					const usedFileNames = new Set<string>();
 
 					for (const doc of documentPaths) {
 						if (doc.isExternal) {
@@ -613,7 +617,20 @@ This PR will be updated automatically when the Auto Run completes.`;
 								});
 								continue;
 							}
-							const destPath = path.join(symphonyDocsDir, safeFileName);
+							const uniqueFileName = uniqueDocumentFileName(safeFileName, usedFileNames);
+							if (!uniqueFileName) {
+								logger.warn('Skipping document, cannot find a free file name', LOG_CONTEXT, {
+									name: doc.name,
+								});
+								continue;
+							}
+							if (uniqueFileName !== safeFileName) {
+								logger.info('Renamed document to avoid a name collision', LOG_CONTEXT, {
+									name: doc.name,
+									to: uniqueFileName,
+								});
+							}
+							const destPath = path.join(symphonyDocsDir, uniqueFileName);
 							try {
 								logger.info('Downloading external document', LOG_CONTEXT, {
 									name: doc.name,

--- a/src/main/ipc/handlers/symphony/lifecycle.ts
+++ b/src/main/ipc/handlers/symphony/lifecycle.ts
@@ -19,6 +19,7 @@ import {
 	readState,
 	writeState,
 	broadcastSymphonyUpdate,
+	isContributionClone,
 	SymphonyHandlerDependencies,
 } from './shared';
 
@@ -461,13 +462,23 @@ export function registerLifecycleHandlers({
 
 				const contribution = state.active[index];
 
-				// Optionally cleanup local files
+				// Optionally cleanup local files. localPath is renderer-supplied and a
+				// user may legitimately choose any working directory, so confirm the
+				// directory is this contribution's clone before removing it
+				// recursively rather than trusting the stored path.
 				if (cleanup && contribution.localPath) {
-					try {
-						await fs.rm(contribution.localPath, { recursive: true, force: true });
-					} catch (e) {
-						void captureException(e);
-						logger.warn('Failed to cleanup contribution directory', LOG_CONTEXT, { error: e });
+					if (await isContributionClone(contribution.localPath, contribution.repoSlug)) {
+						try {
+							await fs.rm(contribution.localPath, { recursive: true, force: true });
+						} catch (e) {
+							void captureException(e);
+							logger.warn('Failed to cleanup contribution directory', LOG_CONTEXT, { error: e });
+						}
+					} else {
+						logger.warn("Skipping cleanup, path is not this contribution's clone", LOG_CONTEXT, {
+							contributionId,
+							localPath: contribution.localPath,
+						});
 					}
 				}
 

--- a/src/main/ipc/handlers/symphony/shared.ts
+++ b/src/main/ipc/handlers/symphony/shared.ts
@@ -69,6 +69,93 @@ export async function ensureSymphonyDir(app: App): Promise<void> {
 }
 
 /**
+ * Validate a contribution ID before it is used to build a filesystem path.
+ *
+ * Contribution IDs are joined into the Symphony directory by several handlers,
+ * so an ID is only ever allowed to be a single path segment. Both generated
+ * shapes (`contrib_<base36>_<base36>` and `manual_<issue>_<timestamp>`) fall
+ * inside this character set, and dots are excluded entirely so `..` cannot
+ * appear at all.
+ */
+export function validateContributionId(contributionId: string): {
+	valid: boolean;
+	error?: string;
+} {
+	if (!contributionId || typeof contributionId !== 'string') {
+		return { valid: false, error: 'Contribution ID is required' };
+	}
+	if (!/^[A-Za-z0-9_-]{1,128}$/.test(contributionId)) {
+		return { valid: false, error: `Invalid contribution ID: ${contributionId}` };
+	}
+	return { valid: true };
+}
+
+/**
+ * Reduce a document reference name to a safe file name for the documents cache.
+ *
+ * `validateContributionParams()` already checks `doc.path`, but the name is
+ * what gets joined onto the cache directory when an external document is
+ * downloaded. The name comes from the link text of a markdown link in a GitHub
+ * issue body, so a perfectly ordinary issue can produce "docs/architecture.md".
+ * Rejecting separators outright would refuse those real documents, so the last
+ * segment is taken instead, which neutralises traversal without losing the
+ * document. Both separators are handled explicitly because `path.basename()`
+ * only treats a backslash as one on win32.
+ *
+ * Returns null when no usable file name remains.
+ */
+export function toSafeDocumentFileName(name: string): string | null {
+	if (!name || typeof name !== 'string' || name.includes('\0')) {
+		return null;
+	}
+	const base = name.split(/[/\\]/).pop()?.trim();
+	// A leading dot covers "." and ".." as well as hidden files.
+	if (!base || base.startsWith('.') || base.length > 255) {
+		return null;
+	}
+	return base;
+}
+
+/**
+ * Confirm a recorded local path really is the clone Symphony made for this
+ * contribution, before anything deletes it recursively.
+ *
+ * `localPath` arrives from the renderer and is stored as-is, because a user is
+ * allowed to pick their own working directory. That means the path itself
+ * cannot be constrained to a known root without breaking the feature, so the
+ * destructive operation is guarded instead: a directory is only ever removed
+ * when it is a git checkout whose origin points at the repository the
+ * contribution is for.
+ *
+ * The repository name is matched rather than the full slug, because fork setup
+ * rewrites origin to the contributor's own fork.
+ */
+export async function isContributionClone(localPath: string, repoSlug?: string): Promise<boolean> {
+	if (!localPath || typeof localPath !== 'string' || !path.isAbsolute(localPath)) {
+		return false;
+	}
+	// A clone always has a .git entry. A plain directory such as a user's
+	// Documents folder does not, so it can never reach the removal below.
+	try {
+		await fs.access(path.join(localPath, '.git'));
+	} catch {
+		return false;
+	}
+	// When the caller knows which repository the contribution is for, also
+	// confirm origin points at it. Callers that do not have the slug still get
+	// the checkout requirement above.
+	const repoName = repoSlug?.split('/')[1];
+	if (!repoName) {
+		return true;
+	}
+	const result = await execFileNoThrow('git', ['remote', 'get-url', 'origin'], localPath);
+	if (result.exitCode !== 0) {
+		return false;
+	}
+	return result.stdout.toLowerCase().includes(repoName.toLowerCase());
+}
+
+/**
  * Write cache to disk.
  */
 export async function writeCache(app: App, cache: SymphonyCache): Promise<void> {

--- a/src/main/ipc/handlers/symphony/shared.ts
+++ b/src/main/ipc/handlers/symphony/shared.ts
@@ -117,6 +117,34 @@ export function toSafeDocumentFileName(name: string): string | null {
 }
 
 /**
+ * Pick a file name that does not collide with one already used in this batch.
+ *
+ * Reducing names to their last segment means two distinct references such as
+ * `docs/architecture.md` and `spec/architecture.md` both arrive here as
+ * `architecture.md`. Writing both would silently leave only the second, so the
+ * later one is suffixed instead. `used` is mutated to record the result.
+ */
+export function uniqueDocumentFileName(fileName: string, used: Set<string>): string {
+	const key = fileName.toLowerCase();
+	if (!used.has(key)) {
+		used.add(key);
+		return fileName;
+	}
+	const dot = fileName.lastIndexOf('.');
+	const stem = dot > 0 ? fileName.slice(0, dot) : fileName;
+	const ext = dot > 0 ? fileName.slice(dot) : '';
+	for (let i = 2; i < 1000; i++) {
+		const candidate = `${stem}-${i}${ext}`;
+		if (!used.has(candidate.toLowerCase())) {
+			used.add(candidate.toLowerCase());
+			return candidate;
+		}
+	}
+	// Pathological input only. The caller skips the document.
+	return '';
+}
+
+/**
  * Confirm a recorded local path really is the clone Symphony made for this
  * contribution, before anything deletes it recursively.
  *
@@ -128,7 +156,13 @@ export function toSafeDocumentFileName(name: string): string | null {
  * contribution is for.
  *
  * The repository name is matched rather than the full slug, because fork setup
- * rewrites origin to the contributor's own fork.
+ * rewrites origin to the contributor's own fork. The comparison is against the
+ * final segment of the origin only: an origin URL also carries the host and the
+ * owner, so a substring test would accept an unrelated checkout such as
+ * `https://github.com/maestro/some-other-project.git` for slug `owner/maestro`.
+ *
+ * This predicate authorises a recursive delete, so every unknown case fails
+ * closed.
  */
 export async function isContributionClone(localPath: string, repoSlug?: string): Promise<boolean> {
 	if (!localPath || typeof localPath !== 'string' || !path.isAbsolute(localPath)) {
@@ -141,18 +175,22 @@ export async function isContributionClone(localPath: string, repoSlug?: string):
 	} catch {
 		return false;
 	}
-	// When the caller knows which repository the contribution is for, also
-	// confirm origin points at it. Callers that do not have the slug still get
-	// the checkout requirement above.
-	const repoName = repoSlug?.split('/')[1];
+	const repoName = repoSlug?.split('/')[1]?.toLowerCase();
 	if (!repoName) {
-		return true;
+		return false;
 	}
 	const result = await execFileNoThrow('git', ['remote', 'get-url', 'origin'], localPath);
 	if (result.exitCode !== 0) {
 		return false;
 	}
-	return result.stdout.toLowerCase().includes(repoName.toLowerCase());
+	// Handles both https URLs and scp-style remotes (git@host:owner/repo.git).
+	const originRepo = result.stdout
+		.trim()
+		.replace(/\.git$/i, '')
+		.split(/[/:]/)
+		.pop()
+		?.toLowerCase();
+	return !!originRepo && originRepo === repoName;
 }
 
 /**

--- a/src/main/services/symphony-runner.ts
+++ b/src/main/services/symphony-runner.ts
@@ -13,11 +13,16 @@ import { resolveGhPath } from '../utils/cliDetection';
 import type { DocumentReference } from '../../shared/symphony-types';
 import { PLAYBOOKS_DIR } from '../../shared/maestro-paths';
 import { captureException } from '../utils/sentry';
+import { toSafeDocumentFileName } from '../ipc/handlers/symphony/shared';
 
 const LOG_CONTEXT = '[SymphonyRunner]';
 
 /**
  * Clean up local repository directory on failure.
+ *
+ * No provenance check here, unlike symphony:cancel: this runner clones into
+ * localPath itself earlier in the same call, so the directory is known to be
+ * ours, and a half-finished clone still has to be removable.
  */
 async function cleanupLocalRepo(localPath: string): Promise<void> {
 	try {
@@ -193,7 +198,14 @@ async function setupAutoRunDocs(
 	await fs.mkdir(autoRunPath, { recursive: true });
 
 	for (const doc of documentPaths) {
-		const destPath = path.posix.join(autoRunPath, doc.name);
+		// The name is link text from the issue body, so reduce it to a bare file
+		// name before joining it onto the Auto Run docs directory.
+		const safeFileName = toSafeDocumentFileName(doc.name);
+		if (!safeFileName) {
+			logger.warn('Skipping document with unusable name', LOG_CONTEXT, { name: doc.name });
+			continue;
+		}
+		const destPath = path.posix.join(autoRunPath, safeFileName);
 
 		if (doc.isExternal) {
 			// Download external file (GitHub attachment)

--- a/src/main/services/symphony-runner.ts
+++ b/src/main/services/symphony-runner.ts
@@ -13,7 +13,7 @@ import { resolveGhPath } from '../utils/cliDetection';
 import type { DocumentReference } from '../../shared/symphony-types';
 import { PLAYBOOKS_DIR } from '../../shared/maestro-paths';
 import { captureException } from '../utils/sentry';
-import { toSafeDocumentFileName } from '../ipc/handlers/symphony/shared';
+import { toSafeDocumentFileName, uniqueDocumentFileName } from '../ipc/handlers/symphony/shared';
 
 const LOG_CONTEXT = '[SymphonyRunner]';
 
@@ -197,6 +197,10 @@ async function setupAutoRunDocs(
 	const autoRunPath = path.posix.join(localPath, PLAYBOOKS_DIR);
 	await fs.mkdir(autoRunPath, { recursive: true });
 
+	// Names already written in this batch, so two references that reduce to the
+	// same file name do not overwrite each other.
+	const usedFileNames = new Set<string>();
+
 	for (const doc of documentPaths) {
 		// The name is link text from the issue body, so reduce it to a bare file
 		// name before joining it onto the Auto Run docs directory.
@@ -205,7 +209,20 @@ async function setupAutoRunDocs(
 			logger.warn('Skipping document with unusable name', LOG_CONTEXT, { name: doc.name });
 			continue;
 		}
-		const destPath = path.posix.join(autoRunPath, safeFileName);
+		const uniqueFileName = uniqueDocumentFileName(safeFileName, usedFileNames);
+		if (!uniqueFileName) {
+			logger.warn('Skipping document, cannot find a free file name', LOG_CONTEXT, {
+				name: doc.name,
+			});
+			continue;
+		}
+		if (uniqueFileName !== safeFileName) {
+			logger.info('Renamed document to avoid a name collision', LOG_CONTEXT, {
+				name: doc.name,
+				to: uniqueFileName,
+			});
+		}
+		const destPath = path.posix.join(autoRunPath, uniqueFileName);
 
 		if (doc.isExternal) {
 			// Download external file (GitHub attachment)


### PR DESCRIPTION
Follow-up to #1369, which deliberately left these out to keep that refactor a clean code-motion diff.

**What changed**
- `contributionId` is validated as a single path segment before it is joined into the Symphony directory in `startContribution` and `createDraftPR`
- external document names are reduced to a bare file name before being joined onto the documents cache
- `symphony:cancel` confirms the stored `localPath` is this contribution's clone before removing it recursively

**Where I diverged from the review suggestions**
- CodeRabbit proposed containing `localPath` to the repositories directory. The renderer builds it as `workingDirectory || /tmp/symphony/...`, and `workingDirectory` is user-chosen in the Symphony modal, so containment would break the feature. The destructive operation is guarded instead.
- Rejecting document names containing separators would refuse real input. `parseDocumentPaths` takes the name from markdown link text, so an ordinary `[docs/architecture.md](...)` yields a name with a slash. Those are reduced, not refused.

**Behaviour notes**
- `docs/architecture.md` previously hit ENOENT inside the cache directory and was silently dropped, it now downloads correctly
- `cancel` skips cleanup when the stored path is not a clone and logs it, the contribution is still cancelled
- no guard in `symphony-runner`'s cleanup, it clones into that path itself in the same call so it provably owns the directory, and a half-finished clone still has to be removable

**Verification**
- Symphony suites 291 passing, up from 290
- integration failing set byte identical to baseline, the 24 failures there are pre-existing on rc
- lint, type-check and production build clean
- confirmed in the running app, `../../etc/passwd` is rejected where it previously reached the filesystem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive contribution workflows, including repository setup, draft pull requests, completion, cancellation, synchronization, and recovery.
  * Added dashboards for active contributions, completed contributions, and contributor statistics.
  * Added repository and issue discovery with caching, progress tracking, and GitHub metadata.
  * Added safer handling for contribution IDs, document filenames, and repository cleanup.

* **Bug Fixes**
  * Improved cleanup behavior to preserve unrelated directories and handle invalid repositories safely.
  * Prevented document name collisions from overwriting files.

* **Documentation**
  * Updated Symphony handler architecture, lifecycle, and runner documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->