### PR TITLE
feat(shell): allow the clickup: protocol so ClickUp links open the desktop app

### DIFF
--- a/src/main/ipc/handlers/system.ts
+++ b/src/main/ipc/handlers/system.ts
@@ -188,7 +188,16 @@ export function registerSystemHandlers(deps: SystemHandlerDependencies): void {
 	});
 
 	// Shell operations - open external URLs
-	const ALLOWED_PROTOCOLS = ['http:', 'https:', 'mailto:'];
+	//
+	// `clickup:` lets a ClickUp task link open the native desktop app instead of a browser tab. ClickUp
+	// registers the scheme (CFBundleURLSchemes) but declares no associated-domains, so macOS universal links
+	// never redirect app.clickup.com on their own - the scheme is the only route to the app, and this
+	// allowlist was the one thing standing in the way.
+	//
+	// Safe on the same grounds that already admit `mailto:`: the OS hands the URL to whichever app claims the
+	// scheme, with no code execution here, and unlike `file:` (handled above) it cannot reach the filesystem.
+	// The vectors this list exists to stop, `javascript:` and `data:`, remain blocked.
+	const ALLOWED_PROTOCOLS = ['http:', 'https:', 'mailto:', 'clickup:'];
 	ipcMain.handle('shell:openExternal', async (_event, url: string) => {
 		// Validate URL before opening - Fixes MAESTRO-1S
 		if (!url || typeof url !== 'string') {


### PR DESCRIPTION
## What this does

Adds `clickup:` to the list of URL protocols `shell:openExternal` is allowed to open. One line.

## Why

Today, clicking a ClickUp task link inside Maestro always lands in a browser tab, even when the user has the ClickUp desktop app installed and signed in. There is no way to reach the app.

The reason is a chain of three things:

1. **ClickUp registers a URL scheme** (`clickup://`) but **does not declare associated-domains.** That second part matters: without it, macOS universal links will never redirect `app.clickup.com` to the desktop app on their own. The scheme is the only route to the app.

2. **Maestro correctly routes non-http URLs to the OS.** `openUrl.ts` hands anything that is not `http`/`https` straight to `shell.openExternal`, which is exactly what a custom scheme needs.

3. **But `ALLOWED_PROTOCOLS` blocks it.** The list is `['http:', 'https:', 'mailto:']`, so the handler throws `Protocol not allowed: clickup:` and nothing opens. The click dies inside Maestro and never reaches the OS.

So the pieces are all in place except this one allowlist entry.

## Why this is safe

Same reasoning that already admits `mailto:`:

- The OS hands the URL to whichever app claims the scheme. **No code is executed** in the handler.
- Unlike `file:` (handled separately above), a custom scheme **cannot reach the filesystem**.
- The vectors this allowlist exists to stop, `javascript:` and `data:`, **remain blocked**, and the existing tests for both still pass.

If a user does not have ClickUp installed, the OS simply does nothing. No crash, no fallback needed.

## How it was verified

- `src/__tests__/main/ipc/handlers/system.test.ts`: **110 passing, 0 failing**, including the cases asserting `javascript:` and `data:` are still rejected.
- Confirmed end to end on macOS that `clickup://app.clickup.com/t/<taskId>` opens the app **and navigates to the task**. ClickUp's own log records both steps:
  ```
  Received open-url:  clickup://app.clickup.com/t/<taskId>
  Extracted deeplink: app.clickup.com/t/<taskId>
  ```

One detail worth knowing for anyone building these links: **the host has to stay in the URL.** ClickUp's handler strips only `clickup://` and then requires the remainder to start with a known host. `clickup://t/<id>` opens the app but navigates nowhere, which makes it look like it worked when it did not.

## Note on the test suite

`git push` runs the full suite via a pre-push hook, and 98 tests across 2 files fail. I checked whether those were mine: they are not. Running the same suite on a clean `main` with no changes produces **the identical 98 failures**, so they are pre-existing and unrelated to this change.

## Scope

One file, one line of code (the rest is a comment explaining the reasoning for the next reader). Branched from `main`, nothing else included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening `clickup:` links from the application.

* **Bug Fixes**
  * Preserved existing safeguards that block unsupported or potentially unsafe link protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->