### PR TITLE
fix: preserve truthful process and session state

### DIFF
--- a/src/__tests__/cli/commands/session.test.ts
+++ b/src/__tests__/cli/commands/session.test.ts
@@ -127,6 +127,35 @@ describe('session list command', () => {
 		expect(line.split('  ').filter(Boolean).length).toBeGreaterThanOrEqual(4);
 	});
 
+	it('preserves an unknown desktop state in human-readable output', async () => {
+		const mockSendCommand = vi.fn().mockResolvedValue({
+			type: 'desktop_sessions_list',
+			success: true,
+			sessions: [
+				{
+					tabId: 'tab-unknown',
+					sessionId: 'tab-unknown',
+					agentId: 'agent-a',
+					agentName: 'Backend',
+					toolType: 'claude-code',
+					name: null,
+					agentSessionId: null,
+					state: 'unknown',
+					createdAt: 1714268000000,
+					starred: false,
+				},
+			],
+		});
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = { sendCommand: mockSendCommand };
+			return action(mockClient as never);
+		});
+
+		await sessionList({});
+
+		expect(consoleSpy.mock.calls[0][0]).toContain('unknown');
+	});
+
 	it('maps connection errors to MAESTRO_NOT_RUNNING (consistent with dispatch)', async () => {
 		vi.mocked(withMaestroClient).mockRejectedValue(new Error('ECONNREFUSED'));
 

--- a/src/__tests__/main/web-server/web-server-factory.test.ts
+++ b/src/__tests__/main/web-server/web-server-factory.test.ts
@@ -166,6 +166,10 @@ vi.mock('../../../main/utils/sentry', () => ({
 	captureException: vi.fn(),
 }));
 
+vi.mock('../../../shared/cli-activity', () => ({
+	isSessionBusyWithCli: vi.fn().mockReturnValue(false),
+}));
+
 import {
 	createWebServerFactory,
 	type WebServerFactoryDependencies,
@@ -175,6 +179,7 @@ import { getThemeById } from '../../../main/themes';
 import { getHistoryManager } from '../../../main/history-manager';
 import { logger } from '../../../main/utils/logger';
 import { importMarketplacePlaybook } from '../../../main/services/marketplace-service';
+import { isSessionBusyWithCli } from '../../../shared/cli-activity';
 
 describe('web-server/web-server-factory', () => {
 	let mockSettingsStore: WebServerFactoryDependencies['settingsStore'];
@@ -182,11 +187,15 @@ describe('web-server/web-server-factory', () => {
 	let mockGroupsStore: WebServerFactoryDependencies['groupsStore'];
 	let mockMainWindow: Partial<BrowserWindow>;
 	let mockWebContents: Partial<WebContents>;
-	let mockProcessManager: { write: ReturnType<typeof vi.fn> };
+	let mockProcessManager: {
+		write: ReturnType<typeof vi.fn>;
+		get: ReturnType<typeof vi.fn>;
+	};
 	let deps: WebServerFactoryDependencies;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		vi.mocked(isSessionBusyWithCli).mockReturnValue(false);
 
 		mockSettingsStore = {
 			get: vi.fn((key: string, defaultValue?: any) => {
@@ -249,6 +258,7 @@ describe('web-server/web-server-factory', () => {
 
 		mockProcessManager = {
 			write: vi.fn().mockReturnValue(true),
+			get: vi.fn().mockReturnValue(undefined),
 		};
 
 		deps = {
@@ -474,6 +484,83 @@ describe('web-server/web-server-factory', () => {
 			expect(sessions[0]).toHaveProperty('id');
 			expect(sessions[0]).toHaveProperty('name');
 			expect(sessions[0]).toHaveProperty('toolType');
+		});
+	});
+
+	describe('listDesktopSessionsCallback behavior', () => {
+		const getCallback = () => {
+			const createWebServer = createWebServerFactory(deps);
+			const server = createWebServer();
+			const setter = server.setListDesktopSessionsCallback as ReturnType<typeof vi.fn>;
+			return setter.mock.calls[0][0];
+		};
+
+		it('reports a persisted busy tab as busy without a managed process', () => {
+			vi.mocked(mockSessionsStore.get).mockReturnValue([
+				{
+					id: 'agent-a',
+					name: 'Backend',
+					toolType: 'claude-code',
+					activeTabId: 'tab-a',
+					aiTabs: [{ id: 'tab-a', state: 'busy' }],
+				},
+			]);
+
+			expect(getCallback()()[0].state).toBe('busy');
+		});
+
+		it('overrides stale idle when the tab has a live managed process', () => {
+			vi.mocked(mockSessionsStore.get).mockReturnValue([
+				{
+					id: 'agent-a',
+					name: 'Backend',
+					toolType: 'claude-code',
+					activeTabId: 'tab-a',
+					aiTabs: [{ id: 'tab-a', state: 'idle' }],
+				},
+			]);
+			mockProcessManager.get.mockImplementation((id: string) =>
+				id === 'agent-a-ai-tab-a' ? { pid: 123 } : undefined
+			);
+
+			expect(getCallback()()[0].state).toBe('busy');
+		});
+
+		it('keeps an inactive sibling idle when only the active tab is running', () => {
+			vi.mocked(mockSessionsStore.get).mockReturnValue([
+				{
+					id: 'agent-a',
+					name: 'Backend',
+					toolType: 'claude-code',
+					activeTabId: 'tab-a',
+					aiTabs: [
+						{ id: 'tab-a', state: 'idle' },
+						{ id: 'tab-b', state: 'idle' },
+					],
+				},
+			]);
+			mockProcessManager.get.mockImplementation((id: string) =>
+				id === 'agent-a-ai-tab-a' ? { pid: 123 } : undefined
+			);
+
+			const entries = getCallback()();
+			expect(entries.map((entry: { state: string }) => entry.state)).toEqual(['busy', 'idle']);
+		});
+
+		it('uses active CLI activity and preserves unknown state when evidence is absent', () => {
+			vi.mocked(mockSessionsStore.get).mockReturnValue([
+				{
+					id: 'agent-a',
+					name: 'Backend',
+					toolType: 'claude-code',
+					activeTabId: 'tab-a',
+					aiTabs: [{ id: 'tab-a' }, { id: 'tab-b' }],
+				},
+			]);
+			vi.mocked(isSessionBusyWithCli).mockReturnValue(true);
+
+			const entries = getCallback()();
+			expect(entries.map((entry: { state: string }) => entry.state)).toEqual(['busy', 'unknown']);
 		});
 	});
 

--- a/src/__tests__/shared/cli-activity.test.ts
+++ b/src/__tests__/shared/cli-activity.test.ts
@@ -369,7 +369,7 @@ describe('cli-activity', () => {
 			// Mock process.kill to throw (process doesn't exist)
 			const originalKill = process.kill;
 			process.kill = vi.fn().mockImplementation(() => {
-				throw new Error('ESRCH: No such process');
+				throw Object.assign(new Error('No such process'), { code: 'ESRCH' });
 			}) as unknown as typeof process.kill;
 
 			const busy = isSessionBusyWithCli('session-123');
@@ -379,6 +379,38 @@ describe('cli-activity', () => {
 			expect(mockFs.writeFileSync).toHaveBeenCalled();
 
 			process.kill = originalKill;
+		});
+
+		it('should preserve busy activity when the process probe returns EPERM', () => {
+			mockFs.readFileSync.mockReturnValue(JSON.stringify({ activities: [sampleActivity] }));
+
+			const originalKill = process.kill;
+			process.kill = vi.fn().mockImplementation(() => {
+				throw Object.assign(new Error('Operation not permitted'), { code: 'EPERM' });
+			}) as unknown as typeof process.kill;
+
+			try {
+				expect(isSessionBusyWithCli('session-123')).toBe(true);
+				expect(mockFs.writeFileSync).not.toHaveBeenCalled();
+			} finally {
+				process.kill = originalKill;
+			}
+		});
+
+		it('should not erase activity after an unknown process-probe error', () => {
+			mockFs.readFileSync.mockReturnValue(JSON.stringify({ activities: [sampleActivity] }));
+
+			const originalKill = process.kill;
+			process.kill = vi.fn().mockImplementation(() => {
+				throw Object.assign(new Error('Unexpected probe failure'), { code: 'EIO' });
+			}) as unknown as typeof process.kill;
+
+			try {
+				expect(isSessionBusyWithCli('session-123')).toBe(false);
+				expect(mockFs.writeFileSync).not.toHaveBeenCalled();
+			} finally {
+				process.kill = originalKill;
+			}
 		});
 
 		it('should check correct PID', () => {

--- a/src/__tests__/shared/cli-server-discovery.test.ts
+++ b/src/__tests__/shared/cli-server-discovery.test.ts
@@ -407,13 +407,29 @@ describe('cli-server-discovery', () => {
 
 			const originalKill = process.kill;
 			process.kill = vi.fn().mockImplementation(() => {
-				throw new Error('ESRCH: No such process');
+				throw Object.assign(new Error('No such process'), { code: 'ESRCH' });
 			}) as unknown as typeof process.kill;
 
 			try {
 				const result = isCliServerRunning();
 
 				expect(result).toBe(false);
+			} finally {
+				process.kill = originalKill;
+			}
+		});
+
+		it('should treat EPERM as alive so the authenticated connection can decide reachability', () => {
+			mockFs.readFileSync.mockReturnValue(JSON.stringify(sampleInfo));
+
+			const originalKill = process.kill;
+			process.kill = vi.fn().mockImplementation(() => {
+				throw Object.assign(new Error('Operation not permitted'), { code: 'EPERM' });
+			}) as unknown as typeof process.kill;
+
+			try {
+				expect(isCliServerRunning()).toBe(true);
+				expect(process.kill).toHaveBeenCalledWith(12345, 0);
 			} finally {
 				process.kill = originalKill;
 			}

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -32,7 +32,7 @@ interface DesktopSessionEntry {
 	toolType: string;
 	name: string | null;
 	agentSessionId: string | null;
-	state: 'idle' | 'busy';
+	state: 'idle' | 'busy' | 'unknown';
 	createdAt: number;
 	starred: boolean;
 }
@@ -137,10 +137,10 @@ export async function sessionList(options: SessionListOptions): Promise<void> {
 		// Compact human-readable view: one tab per line so the output is grep-able
 		// and pipes cleanly into other tools while still being readable for a
 		// quick glance. Columns: state | star | tabId | agent | name | createdAt.
-		// `state` is spelled out (busy/idle) rather than relying on the `*` marker
+		// `state` is spelled out (busy/idle/unknown) rather than relying on the `*` marker
 		// alone so `grep busy` works without column-counting.
 		for (const s of sessions) {
-			const state = s.state === 'busy' ? 'busy' : 'idle';
+			const state = s.state;
 			const star = s.starred ? '★' : ' ';
 			const name = s.name ?? '(unnamed)';
 			const created = Number.isFinite(s.createdAt) ? formatRelativeTime(s.createdAt) : '-';

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -534,7 +534,7 @@ export interface DesktopSessionEntry {
 	name: string | null;
 	/** Provider session id (e.g. Claude `session_id`) bound to this tab. */
 	agentSessionId: string | null;
-	state: 'idle' | 'busy';
+	state: 'idle' | 'busy' | 'unknown';
 	createdAt: number;
 	starred: boolean;
 }

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -24,6 +24,7 @@ import type { CueGraphSession, CueRunResult } from '../../shared/cue/contracts';
 import { composeCueSubscriptionId } from '../../shared/cue/subscription-id';
 import { getDefaultShell } from '../stores/defaults';
 import { buildWebSettingsSnapshot } from './web-settings-snapshot';
+import { isSessionBusyWithCli } from '../../shared/cli-activity';
 import {
 	getMarketplaceManifest,
 	refreshMarketplaceManifest,
@@ -257,14 +258,28 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 		// entries. The CLI does not need group/cwd metadata; the structurally
 		// smaller payload keeps polling cheap. Reads straight from the persisted
 		// session store (same source the renderer pushes to via `sessions:save`),
-		// so the data is as fresh as the desktop's own state.
+		// then reconcile it with live managed-process and CLI-activity evidence.
 		server.setListDesktopSessionsCallback(() => {
 			const sessions = sessionsStore.get<StoredSession[]>('sessions', []);
+			const processManager = getProcessManager();
 			const entries = [];
 			for (const s of sessions) {
 				const aiTabs = (s.aiTabs as Array<Record<string, any>> | undefined) ?? [];
+				const cliBusy = isSessionBusyWithCli(s.id);
 				for (const tab of aiTabs) {
 					if (!tab || typeof tab.id !== 'string') continue;
+					const isActiveTab = tab.id === s.activeTabId;
+					const managedProcessActive = Boolean(
+						processManager?.get(`${s.id}-ai-${tab.id}`) ||
+						(isActiveTab && processManager?.get(`${s.id}-ai`))
+					);
+					const processActive = managedProcessActive || (isActiveTab && cliBusy);
+					const state =
+						tab.state === 'busy' || processActive
+							? ('busy' as const)
+							: tab.state === 'idle'
+								? ('idle' as const)
+								: ('unknown' as const);
 					entries.push({
 						tabId: tab.id,
 						sessionId: tab.id,
@@ -273,7 +288,7 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 						toolType: s.toolType,
 						name: typeof tab.name === 'string' ? tab.name : null,
 						agentSessionId: typeof tab.agentSessionId === 'string' ? tab.agentSessionId : null,
-						state: tab.state === 'busy' ? ('busy' as const) : ('idle' as const),
+						state,
 						createdAt: typeof tab.createdAt === 'number' ? tab.createdAt : 0,
 						starred: tab.starred === true,
 					});

--- a/src/shared/cli-activity.ts
+++ b/src/shared/cli-activity.ts
@@ -126,9 +126,15 @@ export function isSessionBusyWithCli(sessionId: string): boolean {
 	try {
 		process.kill(activity.pid, 0); // Doesn't kill, just checks if process exists
 		return true;
-	} catch {
-		// Process not running, clean up stale entry
-		unregisterCliActivity(sessionId);
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		// EPERM proves the process exists but is outside this caller's signal
+		// permission. Keep the activity and report it busy instead of erasing
+		// truthful evidence from a sandboxed read-only monitor.
+		if (code === 'EPERM') return true;
+		// Only ESRCH proves the process is gone. Unknown probe failures are not
+		// enough evidence to mutate the shared activity file.
+		if (code === 'ESRCH') unregisterCliActivity(sessionId);
 		return false;
 	}
 }

--- a/src/shared/cli-server-discovery.ts
+++ b/src/shared/cli-server-discovery.ts
@@ -115,7 +115,12 @@ export function isCliServerRunning(): boolean {
 	try {
 		process.kill(info.pid, 0); // Doesn't kill, just checks if process exists
 		return true;
-	} catch {
+	} catch (error) {
+		// EPERM means the process exists but this caller cannot signal it. This is
+		// common for sandboxed read-only monitors and must not turn a reachable
+		// desktop into a stale discovery result. The authenticated WebSocket
+		// connection remains the authoritative reachability check.
+		if ((error as NodeJS.ErrnoException).code === 'EPERM') return true;
 		return false;
 	}
 }


### PR DESCRIPTION
## What changed

- treat `EPERM` from `process.kill(pid, 0)` as proof that the process exists
- remove CLI activity only when the process probe returns `ESRCH`
- reconcile persisted tab state with live managed-process and CLI activity
- preserve `unknown` session state in the CLI instead of coercing it to `idle`

## Why

Read-only and sandboxed monitors can receive `EPERM` while probing a live
Maestro process. The existing catch-all behavior reported stale discovery,
removed valid CLI activity, and exposed working tabs as idle. That made health
and recovery decisions depend on a permission failure rather than live state.

## Impact

Process-restricted monitors no longer turn `EPERM` into a false crash. Session
list output reports busy when a matching managed process or active CLI job is
present, and preserves uncertainty when neither persisted nor live evidence is
conclusive.

## Validation

- four focused Vitest files: 149 tests passed
- `tsc -p tsconfig.main.json --noEmit`
- `tsc -p tsconfig.cli.json --noEmit`
- Prettier check passed for all nine changed files
- targeted ESLint completed with no errors

This PR changes source and tests only. It does not modify an installed Maestro
application or request a release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Session listings now preserve and display an `unknown` state instead of incorrectly showing it as idle.
  - Session activity now reflects live desktop processes and CLI activity more accurately.

- **Bug Fixes**
  - Improved detection of active CLI sessions when process checks encounter permission errors.
  - Prevented active sessions from being incorrectly cleared due to transient or unexpected process-check errors.
  - Improved CLI server detection for running processes with restricted permissions.

- **Tests**
  - Added coverage for session states, live activity detection, and process-check error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->