### PR TITLE
fix(debug package): actually collect Auto Run state instead of shipping an empty section

### DIFF
--- a/src/__tests__/main/debug-package/collectors.test.ts
+++ b/src/__tests__/main/debug-package/collectors.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import os from 'os';
+import type { AutoRunDebugSnapshot } from '../../../shared/debugPackage';
 
 // Mock Electron modules
 vi.mock('electron', () => ({
@@ -653,45 +654,59 @@ describe('Debug Package Collectors', () => {
 	});
 
 	describe('collectBatchState', () => {
-		it('should collect Auto Run state from sessions', async () => {
+		// Builds a snapshot the way the renderer service does, so these tests fail
+		// if the wire shape drifts. The previous version of this suite invented a
+		// `session.batchRunState` field that nothing ever wrote, which is why the
+		// collector shipped an empty section for its entire life.
+		const makeSnapshot = (
+			overrides: Partial<AutoRunDebugSnapshot> & { sessionId: string }
+		): AutoRunDebugSnapshot => ({
+			isRunning: false,
+			isStopping: false,
+			documentCount: 0,
+			currentDocumentIndex: 0,
+			currentDocTasksTotal: 0,
+			currentDocTasksCompleted: 0,
+			totalTasksAcrossAllDocs: 0,
+			completedTasksAcrossAllDocs: 0,
+			loopEnabled: false,
+			loopIteration: 0,
+			worktreeActive: false,
+			hasError: false,
+			errorPaused: false,
+			...overrides,
+		});
+
+		it('should collect Auto Run state from a renderer snapshot', async () => {
 			const { collectBatchState } =
 				await import('../../../main/debug-package/collectors/batch-state');
 
 			const startTime = Date.now() - 60000;
-			const mockStore = {
-				get: vi.fn().mockReturnValue([
-					{
-						id: 'session-1',
-						batchRunState: {
-							isRunning: true,
-							isStopping: false,
-							documentCount: 5,
-							currentDocumentIndex: 2,
-							loopEnabled: true,
-							loopIteration: 3,
-							worktreeActive: true,
-							error: null,
-							startTime,
-						},
-					},
-					{
-						id: 'session-2',
-						// No batch state
-					},
-					{
-						id: 'session-3',
-						batchRunState: {
-							isRunning: false,
-							error: { type: 'document_error' },
-						},
-					},
-				]),
-				set: vi.fn(),
-				store: {},
-			};
+			const lastActiveTimestamp = Date.now() - 30000;
 
-			const result = collectBatchState(mockStore as any);
+			const result = collectBatchState([
+				makeSnapshot({
+					sessionId: 'session-1',
+					isRunning: true,
+					documentCount: 5,
+					currentDocumentIndex: 2,
+					loopEnabled: true,
+					loopIteration: 3,
+					worktreeActive: true,
+					startTime,
+					lastActiveTimestamp,
+				}),
+				// Idle agent with no activity: filtered out as noise.
+				makeSnapshot({ sessionId: 'session-2' }),
+				makeSnapshot({
+					sessionId: 'session-3',
+					hasError: true,
+					errorType: 'document_error',
+					errorPaused: true,
+				}),
+			]);
 
+			expect(result.snapshotAvailable).toBe(true);
 			expect(result.activeSessions).toHaveLength(2);
 
 			const session1 = result.activeSessions.find((s) => s.sessionId === 'session-1');
@@ -705,11 +720,43 @@ describe('Debug Package Collectors', () => {
 			expect(session1!.hasError).toBe(false);
 			expect(session1!.startTime).toBe(startTime);
 			expect(session1!.elapsedMs).toBeGreaterThan(0);
+			// The signature of a hung run: started long ago, silent since.
+			expect(session1!.idleMs).toBeGreaterThan(0);
 
 			const session3 = result.activeSessions.find((s) => s.sessionId === 'session-3');
 			expect(session3).toBeDefined();
 			expect(session3!.hasError).toBe(true);
 			expect(session3!.errorType).toBe('document_error');
+		});
+
+		it('should report an unavailable snapshot distinctly from no active runs', async () => {
+			const { collectBatchState } =
+				await import('../../../main/debug-package/collectors/batch-state');
+
+			const missing = collectBatchState(undefined);
+			expect(missing.snapshotAvailable).toBe(false);
+			expect(missing.activeSessions).toEqual([]);
+
+			const empty = collectBatchState([]);
+			expect(empty.snapshotAvailable).toBe(true);
+			expect(empty.activeSessions).toEqual([]);
+		});
+
+		it('should keep a paused run that has completed work', async () => {
+			const { collectBatchState } =
+				await import('../../../main/debug-package/collectors/batch-state');
+
+			const result = collectBatchState([
+				makeSnapshot({
+					sessionId: 'session-paused',
+					isRunning: false,
+					completedTasksAcrossAllDocs: 66,
+					totalTasksAcrossAllDocs: 124,
+				}),
+			]);
+
+			expect(result.activeSessions).toHaveLength(1);
+			expect(result.activeSessions[0].completedTasksAcrossAllDocs).toBe(66);
 		});
 	});
 

--- a/src/__tests__/renderer/services/debugPackage.test.ts
+++ b/src/__tests__/renderer/services/debugPackage.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for the debug package renderer service.
+ *
+ * The point of this service is that Auto Run state lives only in the renderer's
+ * in-memory batchStore, so main cannot collect it on its own. These tests pin
+ * two things: the snapshot is actually attached, and it carries no document
+ * content or paths.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { BatchRunState } from '../../../renderer/types';
+import { useBatchStore } from '../../../renderer/stores/batchStore';
+import {
+	captureAutoRunSnapshots,
+	createDebugPackage,
+} from '../../../renderer/services/debugPackage';
+
+const createBatchRunState = (overrides: Partial<BatchRunState> = {}): BatchRunState => ({
+	isRunning: false,
+	isStopping: false,
+	documents: ['Phase 1'],
+	lockedDocuments: ['Phase 1'],
+	currentDocumentIndex: 0,
+	currentDocTasksTotal: 3,
+	currentDocTasksCompleted: 0,
+	totalTasksAcrossAllDocs: 3,
+	completedTasksAcrossAllDocs: 0,
+	loopEnabled: false,
+	loopIteration: 0,
+	folderPath: '/test/folder',
+	worktreeActive: false,
+	totalTasks: 3,
+	completedTasks: 0,
+	currentTaskIndex: 0,
+	originalContent: '',
+	sessionIds: [],
+	...overrides,
+});
+
+describe('debugPackage service', () => {
+	beforeEach(() => {
+		useBatchStore.setState({ batchRunStates: {} });
+	});
+
+	describe('captureAutoRunSnapshots', () => {
+		it('captures live Auto Run state per agent', () => {
+			const startTime = Date.now() - 60_000;
+			useBatchStore.setState({
+				batchRunStates: {
+					'agent-1': createBatchRunState({
+						isRunning: true,
+						currentDocumentIndex: 2,
+						documents: ['Phase 1', 'Phase 2', 'Phase 3'],
+						completedTasksAcrossAllDocs: 66,
+						totalTasksAcrossAllDocs: 124,
+						loopEnabled: true,
+						loopIteration: 3,
+						startTime,
+					}),
+				},
+			});
+
+			const [snapshot] = captureAutoRunSnapshots();
+
+			expect(snapshot.sessionId).toBe('agent-1');
+			expect(snapshot.isRunning).toBe(true);
+			expect(snapshot.documentCount).toBe(3);
+			expect(snapshot.currentDocumentIndex).toBe(2);
+			expect(snapshot.completedTasksAcrossAllDocs).toBe(66);
+			expect(snapshot.totalTasksAcrossAllDocs).toBe(124);
+			expect(snapshot.loopIteration).toBe(3);
+			expect(snapshot.startTime).toBe(startTime);
+		});
+
+		it('omits document content, filenames, and paths', () => {
+			useBatchStore.setState({
+				batchRunStates: {
+					'agent-1': createBatchRunState({
+						isRunning: true,
+						documents: ['Secret Phase Name'],
+						folderPath: '/Users/someone/private/docs',
+						worktreePath: '/Users/someone/worktrees/wt',
+						customPrompt: 'a prompt that may quote the document',
+						errorTaskDescription: 'task text from the document',
+						originalContent: '# document body',
+					}),
+				},
+			});
+
+			const serialized = JSON.stringify(captureAutoRunSnapshots());
+
+			expect(serialized).not.toContain('Secret Phase Name');
+			expect(serialized).not.toContain('/Users/someone');
+			expect(serialized).not.toContain('a prompt that may quote');
+			expect(serialized).not.toContain('task text from the document');
+			expect(serialized).not.toContain('# document body');
+		});
+
+		it('reports an error without leaking the error message', () => {
+			useBatchStore.setState({
+				batchRunStates: {
+					'agent-1': createBatchRunState({
+						errorPaused: true,
+						error: {
+							type: 'rate_limited',
+							message: 'quota exceeded for /Users/someone/repo',
+							recoverable: true,
+							agentId: 'claude-code',
+							timestamp: Date.now(),
+						},
+					}),
+				},
+			});
+
+			const [snapshot] = captureAutoRunSnapshots();
+
+			expect(snapshot.hasError).toBe(true);
+			expect(snapshot.errorType).toBe('rate_limited');
+			expect(snapshot.errorPaused).toBe(true);
+			expect(JSON.stringify(snapshot)).not.toContain('quota exceeded');
+		});
+	});
+
+	describe('createDebugPackage', () => {
+		it('attaches the snapshot so main never has to guess', async () => {
+			const createPackage = vi.fn().mockResolvedValue({ success: true });
+			(globalThis as unknown as { window: unknown }).window = {
+				maestro: { debug: { createPackage } },
+			};
+
+			useBatchStore.setState({
+				batchRunStates: { 'agent-1': createBatchRunState({ isRunning: true }) },
+			});
+
+			await createDebugPackage({ includeLogs: false });
+
+			expect(createPackage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					includeLogs: false,
+					autoRunSnapshots: [expect.objectContaining({ sessionId: 'agent-1', isRunning: true })],
+				})
+			);
+		});
+	});
+});

--- a/src/main/debug-package/collectors/batch-state.ts
+++ b/src/main/debug-package/collectors/batch-state.ts
@@ -2,58 +2,61 @@
  * Batch State Collector
  *
  * Collects Auto Run / batch processing state.
- * - No document content or prompts included
+ * - No document content, filenames, paths, or prompts included
+ *
+ * The state itself is captured in the renderer and passed in: Auto Run's live
+ * state is in-memory in `batchStore` and is intentionally not persisted, so
+ * there is nothing in any main-process store for this collector to read. It
+ * previously read a `session.batchRunState` field that nothing has ever
+ * written, so every package shipped an empty section.
  */
 
-import Store from 'electron-store';
+import type { AutoRunDebugSnapshot } from '../../../shared/debugPackage';
 
 export interface BatchStateInfo {
-	activeSessions: Array<{
-		sessionId: string;
-		isRunning: boolean;
-		isStopping: boolean;
-		documentCount: number;
-		currentDocumentIndex: number;
-		loopEnabled: boolean;
-		loopIteration: number;
-		worktreeActive: boolean;
-		hasError: boolean;
-		errorType?: string;
-		startTime?: number;
-		elapsedMs?: number;
-	}>;
+	/**
+	 * False when the caller could not supply renderer state (for example a
+	 * package generated without a live window). Distinguishes "no Auto Run was
+	 * active" from "we could not tell", which is the difference that made the
+	 * previous empty section so misleading.
+	 */
+	snapshotAvailable: boolean;
+	activeSessions: Array<
+		AutoRunDebugSnapshot & {
+			/** Wall-clock time since the run started, at collection time. */
+			elapsedMs?: number;
+			/** Time since the run last reported activity, at collection time. */
+			idleMs?: number;
+		}
+	>;
 }
 
 /**
- * Collect batch/Auto Run state from sessions.
+ * Collect batch/Auto Run state from a renderer-supplied snapshot.
+ *
+ * Sessions with no Auto Run activity are filtered out: a run that never started
+ * and has no progress is noise in a support package.
  */
-export function collectBatchState(sessionsStore: Store<any>): BatchStateInfo {
-	const result: BatchStateInfo = {
-		activeSessions: [],
-	};
-
-	const sessions = sessionsStore.get('sessions', []) as any[];
-
-	for (const session of sessions) {
-		// Check if this session has batch/Auto Run state
-		const batchState = session.batchRunState;
-		if (batchState) {
-			result.activeSessions.push({
-				sessionId: session.id || 'unknown',
-				isRunning: !!batchState.isRunning,
-				isStopping: !!batchState.isStopping,
-				documentCount: batchState.documentCount || 0,
-				currentDocumentIndex: batchState.currentDocumentIndex || 0,
-				loopEnabled: !!batchState.loopEnabled,
-				loopIteration: batchState.loopIteration || 0,
-				worktreeActive: !!batchState.worktreeActive,
-				hasError: !!batchState.error,
-				errorType: batchState.error?.type,
-				startTime: batchState.startTime,
-				elapsedMs: batchState.startTime ? Date.now() - batchState.startTime : undefined,
-			});
-		}
+export function collectBatchState(snapshots?: AutoRunDebugSnapshot[]): BatchStateInfo {
+	if (!snapshots) {
+		return { snapshotAvailable: false, activeSessions: [] };
 	}
 
-	return result;
+	const now = Date.now();
+	const activeSessions = snapshots
+		.filter(
+			(s) =>
+				s.isRunning ||
+				s.isStopping ||
+				s.hasError ||
+				s.errorPaused ||
+				s.completedTasksAcrossAllDocs > 0
+		)
+		.map((s) => ({
+			...s,
+			elapsedMs: s.startTime ? now - s.startTime : undefined,
+			idleMs: s.lastActiveTimestamp ? now - s.lastActiveTimestamp : undefined,
+		}));
+
+	return { snapshotAvailable: true, activeSessions };
 }

--- a/src/main/debug-package/index.ts
+++ b/src/main/debug-package/index.ts
@@ -34,14 +34,9 @@ import { AgentDetector } from '../agents';
 import { ProcessManager } from '../process-manager';
 import { WebServer } from '../web-server';
 import Store from 'electron-store';
+import type { DebugPackageOptions } from '../../shared/debugPackage';
 
-export interface DebugPackageOptions {
-	includeLogs?: boolean; // Default: true
-	includeErrors?: boolean; // Default: true
-	includeSessions?: boolean; // Default: true
-	includeGroupChats?: boolean; // Default: true
-	includeBatchState?: boolean; // Default: true
-}
+export type { DebugPackageOptions };
 
 export interface DebugPackageResult {
 	success: boolean;
@@ -242,7 +237,7 @@ export async function generateDebugPackage(
 	// Collect batch state (optional)
 	if (opts.includeBatchState) {
 		try {
-			const batchState = collectBatchState(deps.sessionsStore);
+			const batchState = collectBatchState(opts.autoRunSnapshots);
 			contents['batch-state.json'] = batchState;
 			filesIncluded.push('batch-state.json');
 		} catch (error) {

--- a/src/main/preload/debug.ts
+++ b/src/main/preload/debug.ts
@@ -7,17 +7,9 @@
  */
 
 import { ipcRenderer } from 'electron';
+import type { DebugPackageOptions } from '../../shared/debugPackage';
 
-/**
- * Debug package options
- */
-export interface DebugPackageOptions {
-	includeLogs?: boolean;
-	includeErrors?: boolean;
-	includeSessions?: boolean;
-	includeGroupChats?: boolean;
-	includeBatchState?: boolean;
-}
+export type { DebugPackageOptions };
 
 /**
  * Document graph file change event

--- a/src/renderer/components/DebugPackageModal.tsx
+++ b/src/renderer/components/DebugPackageModal.tsx
@@ -17,6 +17,7 @@ import { Modal, ModalFooter } from './ui/Modal';
 import { notifyToast } from '../stores/notificationStore';
 import { flashCopiedToClipboard } from '../utils/flashCopiedToClipboard';
 import { logger } from '../utils/logger';
+import { createDebugPackage } from '../services/debugPackage';
 
 interface DebugPackageModalProps {
 	theme: Theme;
@@ -104,7 +105,7 @@ export function DebugPackageModal({ theme, isOpen, onClose }: DebugPackageModalP
 				includeBatchState: categories.find((c) => c.id === 'batchState')?.included ?? true,
 			};
 
-			const result = await window.maestro.debug.createPackage(options);
+			const result = await createDebugPackage(options);
 
 			if (result.cancelled) {
 				setGenerationState('idle');

--- a/src/renderer/components/QuickActionsModal/QuickActionsModal.tsx
+++ b/src/renderer/components/QuickActionsModal/QuickActionsModal.tsx
@@ -29,6 +29,7 @@ import type { GroupChatBusySnapshot } from '../../utils/groupChatStatus';
 import { openUrl } from '../../utils/openUrl';
 import { outputSearchKeyFor } from '../../utils/outputSearch';
 import { logger } from '../../utils/logger';
+import { createDebugPackage } from '../../services/debugPackage';
 import { getActiveTabInfo } from './utils/activeTabInfo';
 import {
 	filterAndSortQuickActions,
@@ -698,7 +699,7 @@ export const QuickActionsModal = memo(function QuickActionsModal(props: QuickAct
 			setDebugPackageModalOpen,
 			startTour,
 			getFeedbackDraft: () => useFeedbackDraftStore.getState(),
-			createDebugPackage: () => window.maestro.debug.createPackage(),
+			createDebugPackage: () => createDebugPackage(),
 			notifyToast,
 			openUrl,
 			toggleDevtools: () => window.maestro.devtools.toggle(),

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -166,6 +166,7 @@ import type { CueLogPayload } from '../shared/cue-log-types';
 import type { CueStatsAggregation, CueStatsTimeRange } from '../shared/cue-stats-types';
 import type { DurationPercentiles } from '../shared/percentiles';
 import type { MaestroCliStatus, MaestroCliInstallResult } from '../shared/maestro-cli';
+import type { DebugPackageOptions } from '../shared/debugPackage';
 import type {
 	GitWorktreeSetupResult,
 	GitWorktreeCheckoutResult,
@@ -2644,13 +2645,7 @@ interface MaestroAPI {
 	};
 	// Debug Package API
 	debug: {
-		createPackage: (options?: {
-			includeLogs?: boolean;
-			includeErrors?: boolean;
-			includeSessions?: boolean;
-			includeGroupChats?: boolean;
-			includeBatchState?: boolean;
-		}) => Promise<{
+		createPackage: (options?: DebugPackageOptions) => Promise<{
 			success: boolean;
 			path?: string;
 			filesIncluded: string[];

--- a/src/renderer/services/debugPackage.ts
+++ b/src/renderer/services/debugPackage.ts
@@ -1,0 +1,66 @@
+/**
+ * Debug package service.
+ *
+ * Single entry point for generating a support package. It exists so the Auto
+ * Run snapshot is captured in one place: that state lives only in the
+ * renderer's in-memory `batchStore`, so a call site that goes straight to
+ * `window.maestro.debug.createPackage` silently ships a package with no Auto
+ * Run diagnostics at all. Call this instead.
+ */
+
+import { useBatchStore } from '../stores/batchStore';
+import type { AutoRunDebugSnapshot, DebugPackageOptions } from '../../shared/debugPackage';
+
+/**
+ * Capture the current Auto Run state for every agent, as counters and flags.
+ *
+ * Deliberately omits `documents` (filenames), `folderPath`, worktree paths,
+ * `customPrompt`, `errorTaskDescription`, and the error message: a support
+ * package must not carry document content or paths.
+ */
+export function captureAutoRunSnapshots(): AutoRunDebugSnapshot[] {
+	const states = useBatchStore.getState().batchRunStates;
+
+	return Object.entries(states).map(([sessionId, state]) => ({
+		sessionId,
+		isRunning: state.isRunning,
+		isStopping: state.isStopping,
+		processingState: state.processingState,
+
+		documentCount: state.documents?.length ?? 0,
+		currentDocumentIndex: state.currentDocumentIndex,
+
+		currentDocTasksTotal: state.currentDocTasksTotal,
+		currentDocTasksCompleted: state.currentDocTasksCompleted,
+		totalTasksAcrossAllDocs: state.totalTasksAcrossAllDocs,
+		completedTasksAcrossAllDocs: state.completedTasksAcrossAllDocs,
+
+		loopEnabled: state.loopEnabled,
+		loopIteration: state.loopIteration,
+		maxLoops: state.maxLoops,
+
+		worktreeActive: state.worktreeActive,
+
+		hasError: !!state.error,
+		errorType: state.error?.type,
+		errorPaused: !!state.errorPaused,
+		errorDocumentIndex: state.errorDocumentIndex,
+
+		startTime: state.startTime,
+		cumulativeTaskTimeMs: state.cumulativeTaskTimeMs,
+		accumulatedElapsedMs: state.accumulatedElapsedMs,
+		lastActiveTimestamp: state.lastActiveTimestamp,
+	}));
+}
+
+/**
+ * Generate a debug package, attaching the live Auto Run snapshot.
+ */
+export function createDebugPackage(
+	options?: Omit<DebugPackageOptions, 'autoRunSnapshots'>
+): ReturnType<typeof window.maestro.debug.createPackage> {
+	return window.maestro.debug.createPackage({
+		...options,
+		autoRunSnapshots: captureAutoRunSnapshots(),
+	});
+}

--- a/src/renderer/services/index.ts
+++ b/src/renderer/services/index.ts
@@ -40,6 +40,9 @@ export {
 } from './systemSleep';
 export type { SleepAwareSpan } from './systemSleep';
 
+// Debug/support package service (owns the Auto Run snapshot capture)
+export { createDebugPackage, captureAutoRunSnapshots } from './debugPackage';
+
 // Wizard intent parser service
 export { parseWizardIntent, suggestsIterateIntent, suggestsNewIntent } from './wizardIntentParser';
 export type { WizardIntentResult } from './wizardIntentParser';

--- a/src/shared/debugPackage.ts
+++ b/src/shared/debugPackage.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared types for the debug/support package.
+ *
+ * These cross the IPC boundary (renderer -> preload -> main), so they live here
+ * rather than being redeclared per process. `DebugPackageOptions` used to be
+ * copy-pasted into three files and drifted the moment a field was added.
+ *
+ * Privacy: nothing in here carries document content, prompts, task text, or
+ * filesystem paths. Auto Run's live state is counters and flags only.
+ */
+
+/**
+ * One agent's Auto Run (batch) state at the moment a debug package is captured.
+ *
+ * The authoritative state lives in the renderer's in-memory `batchStore` and is
+ * deliberately never persisted (see `useAutoResumeCoordinator` - the
+ * orchestration loop does not survive a restart by design). Main therefore has
+ * no way to read it on its own, so the renderer hands over this snapshot when
+ * it asks for a package.
+ */
+export interface AutoRunDebugSnapshot {
+	sessionId: string;
+	isRunning: boolean;
+	isStopping: boolean;
+	/** Batch state-machine phase, e.g. 'idle' | 'processing' | 'paused'. */
+	processingState?: string;
+
+	// Document-level progress
+	documentCount: number;
+	currentDocumentIndex: number;
+
+	// Task-level progress
+	currentDocTasksTotal: number;
+	currentDocTasksCompleted: number;
+	totalTasksAcrossAllDocs: number;
+	completedTasksAcrossAllDocs: number;
+
+	// Loop mode
+	loopEnabled: boolean;
+	loopIteration: number;
+	maxLoops?: number | null;
+
+	worktreeActive: boolean;
+
+	// Error state. The message and the failing task's description are omitted on
+	// purpose - they can quote document content.
+	hasError: boolean;
+	errorType?: string;
+	errorPaused: boolean;
+	errorDocumentIndex?: number;
+
+	// Timing. `startTime` plus a long-idle `lastActiveTimestamp` is the signature
+	// of a hung run, which is the main thing this section exists to show.
+	startTime?: number;
+	cumulativeTaskTimeMs?: number;
+	accumulatedElapsedMs?: number;
+	lastActiveTimestamp?: number;
+}
+
+/**
+ * Which optional sections to include in a generated package.
+ */
+export interface DebugPackageOptions {
+	includeLogs?: boolean; // Default: true
+	includeErrors?: boolean; // Default: true
+	includeSessions?: boolean; // Default: true
+	includeGroupChats?: boolean; // Default: true
+	includeBatchState?: boolean; // Default: true
+	/**
+	 * Auto Run state captured by the renderer at request time. Omitted when the
+	 * caller has no renderer state to offer; the section then reports that it was
+	 * unavailable rather than silently claiming no runs were active.
+	 */
+	autoRunSnapshots?: AutoRunDebugSnapshot[];
+}


### PR DESCRIPTION
Ports e4abec659 from `main` to `rc`.

## The bug

The "Auto Run State" section of every debug package has always been empty.

`collectBatchState` read `session.batchRunState` from the sessions store - a field nothing has ever written, and which is not on the `Session` type. The `sessionsStore.get('sessions', []) as any[]` cast is why no type error ever surfaced. So `batch-state.json` has always shipped `{"activeSessions": []}`, and the one diagnostic you want when Auto Run hangs has never contained anything.

This surfaced while diagnosing a real stalled Auto Run: there was no usable state to look at.

## Why it can't just read from main

Auto Run state lives in the renderer's in-memory `batchStore` and is deliberately never persisted - the orchestration loop does not survive a restart by design (see the comment in `useAutoResumeCoordinator.ts:274-286`). Main's only other copy is `LiveSessionManager`'s map, which is populated solely when the web server is running (`web:broadcastAutoRunState` is gated on `getWebServer()`), so it isn't a dependable source either.

## The fix

The renderer hands over a snapshot when it asks for a package.

- New `src/renderer/services/debugPackage.ts` owns the capture. Both call sites (`DebugPackageModal`, `QuickActionsModal`) go through `createDebugPackage()`, so neither can forget the snapshot.
- `collectBatchState` is now a pure transform over that snapshot and reports `snapshotAvailable`, keeping "no Auto Run was active" distinct from "we could not tell". That ambiguity is what made the empty section so misleading.
- Adds `idleMs` alongside `elapsedMs`: a run that started long ago and has been silent since is the actual signature of a hang.
- `DebugPackageOptions` was copy-pasted into three files, so rather than add the new field a fourth time it moved to `src/shared/debugPackage.ts`.

## Privacy

The snapshot is counters and flags only. No filenames, folder or worktree paths, custom prompt, task descriptions, or error messages. Covered by an explicit test.

## Tests

The old test fabricated a session carrying `batchRunState`, asserting against a shape production never produces - exactly how this survived. It now builds snapshots the way the renderer service does, plus new coverage for the unavailable-vs-empty distinction and the privacy guarantee.

Full rc suite green locally: 36,919 passed.
