### PR TITLE
fix(symphony): harden IPC handlers, dashboard stats, and cache reuse

### DIFF
--- a/src/__tests__/main/ipc/handlers/symphony.test.ts
+++ b/src/__tests__/main/ipc/handlers/symphony.test.ts
@@ -1151,6 +1151,46 @@ describe('Symphony IPC handlers', () => {
 		});
 	});
 
+	describe('symphony:getIssueCounts cache operations', () => {
+		it('should not serve a stale-fallback cache built for a different repo set', async () => {
+			const cacheData = {
+				issues: {},
+				issueCounts: {
+					data: { 'owner/other-repo': 7 },
+					fetchedAt: Date.now() - 60 * 60 * 1000, // 1 hour ago, past the 30-minute TTL
+					repoSlugs: ['owner/other-repo'],
+				},
+			};
+			vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(cacheData));
+			mockFetch.mockRejectedValue(new Error('Network error'));
+
+			const handler = handlers.get('symphony:getIssueCounts');
+			const result = await handler!({} as any, ['owner/repo'], false);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Network error');
+		});
+
+		it('should serve the stale-fallback cache when the repo set matches', async () => {
+			const cacheData = {
+				issues: {},
+				issueCounts: {
+					data: { 'owner/repo': 3 },
+					fetchedAt: Date.now() - 60 * 60 * 1000, // 1 hour ago, past the 30-minute TTL
+					repoSlugs: ['owner/repo'],
+				},
+			};
+			vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(cacheData));
+			mockFetch.mockRejectedValue(new Error('Network error'));
+
+			const handler = handlers.get('symphony:getIssueCounts');
+			const result = await handler!({} as any, ['owner/repo'], false);
+
+			expect(result.fromCache).toBe(true);
+			expect(result.counts).toEqual({ 'owner/repo': 3 });
+		});
+	});
+
 	describe('symphony:getIssues cache operations', () => {
 		it('should return cached issues when cache is valid', async () => {
 			const cachedIssues = [{ number: 1, title: 'Cached Issue' }];
@@ -1570,6 +1610,7 @@ describe('Symphony IPC handlers', () => {
 				active: [
 					{
 						id: 'contrib_1',
+						sessionId: 'session_1',
 						tokenUsage: { inputTokens: 1000, outputTokens: 500, estimatedCost: 0.1 },
 						timeSpent: 60000,
 						progress: {
@@ -1597,6 +1638,7 @@ describe('Symphony IPC handlers', () => {
 				},
 			};
 			vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(stateWithActive));
+			mockSessionsStore.get.mockReturnValue([{ id: 'session_1', name: 'Session 1' }]);
 
 			const handler = handlers.get('symphony:getStats');
 			const result = await handler!({} as any);
@@ -1614,6 +1656,7 @@ describe('Symphony IPC handlers', () => {
 				active: [
 					{
 						id: 'contrib_1',
+						sessionId: 'session_1',
 						tokenUsage: { inputTokens: 1000, outputTokens: 500, estimatedCost: 0.1 },
 						timeSpent: 60000,
 						progress: {
@@ -1625,6 +1668,7 @@ describe('Symphony IPC handlers', () => {
 					},
 					{
 						id: 'contrib_2',
+						sessionId: 'session_2',
 						tokenUsage: { inputTokens: 2000, outputTokens: 1000, estimatedCost: 0.2 },
 						timeSpent: 120000,
 						progress: {
@@ -1636,6 +1680,7 @@ describe('Symphony IPC handlers', () => {
 					},
 					{
 						id: 'contrib_3',
+						sessionId: 'session_3',
 						tokenUsage: { inputTokens: 500, outputTokens: 250, estimatedCost: 0.05 },
 						timeSpent: 30000,
 						progress: {
@@ -1663,6 +1708,11 @@ describe('Symphony IPC handlers', () => {
 				},
 			};
 			vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(stateWithMultipleActive));
+			mockSessionsStore.get.mockReturnValue([
+				{ id: 'session_1', name: 'Session 1' },
+				{ id: 'session_2', name: 'Session 2' },
+				{ id: 'session_3', name: 'Session 3' },
+			]);
 
 			const handler = handlers.get('symphony:getStats');
 			const result = await handler!({} as any);
@@ -1678,6 +1728,65 @@ describe('Symphony IPC handlers', () => {
 			expect(result.stats.totalDocumentsProcessed).toBe(4);
 			// Tasks: 2 + 7 + 1 = 10
 			expect(result.stats.totalTasksCompleted).toBe(10);
+		});
+
+		it('should exclude orphaned active contributions whose sessions are gone', async () => {
+			const stateWithOrphan = {
+				active: [
+					{
+						id: 'contrib_alive',
+						sessionId: 'session_exists',
+						tokenUsage: { inputTokens: 1000, outputTokens: 500, estimatedCost: 0.1 },
+						timeSpent: 60000,
+						progress: {
+							completedDocuments: 1,
+							completedTasks: 2,
+							totalDocuments: 2,
+							totalTasks: 5,
+						},
+					},
+					{
+						id: 'contrib_orphan',
+						sessionId: 'session_gone',
+						tokenUsage: { inputTokens: 9000, outputTokens: 9000, estimatedCost: 9 },
+						timeSpent: 900000,
+						progress: {
+							completedDocuments: 9,
+							completedTasks: 9,
+							totalDocuments: 9,
+							totalTasks: 9,
+						},
+					},
+				],
+				history: [],
+				stats: {
+					totalContributions: 0,
+					totalMerged: 0,
+					totalIssuesResolved: 0,
+					totalDocumentsProcessed: 0,
+					totalTasksCompleted: 0,
+					totalTokensUsed: 0,
+					totalTimeSpent: 0,
+					estimatedCostDonated: 0,
+					repositoriesContributed: [],
+					uniqueMaintainersHelped: 0,
+					currentStreak: 0,
+					longestStreak: 0,
+				},
+			};
+			vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(stateWithOrphan));
+			// Only session_exists is a live session; session_gone's contribution is orphaned
+			mockSessionsStore.get.mockReturnValue([{ id: 'session_exists', name: 'Existing Session' }]);
+
+			const handler = handlers.get('symphony:getStats');
+			const result = await handler!({} as any);
+
+			// Only contrib_alive's stats should be aggregated
+			expect(result.stats.totalTokensUsed).toBe(1500);
+			expect(result.stats.totalTimeSpent).toBe(60000);
+			expect(result.stats.estimatedCostDonated).toBeCloseTo(0.1, 5);
+			expect(result.stats.totalDocumentsProcessed).toBe(1);
+			expect(result.stats.totalTasksCompleted).toBe(2);
 		});
 	});
 
@@ -4984,6 +5093,36 @@ describe('Symphony IPC handlers', () => {
 					.mock.calls.filter((call) => call[0] === 'git' && call[1]?.[0] === 'push');
 				expect(pushCalls).toHaveLength(0);
 			});
+
+			it('should return an error instead of skipping PR creation when rev-list fails', async () => {
+				const metadata = createValidMetadata();
+				vi.mocked(fs.readFile).mockImplementation(async (filePath) => {
+					if ((filePath as string).includes('metadata.json')) {
+						return JSON.stringify(metadata);
+					}
+					throw new Error('ENOENT');
+				});
+				vi.mocked(execFileNoThrow).mockImplementation(async (cmd, args) => {
+					if (cmd === 'gh' && args?.[0] === 'auth')
+						return { stdout: 'Logged in', stderr: '', exitCode: 0 };
+					if (cmd === 'git' && args?.[0] === 'symbolic-ref')
+						return { stdout: 'refs/remotes/origin/main', stderr: '', exitCode: 0 };
+					if (cmd === 'git' && args?.[0] === 'rev-list')
+						return { stdout: '', stderr: 'fatal: bad revision', exitCode: 128 };
+					return { stdout: '', stderr: '', exitCode: 0 };
+				});
+
+				const handler = getCreateDraftPRHandler();
+				const result = await handler!({} as any, { contributionId: 'contrib_draft_test' });
+
+				expect(result.success).toBe(false);
+				expect(result.error).toContain('Failed to check commits');
+				// git push should not have been called
+				const pushCalls = vi
+					.mocked(execFileNoThrow)
+					.mock.calls.filter((call) => call[0] === 'git' && call[1]?.[0] === 'push');
+				expect(pushCalls).toHaveLength(0);
+			});
 		});
 
 		describe('PR creation', () => {
@@ -5889,6 +6028,36 @@ This is a Symphony task document.
 				});
 
 				expect(result.error).toContain('Missing required fields');
+				expect(result.contributionId).toBeUndefined();
+			});
+
+			it('should reject a negative issue number', async () => {
+				const handler = getManualCreditHandler();
+				const result = await handler!({} as any, {
+					repoSlug: 'owner/repo',
+					repoName: 'Test Repo',
+					issueNumber: -5,
+					issueTitle: 'Test Issue',
+					prNumber: 456,
+					prUrl: 'https://github.com/owner/repo/pull/456',
+				});
+
+				expect(result.error).toContain('Invalid issue number');
+				expect(result.contributionId).toBeUndefined();
+			});
+
+			it('should reject a non-integer PR number', async () => {
+				const handler = getManualCreditHandler();
+				const result = await handler!({} as any, {
+					repoSlug: 'owner/repo',
+					repoName: 'Test Repo',
+					issueNumber: 123,
+					issueTitle: 'Test Issue',
+					prNumber: 456.5,
+					prUrl: 'https://github.com/owner/repo/pull/456',
+				});
+
+				expect(result.error).toContain('Invalid PR number');
 				expect(result.contributionId).toBeUndefined();
 			});
 

--- a/src/main/ipc/handlers/symphony/contributionFinish.ts
+++ b/src/main/ipc/handlers/symphony/contributionFinish.ts
@@ -116,6 +116,15 @@ export function registerContributionFinishHandlers({
 					localPath
 				);
 
+				if (commitCheckResult.exitCode !== 0) {
+					logger.error('Failed to count commits ahead of base branch', LOG_CONTEXT, {
+						contributionId,
+						baseBranch,
+						error: commitCheckResult.stderr,
+					});
+					return { success: false, error: `Failed to check commits: ${commitCheckResult.stderr}` };
+				}
+
 				const commitCount = parseInt(commitCheckResult.stdout.trim(), 10) || 0;
 				if (commitCount === 0) {
 					// No commits yet - return success but indicate no PR created
@@ -306,6 +315,12 @@ This PR will be updated automatically when the Auto Run completes.`;
 					return {
 						error: 'Missing required fields: repoSlug, repoName, issueNumber, prNumber, prUrl',
 					};
+				}
+				if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+					return { error: 'Invalid issue number' };
+				}
+				if (!Number.isInteger(prNumber) || prNumber <= 0) {
+					return { error: 'Invalid PR number' };
 				}
 
 				const state = await readState(app);

--- a/src/main/ipc/handlers/symphony/dashboard.ts
+++ b/src/main/ipc/handlers/symphony/dashboard.ts
@@ -14,10 +14,15 @@ import { LOG_CONTEXT, handlerOpts, readState, SymphonyHandlerDependencies } from
 /**
  * Filter out orphaned contributions whose sessions no longer exist.
  * Returns only contributions that have a corresponding session in the sessions store.
+ *
+ * Pass logOrphans: false for callers that run on a poll timer. getStats is
+ * polled every 5 seconds, and the orphaned ids it would report are already
+ * logged by the getState / getActive paths, so logging there is pure duplication.
  */
 function filterOrphanedContributions(
 	contributions: ActiveContribution[],
-	sessionsStore: Store<SessionsData>
+	sessionsStore: Store<SessionsData>,
+	logOrphans = true
 ): ActiveContribution[] {
 	const sessions = sessionsStore.get('sessions', []) as StoredSession[];
 	const sessionIds = new Set(sessions.map((s) => s.id));
@@ -33,7 +38,7 @@ function filterOrphanedContributions(
 		}
 	}
 
-	if (orphanedIds.length > 0) {
+	if (logOrphans && orphanedIds.length > 0) {
 		logger.info(
 			`Filtering ${orphanedIds.length} orphaned contribution(s) with missing sessions`,
 			LOG_CONTEXT,
@@ -124,7 +129,8 @@ export function registerDashboardHandlers({
 				let activeDocs = 0;
 				let activeTasks = 0;
 
-				for (const contribution of state.active) {
+				const validActive = filterOrphanedContributions(state.active, sessionsStore, false);
+				for (const contribution of validActive) {
 					activeTokens +=
 						contribution.tokenUsage.inputTokens + contribution.tokenUsage.outputTokens;
 					activeTime += contribution.timeSpent;

--- a/src/main/ipc/handlers/symphony/discovery.ts
+++ b/src/main/ipc/handlers/symphony/discovery.ts
@@ -661,15 +661,17 @@ export function registerDiscoveryHandlers({
 			): Promise<Omit<GetIssueCountsResponse, 'success'>> => {
 				const cache = await readCache(app);
 				const requestedSlugs = [...new Set(repoSlugs)].sort();
+				const cachedSlugsMatch = (cachedSlugs?: string[]): boolean =>
+					!!cachedSlugs &&
+					requestedSlugs.length === cachedSlugs.length &&
+					requestedSlugs.every((s) => cachedSlugs.includes(s));
 
 				// Check cache (must match requested slugs AND be within TTL)
 				if (
 					!forceRefresh &&
 					cache?.issueCounts &&
 					isCacheValid(cache.issueCounts.fetchedAt, ISSUE_COUNTS_CACHE_TTL_MS) &&
-					cache.issueCounts.repoSlugs &&
-					requestedSlugs.length === cache.issueCounts.repoSlugs.length &&
-					requestedSlugs.every((s) => cache.issueCounts!.repoSlugs.includes(s))
+					cachedSlugsMatch(cache.issueCounts.repoSlugs)
 				) {
 					return {
 						counts: cache.issueCounts.data,
@@ -704,8 +706,8 @@ export function registerDiscoveryHandlers({
 						error,
 					});
 
-					// Fallback to expired cache if available
-					if (cache?.issueCounts?.data) {
+					// Fallback to expired cache if available for the same repo set
+					if (cache?.issueCounts?.data && cachedSlugsMatch(cache.issueCounts.repoSlugs)) {
 						const cacheAge = Date.now() - cache.issueCounts.fetchedAt;
 						return {
 							counts: cache.issueCounts.data,


### PR DESCRIPTION
## Summary

Four independent correctness fixes in the Symphony IPC handlers, grouped by root cause. All four are pre-existing on `refactoring` and were kept out of #1384 so that PR stays scoped to path traversal.

This targets `refactoring` while #1369 is open. If #1369 merges first, this can be retargeted to `rc` and rebased.

### Unchecked subprocess result (`contributionFinish.ts`)

`createDraftPR` used `git rev-list --count <base>..HEAD` to decide whether a branch has commits worth opening a PR for, then read the result with `parseInt(stdout) || 0` without checking `exitCode`. When that command fails, for example when the base ref is missing, stdout is empty and the count reads as zero, so the handler reported success and skipped PR creation instead of surfacing the failure.

It now checks `exitCode` first and returns `{ success: false, error }` with the git stderr attached. The legitimate zero-commit path is unchanged: when the base ref resolves and the branch has no commits ahead, git exits 0 and the handler still returns success with no PR fields.

### Missing numeric validation (`contributionFinish.ts`)

`symphony:start` validates its issue number with `Number.isInteger(n) && n > 0`. `symphony:manualCredit` used a truthy check, so negative and fractional values were accepted and would reach the generated PR title, the stored history entry, and the GitHub URLs built from it.

`manualCredit` now applies the same check to `issueNumber` and `prNumber`. This also rejects numeric strings, which the truthy check previously allowed. That matches the declared parameter types, and the existing duplicate-credit lookup already compares with `===`, so string values were never handled correctly on that path.

### Inconsistent orphan filtering (`dashboard.ts`)

`getState` and `getActive` both drop active contributions whose backing session no longer exists, via `filterOrphanedContributions`. `getStats` aggregated the same `state.active` array for its live totals without that filter, so tokens, time, cost, documents, and tasks belonging to a removed session kept counting toward the dashboard.

`getStats` now filters before aggregating, which makes the three read paths consistent. `filterOrphanedContributions` gained an optional `logOrphans` flag and `getStats` passes `false`, because it runs on a five second poll and the orphaned ids are already logged by `getState` and `getActive`.

### Cache reuse without a key match (`discovery.ts`)

`symphony:getIssueCounts` has two cache reads. The in-TTL path compares the cached `repoSlugs` against the request. The expired-cache fallback, used when the live Search API call fails, returned `cache.issueCounts.data` without that comparison, so a cache written for a different repo set could be served against the current request.

The slug set comparison is now a single `cachedSlugsMatch` helper used by both paths. When the sets differ, the original fetch error propagates instead. The renderer already handles that outcome: the response guard skips the state update, and the card reads `issueCounts?.[repo.slug] ?? null`.

## Scope

`symphony:createDraftPR` and `symphony:manualCredit` are exposed through the preload bridge and have no caller in the renderer or CLI today, so those two fixes harden reachable IPC surface rather than an active UI flow. `getStats` and `getIssueCounts` are both on live paths.

## Tests

Six tests added to `src/__tests__/main/ipc/handlers/symphony.test.ts`, one per fix plus the passing counterpart for the cache change, alongside the existing Symphony coverage:

- `should return an error instead of skipping PR creation when rev-list fails`
- `should reject a negative issue number`
- `should reject a non-integer PR number`
- `should exclude orphaned active contributions whose sessions are gone`
- `should not serve a stale-fallback cache built for a different repo set`
- `should serve the stale-fallback cache when the repo set matches`

The last two sit in a new `symphony:getIssueCounts cache operations` block, since that handler had no cache coverage before. Both use a `fetchedAt` older than the thirty minute TTL so the expired-cache branch is the one under test.

Two existing `symphony:getStats` tests were updated as a consequence of the orphan filter, `should include real-time stats from active contributions` and `should aggregate tokens, time, cost from active contributions`. Their fixtures gained a `sessionId` and a matching `mockSessionsStore` return value so the contributions are not orphans. The assertions and expected totals in both are unchanged.

## Deferred

Recorded rather than changed here, since each needs a design instead of a local edit:

- `fetch()` in `discovery.ts`, `contributionStart.ts`, `contributionFinish.ts`, and `sync.ts` has no timeout or `AbortSignal`. One shared helper is the right shape.
- `readState` / `writeState` and `readCache` / `writeCache` are uncoordinated file IO. `getRegistry` also writes an `issues` snapshot taken before a later `readCache`. This needs one serialization design.
- Symphony clones and branches locally even when the agent session is SSH backed. This is a product and architecture question.
- `repoSlug` is interpolated into GitHub URLs in `discovery.ts` without the `validateRepoSlug` check that `contributionStart.ts` applies. Separate finding, left out to keep this diff focused.

## Verification

- `npx vitest run src/__tests__/main/ipc/handlers/symphony.test.ts src/__tests__/main/services/symphony-runner.test.ts`: 296 passed
- `npm run lint` (tsc across the lint, main, and cli configs): clean
- `npx eslint src/main/ipc/handlers/symphony/`: clean
- `npx prettier --check` on the touched files: clean
- Behavior checked against a built Electron app over the real preload bridge: `manualCredit` rejects a negative issue number and a fractional PR number and still accepts valid input, `getStats` excludes an orphaned contribution from live totals, `getIssueCounts` declines a cache written for a different repo set, `createDraftPR` reports a git failure instead of skipping PR creation, and the app starts with no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented issue counts from using stale data from unrelated repositories.
  * Improved live statistics by excluding orphaned contributions.
  * Draft pull request creation now reports commit-count failures instead of proceeding silently.
  * Manual contribution credits now reject invalid or negative issue and pull request numbers.

* **Tests**
  * Added regression coverage for cache isolation, contribution filtering, pull request failures, and input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->