### PR TITLE
feat(settings): add OrcaRouter as an LLM provider

### DIFF
--- a/src/renderer/components/Settings/SettingsModal.tsx
+++ b/src/renderer/components/Settings/SettingsModal.tsx
@@ -377,6 +377,39 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 					status: 'success',
 					message: 'Successfully connected to OpenRouter!',
 				});
+			} else if (llmProvider === 'orcarouter') {
+				if (!apiKey) {
+					throw new Error('API key is required for OrcaRouter');
+				}
+
+				response = await fetch('https://api.orcarouter.ai/v1/chat/completions', {
+					method: 'POST',
+					headers: {
+						Authorization: `Bearer ${apiKey}`,
+						'Content-Type': 'application/json',
+						'HTTP-Referer': 'https://maestro.local',
+					},
+					body: JSON.stringify({
+						model: modelSlug || 'anthropic/claude-sonnet-5',
+						messages: [{ role: 'user', content: testPrompt }],
+						max_tokens: 50,
+					}),
+				});
+
+				if (!response.ok) {
+					const error = await response.json();
+					throw new Error(error.error?.message || `OrcaRouter API error: ${response.status}`);
+				}
+
+				const data = await response.json();
+				if (!data.choices?.[0]?.message?.content) {
+					throw new Error('Invalid response from OrcaRouter');
+				}
+
+				setTestResult({
+					status: 'success',
+					message: 'Successfully connected to OrcaRouter!',
+				});
 			} else if (llmProvider === 'anthropic') {
 				if (!apiKey) {
 					throw new Error('API key is required for Anthropic');
@@ -560,6 +593,7 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 										style={{ borderColor: theme.colors.border }}
 									>
 										<option value="openrouter">OpenRouter</option>
+										<option value="orcarouter">OrcaRouter</option>
 										<option value="anthropic">Anthropic</option>
 										<option value="ollama">Ollama (Local)</option>
 									</select>

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -92,7 +92,7 @@ export type SettingsTab =
 	| 'prompts';
 // Note: ScratchPadMode was removed as part of the Scratchpad → Auto Run migration
 export type FocusArea = 'sidebar' | 'main' | 'right';
-export type LLMProvider = 'openrouter' | 'anthropic' | 'ollama';
+export type LLMProvider = 'openrouter' | 'orcarouter' | 'anthropic' | 'ollama';
 
 // Inline wizard types for per-session/per-tab wizard state
 export type WizardMode = 'new' | 'iterate' | null;

--- a/src/shared/settingsMetadata.ts
+++ b/src/shared/settingsMetadata.ts
@@ -538,7 +538,7 @@ export const SETTINGS_METADATA: Record<string, SettingMetadata> = {
 
 	// --- LLM / Provider ---
 	llmProvider: {
-		description: 'LLM provider for built-in AI features. E.g., openrouter, anthropic, openai.',
+		description: 'LLM provider for built-in AI features. E.g., openrouter, orcarouter, anthropic, openai.',
 		type: 'string',
 		default: 'openrouter',
 		category: 'advanced',


### PR DESCRIPTION
## Add OrcaRouter as an LLM provider option

This PR adds [OrcaRouter](https://www.orcarouter.ai) as a selectable LLM provider in Maestro's settings, mirroring the existing OpenRouter wiring exactly.

OrcaRouter is an AI gateway that fronts many upstream models (`anthropic/claude-*`, `openai/*`, etc.) behind a single OpenAI-compatible Chat Completions endpoint (`https://api.orcarouter.ai/v1/chat/completions`), so it slots into the existing provider list:

- **`LLMProvider`** type extended with `'orcarouter'` (`src/renderer/types/index.ts`)
- **Settings dropdown** now offers OrcaRouter next to OpenRouter / Anthropic / Ollama
- **Connection test**: a new `llmProvider === 'orcarouter'` branch in `testLLMConnection` mirrors the OpenRouter branch (Bearer auth, `HTTP-Referer`, OpenAI-compatible request/response), with default model slug `anthropic/claude-sonnet-5`
- **Settings metadata** description updated to list OrcaRouter

The wire format was verified live against `https://api.orcarouter.ai/v1/chat/completions`: a POST with Bearer auth, the namespaced model id `anthropic/claude-sonnet-5`, and the same `{ model, messages, max_tokens }` body Maestro sends returns `choices[0].message.content` as expected.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OrcaRouter as a supported LLM provider.
  * Added connection testing with API key validation and response checks.
  * Displays provider-specific errors when the connection test fails.

* **Documentation**
  * Updated provider settings to include OrcaRouter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->