### PR TITLE
fix(readme): restore the broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,10 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, architecture detai
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=runmaestro%2Fmaestro&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#runmaestro/maestro&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=runmaestro/maestro&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=runmaestro/maestro&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=runmaestro/maestro&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=runmaestro/maestro&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=runmaestro/maestro&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=runmaestro/maestro&type=date&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
The Star History chart in the README is currently broken because GitHub restricts the stargazer API the old chart relied on, so the section renders nothing. This switches the chart to a working mirror that uses a different data source and requires no API token. The chart and its wrapping link now point to the new URL, and everything else is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History embed links and chart endpoints to use the new hosting domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->