### PR TITLE
fix(grooming): spawn the detected agent path so compaction works on Windows

### DIFF
--- a/src/__tests__/main/utils/context-groomer.test.ts
+++ b/src/__tests__/main/utils/context-groomer.test.ts
@@ -55,7 +55,11 @@ function makeAgent(overrides: Partial<AgentConfig> = {}): AgentConfig {
 		id: 'claude-code',
 		name: 'Claude Code',
 		binaryName: 'claude',
-		command: '/usr/local/bin/claude',
+		// `command` is the static, bare name from definitions.ts; `path` is what
+		// the detector resolves. Keep them distinct so command-resolution tests
+		// can tell which field actually reaches spawn().
+		command: 'claude',
+		path: '/usr/local/bin/claude',
 		args: ['--default'],
 		available: true,
 		capabilities: {} as AgentConfig['capabilities'],
@@ -205,7 +209,7 @@ describe('groomContext', () => {
 		expect(mockPM._lastSpawnConfig!.args).toContain('--resolved');
 	});
 
-	it('uses sessionCustomPath to override agent.command', async () => {
+	it('uses sessionCustomPath to override the detected agent path', async () => {
 		const detector = createMockAgentDetector(agent);
 
 		await groomContext(
@@ -222,7 +226,7 @@ describe('groomContext', () => {
 		expect(mockPM._lastSpawnConfig!.command).toBe('/custom/claude');
 	});
 
-	it('falls back to agent.command when sessionCustomPath is not provided', async () => {
+	it('falls back to agent.path when sessionCustomPath is not provided', async () => {
 		const detector = createMockAgentDetector(agent);
 
 		await groomContext(
@@ -232,6 +236,38 @@ describe('groomContext', () => {
 		);
 
 		expect(mockPM._lastSpawnConfig!.command).toBe('/usr/local/bin/claude');
+	});
+
+	it('spawns the detected .cmd shim rather than the bare command on Windows', async () => {
+		// Regression: grooming used to spawn `agent.command` ('claude'), which is
+		// not on PATH on Windows (npm installs a claude.cmd shim), so every
+		// "Compact and Continue" failed with `spawn claude ENOENT`.
+		const windowsAgent = makeAgent({
+			path: 'C:\\Users\\u\\AppData\\Roaming\\npm\\claude.cmd',
+		});
+		const detector = createMockAgentDetector(windowsAgent);
+
+		await groomContext(
+			{ projectRoot: 'C:\\project', agentType: 'claude-code', prompt: 'summarize' },
+			mockPM,
+			detector
+		);
+
+		expect(mockPM._lastSpawnConfig!.command).toBe(
+			'C:\\Users\\u\\AppData\\Roaming\\npm\\claude.cmd'
+		);
+	});
+
+	it('falls back to agent.command when the detector resolved no path', async () => {
+		const detector = createMockAgentDetector(makeAgent({ path: undefined }));
+
+		await groomContext(
+			{ projectRoot: '/project', agentType: 'claude-code', prompt: 'summarize' },
+			mockPM,
+			detector
+		);
+
+		expect(mockPM._lastSpawnConfig!.command).toBe('claude');
 	});
 
 	it('passes resolved customEnvVars on spawn config', async () => {

--- a/src/main/utils/context-groomer.ts
+++ b/src/main/utils/context-groomer.ts
@@ -233,7 +233,14 @@ export async function groomContext(
 	});
 	const resolvedArgs = configResolution.args;
 	const resolvedEnvVars = configResolution.effectiveCustomEnvVars;
-	const resolvedCommand = sessionCustomPath || agent.command;
+	// Prefer the absolute path the detector resolved over the static `command`
+	// field from the agent definition. `agent.command` is a bare name like
+	// `claude`, which is not spawnable on Windows: the npm install leaves a
+	// `claude.cmd` shim in %APPDATA%\npm and there is no bare `claude` on PATH,
+	// so spawn() fails with ENOENT. Every other spawn site already resolves
+	// `agent.path || agent.command`; the fallback keeps working on platforms
+	// where the bare command is already on PATH and `path` is unset.
+	const resolvedCommand = sessionCustomPath || agent.path || agent.command;
 
 	// Create a promise that collects the response
 	return new Promise<GroomContextResult>((resolve, reject) => {

--- a/src/main/utils/context-groomer.ts
+++ b/src/main/utils/context-groomer.ts
@@ -240,6 +240,12 @@ export async function groomContext(
 	// so spawn() fails with ENOENT. Every other spawn site already resolves
 	// `agent.path || agent.command`; the fallback keeps working on platforms
 	// where the bare command is already on PATH and `path` is unset.
+	//
+	// `agent.path` is a LOCAL path. Grooming only ever spawns locally today (see
+	// the note on the spawn call below), so that is correct as written - but
+	// whoever routes grooming through SSH must not send this to a remote host,
+	// which has its own filesystem. Remote execution uses the agent's
+	// `binaryName`; `wrapSpawnWithSsh` handles that.
 	const resolvedCommand = sessionCustomPath || agent.path || agent.command;
 
 	// Create a promise that collects the response
@@ -390,7 +396,14 @@ export async function groomContext(
 			promptArgs: agent.promptArgs, // For agents using flag-based prompt (e.g., OpenCode -p)
 			noPromptSeparator: agent.noPromptSeparator,
 			sendPromptViaStdinRaw: useStdinForPrompt,
-			// Pass SSH config for remote execution support
+			// KNOWN GAP (issue #1416): this is accepted but NOT acted on. Unlike
+			// group chat, Cue, and the CLI, grooming never calls
+			// `wrapSpawnWithSsh`, and `ProcessManager.spawn()` does no SSH
+			// wrapping of its own - `ProcessConfig` has no such field, so this
+			// value is dropped on the floor. Grooming therefore always runs on the
+			// local machine even when the agent is configured for an SSH remote.
+			// Kept wired up because the value is correct and the only missing
+			// piece is the wrapper call; do not read its presence as SSH support.
 			sessionSshRemoteConfig,
 			// Pass resolved env vars (merged from agent defaults + agent config + session overrides)
 			customEnvVars: resolvedEnvVars,


### PR DESCRIPTION
Closes #1402

## Problem

`Compact and Continue` and automatic context grooming (`autoGroomContexts: true`) failed 100% of the time on Windows with `Failed to spawn grooming process for claude-code` / `spawn claude ENOENT`.

`groomContext()` in `src/main/utils/context-groomer.ts` resolved its spawn target as:

```ts
const resolvedCommand = sessionCustomPath || agent.command;
```

`agent.command` is the static field from `src/main/agents/definitions.ts` - the literal string `'claude'`, with no path and no extension. That is not a spawnable binary on Windows: the npm install leaves a `claude.cmd` shim under `%APPDATA%\npm` and there is no bare `claude` on PATH, so `spawn()` throws `ENOENT` immediately.

This was the only spawn site in the codebase skipping the detector-resolved path. Every other one already uses `agent.path || agent.command`:

- `src/main/ipc/handlers/tabNaming.ts:184`
- `src/main/ipc/handlers/agents.ts:1474`
- `src/main/group-chat/group-chat-router.ts` (several)
- `src/main/group-chat/spawnGroupChatAgent.ts:112`
- `src/main/cross-agent/cross-agent-router.ts:235`
- `src/main/agents/detector.ts:344`

Credit to @pedro12u for the diagnosis and for validating the patch against a repacked build.

## Fix

```ts
const resolvedCommand = sessionCustomPath || agent.path || agent.command;
```

`ChildProcessSpawner` already auto-enables `shell` for `.cmd`/`.bat` targets on Windows (`src/main/process-manager/spawners/ChildProcessSpawner.ts:278`), so handing it the resolved shim path is all that was needed - no shell handling changes here. The `agent.command` fallback is preserved for environments where the detector never populated a path and the bare name is already on PATH.

## Tests

The existing suite missed this because the agent fixture set `command: '/usr/local/bin/claude'`, an absolute path no real agent definition ever has - so `agent.command` looked spawnable in tests. The fixture now mirrors reality (bare `command: 'claude'` plus a detector-resolved `path`), and three cases cover the resolution order:

- falls back to `agent.path` when no `sessionCustomPath` is set
- spawns the Windows `claude.cmd` shim rather than the bare command (the regression)
- falls back to `agent.command` when the detector resolved no path

Both new assertions fail against the pre-fix code (`expected 'claude' to be '...claude.cmd'`) and pass after. 27/27 in `context-groomer.test.ts`; `tsc --noEmit -p tsconfig.node.json` and eslint are clean.

Note: this is a distinct code path and root cause from the Windows batch-file spawn issue previously fixed for tab naming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved agent command resolution by prioritizing custom paths, detected absolute paths, and reliable fallback commands.
  - Added support for launching Windows `.cmd` command shims correctly.

- **Tests**
  - Expanded coverage for custom path overrides, detected paths, Windows command shims, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->