### PR TITLE
fix(transcript): load older history when scrolling to the top of a session

### DIFF
--- a/src/__tests__/renderer/hooks/agent/useTranscriptBackfill.test.tsx
+++ b/src/__tests__/renderer/hooks/agent/useTranscriptBackfill.test.tsx
@@ -131,7 +131,7 @@ describe('useTranscriptBackfill', () => {
 
 	it('widens the read window on each successive page', async () => {
 		const session = seedStore(makeTab({ logs: [] }));
-		read.mockResolvedValue(page(2000, 250));
+		read.mockResolvedValue(page(2000, 750));
 
 		const { result } = renderHook(() =>
 			useTranscriptBackfill(session, useSessionStore.getState().sessions[0].aiTabs![0])
@@ -142,8 +142,11 @@ describe('useTranscriptBackfill', () => {
 		act(() => result.current.loadEarlier());
 		await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-		expect(read.mock.calls[0][3]).toEqual({ offset: 0, limit: 250 });
-		expect(read.mock.calls[1][3]).toEqual({ offset: 0, limit: 500 });
+		// The first window is seeded from TRANSCRIPT_RESUME_READ_LIMIT (500), not
+		// from the tab's entry count, so it clears the depth the resume path
+		// already put on screen. Each further page adds one TRANSCRIPT_BACKFILL_PAGE.
+		expect(read.mock.calls[0][3]).toEqual({ offset: 0, limit: 750 });
+		expect(read.mock.calls[1][3]).toEqual({ offset: 0, limit: 1000 });
 	});
 
 	it('stops once the window covers the whole transcript', async () => {
@@ -189,5 +192,100 @@ describe('useTranscriptBackfill', () => {
 		act(() => result.current.loadEarlier());
 		await waitFor(() => expect(result.current.error).toBeNull());
 		expect(storedLogs()).toEqual(['message 0', 'message 1']);
+	});
+
+	// A tool-heavy conversation shows far fewer entries than the provider
+	// messages they were built from, so a window sized from the entry count can
+	// land entirely inside what is already on screen. That read prepends nothing
+	// while hasMore stays true, and the user is parked at scrollTop 0 with no way
+	// to fire another scroll event - so one loadEarlier() has to keep widening
+	// until it actually makes progress.
+	it('keeps widening within one load until a page falls above the visible transcript', async () => {
+		// 1200 messages on disk; the tab already shows the newest 1000 of them,
+		// but as only 40 entries. Windows of 750 and 1000 are both inside that.
+		const TOTAL = 1200;
+		const VISIBLE_COVERS = 1000;
+		const visible = Array.from({ length: 40 }, (_, i) => {
+			const n = TOTAL - VISIBLE_COVERS + i * 25;
+			const m = message(n);
+			return {
+				id: m.uuid,
+				timestamp: new Date(m.timestamp).getTime(),
+				source: 'user' as const,
+				text: m.content,
+			};
+		});
+		const session = seedStore(makeTab({ logs: visible }));
+		read.mockImplementation((_a: string, _b: string, _c: string, opts: { limit: number }) =>
+			Promise.resolve(page(TOTAL, opts.limit))
+		);
+
+		const { result } = renderHook(() =>
+			useTranscriptBackfill(session, useSessionStore.getState().sessions[0].aiTabs![0])
+		);
+
+		act(() => result.current.loadEarlier());
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+		// Two reads landed inside the visible range and prepended nothing; the
+		// third (limit 1250) reaches past it. One user gesture, real progress.
+		expect(read.mock.calls.map((c: unknown[]) => (c[3] as { limit: number }).limit)).toEqual([
+			750, 1000, 1250,
+		]);
+		expect(storedLogs()[0]).toBe('message 0');
+	});
+
+	it('gives up widening after a bounded number of steps rather than looping forever', async () => {
+		// Every read comes back entirely inside the visible transcript.
+		const visible = [{ id: 'uuid-0', timestamp: 0, source: 'user' as const, text: 'message 0' }];
+		const session = seedStore(makeTab({ logs: visible }));
+		read.mockResolvedValue({ messages: [message(0)], total: 99999, hasMore: true });
+
+		const { result } = renderHook(() =>
+			useTranscriptBackfill(session, useSessionStore.getState().sessions[0].aiTabs![0])
+		);
+
+		act(() => result.current.loadEarlier());
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+		expect(read).toHaveBeenCalledTimes(8);
+		// Not latched shut: the next scroll picks up where this left off.
+		expect(result.current.reachedStart).toBe(false);
+		expect(result.current.error).toBeNull();
+	});
+
+	// A read that outlives its tab must not write into whatever tab replaced it,
+	// or the new tab's render window gets shifted by the old tab's prepend count
+	// and its "beginning of conversation" state is decided by the wrong file.
+	it('discards a read that resolves after the tab changed', async () => {
+		const session = seedStore(makeTab({ logs: [] }));
+		let release!: (v: unknown) => void;
+		read.mockReturnValue(
+			new Promise((resolve) => {
+				release = resolve;
+			})
+		);
+		const onPrepend = vi.fn();
+
+		const { result, rerender } = renderHook(
+			({ tab }: { tab: AITab }) => useTranscriptBackfill(session, tab, { onPrepend }),
+			{ initialProps: { tab: useSessionStore.getState().sessions[0].aiTabs![0] } }
+		);
+
+		act(() => result.current.loadEarlier());
+
+		// User switches to a different tab while the read is still outstanding.
+		rerender({ tab: makeTab({ id: 'tab-2', agentSessionId: 'agent-session-2' }) });
+
+		// The old tab's read now lands, claiming the whole transcript.
+		await act(async () => {
+			release(page(3, 3));
+			await Promise.resolve();
+		});
+
+		expect(onPrepend).not.toHaveBeenCalled();
+		expect(storedLogs()).toEqual([]);
+		// hasMore was false on that stale page, but it belonged to the old tab.
+		expect(result.current.reachedStart).toBe(false);
 	});
 });

--- a/src/__tests__/renderer/hooks/agent/useTranscriptBackfill.test.tsx
+++ b/src/__tests__/renderer/hooks/agent/useTranscriptBackfill.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * Tests for useTranscriptBackfill - scroll-to-top history loading (issue #1407).
+ *
+ * An AI tab only holds the newest slice of its conversation, so the behaviours
+ * that matter are: a page of older history actually lands at the head of the
+ * tab, successive pages widen the read window rather than re-reading the same
+ * one, the caller is told how many entries were prepended (so the render window
+ * can absorb them), and the hook stops once the transcript is exhausted.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useTranscriptBackfill } from '../../../../renderer/hooks/agent/useTranscriptBackfill';
+import { useSessionStore } from '../../../../renderer/stores/sessionStore';
+import { createMockSession } from '../../../helpers/mockSession';
+import type { AITab, Session } from '../../../../renderer/types';
+
+const read = vi.fn();
+
+/** A provider transcript message as agentSessions.read returns it. */
+function message(n: number) {
+	return {
+		type: n % 2 === 0 ? 'user' : 'assistant',
+		content: `message ${n}`,
+		timestamp: new Date(1_700_000_000_000 + n * 1000).toISOString(),
+		uuid: `uuid-${n}`,
+	};
+}
+
+/** The newest `count` of a `total`-message transcript, as storage would page it. */
+function page(total: number, count: number) {
+	const start = Math.max(0, total - count);
+	return {
+		messages: Array.from({ length: total - start }, (_, i) => message(start + i)),
+		total,
+		hasMore: start > 0,
+	};
+}
+
+function makeTab(overrides: Partial<AITab> = {}): AITab {
+	return {
+		id: 'tab-1',
+		agentSessionId: 'agent-session-1',
+		name: null,
+		starred: false,
+		logs: [],
+		inputValue: '',
+		stagedImages: [],
+		createdAt: 0,
+		state: 'idle',
+		...overrides,
+	} as AITab;
+}
+
+function seedStore(tab: AITab): Session {
+	const session = createMockSession({
+		id: 'sess-1',
+		toolType: 'claude-code',
+		projectRoot: '/repo',
+		activeTabId: tab.id,
+		aiTabs: [tab],
+	} as Partial<Session>);
+	useSessionStore.setState({ sessions: [session] } as never);
+	return session;
+}
+
+/** Logs on the seeded tab, read back out of the store. */
+function storedLogs(): string[] {
+	const tab = useSessionStore.getState().sessions[0]?.aiTabs?.[0];
+	return (tab?.logs ?? []).map((l) => l.text);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	useSessionStore.setState({
+		sessions: [],
+		groups: [],
+		activeSessionId: '',
+		initialLoadComplete: false,
+		removedWorktreePaths: new Set(),
+	} as never);
+	(window as any).maestro = {
+		...((window as any).maestro || {}),
+		agentSessions: { read },
+	};
+});
+
+describe('useTranscriptBackfill', () => {
+	it('prepends older history above what the tab already shows', async () => {
+		// Tab holds the newest 2 of a 10-message transcript.
+		const visible = [message(8), message(9)].map((m) => ({
+			id: m.uuid,
+			timestamp: new Date(m.timestamp).getTime(),
+			source: 'user' as const,
+			text: m.content,
+		}));
+		const session = seedStore(makeTab({ logs: visible }));
+		read.mockResolvedValue(page(10, 10));
+
+		const { result } = renderHook(() =>
+			useTranscriptBackfill(session, useSessionStore.getState().sessions[0].aiTabs![0])
+		);
+
+		act(() => result.current.loadEarlier());
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+		// All 8 older messages land at the head; the 2 already on screen are not duplicated.
+		expect(storedLogs()).toEqual([
+			...Array.from({ length: 8 }, (_, i) => `message ${i}`),
+			'message 8',
+			'message 9',
+		]);
+	});
+
+	it('reports the prepended count so the render window can absorb it', async () => {
+		const session = seedStore(makeTab({ logs: [] }));
+		read.mockResolvedValue(page(4, 4));
+		const onPrepend = vi.fn();
+
+		const { result } = renderHook(() =>
+			useTranscriptBackfill(session, useSessionStore.getState().sessions[0].aiTabs![0], {
+				onPrepend,
+			})
+		);
+
+		act(() => result.current.loadEarlier());
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+		expect(onPrepend).toHaveBeenCalledWith(4);
+	});
+
+	it('widens the read window on each successive page', async () => {
+		const session = seedStore(makeTab({ logs: [] }));
+		read.mockResolvedValue(page(2000, 250));
+
+		const { result } = renderHook(() =>
+			useTranscriptBackfill(session, useSessionStore.getState().sessions[0].aiTabs![0])
+		);
+
+		act(() => result.current.loadEarlier());
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		act(() => result.current.loadEarlier());
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+		expect(read.mock.calls[0][3]).toEqual({ offset: 0, limit: 250 });
+		expect(read.mock.calls[1][3]).toEqual({ offset: 0, limit: 500 });
+	});
+
+	it('stops once the window covers the whole transcript', async () => {
+		const session = seedStore(makeTab({ logs: [] }));
+		read.mockResolvedValue(page(3, 3)); // hasMore: false
+
+		const { result } = renderHook(() =>
+			useTranscriptBackfill(session, useSessionStore.getState().sessions[0].aiTabs![0])
+		);
+
+		act(() => result.current.loadEarlier());
+		await waitFor(() => expect(result.current.reachedStart).toBe(true));
+
+		act(() => result.current.loadEarlier());
+		expect(read).toHaveBeenCalledTimes(1);
+	});
+
+	it('does nothing for a tab with no agent session on disk', () => {
+		const session = seedStore(makeTab({ agentSessionId: null }));
+
+		const { result } = renderHook(() =>
+			useTranscriptBackfill(session, useSessionStore.getState().sessions[0].aiTabs![0])
+		);
+
+		act(() => result.current.loadEarlier());
+		expect(read).not.toHaveBeenCalled();
+	});
+
+	it('surfaces a retryable error when the read fails', async () => {
+		const session = seedStore(makeTab({ logs: [] }));
+		read.mockRejectedValue(new Error('ENOENT'));
+
+		const { result } = renderHook(() =>
+			useTranscriptBackfill(session, useSessionStore.getState().sessions[0].aiTabs![0])
+		);
+
+		act(() => result.current.loadEarlier());
+		await waitFor(() => expect(result.current.error).toBe('Could not load earlier messages'));
+
+		// A failed read must not latch the hook shut - the user can retry.
+		expect(result.current.reachedStart).toBe(false);
+		read.mockResolvedValue(page(2, 2));
+		act(() => result.current.loadEarlier());
+		await waitFor(() => expect(result.current.error).toBeNull());
+		expect(storedLogs()).toEqual(['message 0', 'message 1']);
+	});
+});

--- a/src/__tests__/renderer/hooks/utils/useProgressiveRenderWindow.test.ts
+++ b/src/__tests__/renderer/hooks/utils/useProgressiveRenderWindow.test.ts
@@ -175,6 +175,53 @@ describe('useProgressiveRenderWindow', () => {
 		});
 	});
 
+	describe('absorbPrepend (scroll-to-top history backfill, issue #1407)', () => {
+		it('keeps the visible slice stable when history is prepended', () => {
+			// 300 entries, window walked to the head, then 250 older ones arrive.
+			const { result, rerender } = renderHook(
+				({ total }) => useProgressiveRenderWindow(total, 'a'),
+				{ initialProps: { total: 300 } }
+			);
+			act(() => {
+				result.current.revealTo(0);
+			});
+			expect(result.current.startIndex).toBe(0);
+
+			act(() => {
+				result.current.absorbPrepend(250);
+			});
+			rerender({ total: 550 });
+
+			// The same 300 entries stay rendered - the new history sits above the
+			// window rather than mounting in one commit.
+			expect(result.current.startIndex).toBe(250);
+		});
+
+		it('lets the idle loop walk back through the prepended history', () => {
+			const { result, rerender } = renderHook(
+				({ total }) => useProgressiveRenderWindow(total, 'a'),
+				{ initialProps: { total: 300 } }
+			);
+			act(() => {
+				result.current.revealTo(0);
+				result.current.absorbPrepend(250);
+			});
+			rerender({ total: 550 });
+
+			flushIdleTick();
+			expect(result.current.startIndex).toBe(250 - DEFAULT_BACKFILL_CHUNK);
+		});
+
+		it('ignores non-positive counts', () => {
+			const { result } = renderHook(() => useProgressiveRenderWindow(500, 'a'));
+			const before = result.current.startIndex;
+			act(() => {
+				result.current.absorbPrepend(0);
+			});
+			expect(result.current.startIndex).toBe(before);
+		});
+	});
+
 	it('uses requestIdleCallback when the platform provides one', () => {
 		const scheduled: Array<() => void> = [];
 		const ric = vi.fn((cb: () => void) => {

--- a/src/__tests__/renderer/utils/transcriptMessages.test.ts
+++ b/src/__tests__/renderer/utils/transcriptMessages.test.ts
@@ -126,6 +126,66 @@ describe('selectOlderEntries', () => {
 		expect(selectOlderEntries(loaded, visible).map((e) => e.id)).toEqual(['1', '2', '3']);
 	});
 
+	// The expected splice point is only an estimate: it is off by however many
+	// renderer-only entries the tab holds (system notices, outage markers). Push
+	// that estimate past one repetition of a repeated message and the NEAREST
+	// source+text hit is the wrong occurrence, which silently drops the genuine
+	// older turns between the two. A match needs corroboration, not just proximity.
+	it('prefers the occurrence whose timestamp matches over a nearer text-only hit', () => {
+		const loaded = [
+			entry('1', 'start', 'user', 0),
+			entry('2', 'continue', 'user', 100),
+			entry('3', 'work', 'user', 200),
+			entry('4', 'continue', 'user', 300),
+			entry('5', 'more', 'user', 400),
+			entry('6', 'done', 'user', 500),
+		];
+		// Tab was hydrated from disk (timestamps survive) but holds two
+		// renderer-only notices, so expected lands on index 1 - the WRONG
+		// "continue". The timestamp pins the real boundary at index 3.
+		const visible = [
+			entry('local-a', 'continue', 'user', 300),
+			entry('sys-1', 'Agent reconnected', 'system', 310),
+			entry('sys-2', 'Retrying', 'system', 320),
+			entry('local-b', 'more', 'user', 400),
+			entry('local-c', 'done', 'user', 500),
+		];
+
+		expect(selectOlderEntries(loaded, visible).map((e) => e.id)).toEqual(['1', '2', '3']);
+	});
+
+	it('prefers the occurrence whose following entry also lines up', () => {
+		const loaded = [
+			entry('1', 'start', 'user', 0),
+			entry('2', 'continue', 'user', 100),
+			entry('3', 'work', 'user', 200),
+			entry('4', 'continue', 'user', 300),
+			entry('5', 'more', 'user', 400),
+			entry('6', 'done', 'user', 500),
+		];
+		// The restart path: local ids AND renderer clock timestamps, so neither id
+		// nor timestamp can pick between the two "continue" entries. The entry that
+		// FOLLOWS the boundary is what breaks the tie.
+		const visible = [
+			entry('local-a', 'continue', 'user', 9001),
+			entry('local-b', 'more', 'user', 9002),
+			entry('local-c', 'done', 'user', 9003),
+			entry('sys-1', 'Agent reconnected', 'system', 9004),
+			entry('sys-2', 'Retrying', 'system', 9005),
+		];
+
+		expect(selectOlderEntries(loaded, visible).map((e) => e.id)).toEqual(['1', '2', '3']);
+	});
+
+	it('still takes the nearest match when nothing corroborates either occurrence', () => {
+		// No timestamps, no usable next entry: fall back to proximity, which is the
+		// best guess available and the behavior every non-repeating case relies on.
+		const loaded = [entry('1', 'continue'), entry('2', 'work'), entry('3', 'continue')];
+		const visible = [entry('local-a', 'continue')];
+
+		expect(selectOlderEntries(loaded, visible).map((e) => e.id)).toEqual(['1', '2']);
+	});
+
 	it('cuts on timestamp when the boundary entry never reached disk', () => {
 		// Maestro-injected system notices live only in the tab, so there is nothing
 		// on disk to match. Anything strictly older than it is still safe to prepend.

--- a/src/__tests__/renderer/utils/transcriptMessages.test.ts
+++ b/src/__tests__/renderer/utils/transcriptMessages.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the transcript message helpers that back scroll-to-top history
+ * loading (issue #1407).
+ *
+ * `selectOlderEntries` is the load-bearing piece: it decides where a freshly
+ * read transcript window overlaps what the tab already shows. Getting it wrong
+ * either duplicates the visible conversation or silently drops history, so the
+ * cases below cover both id-matched tabs (hydrated from disk) and text-matched
+ * tabs (ran live, then survived a restart with locally generated ids).
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { LogEntry } from '../../../renderer/types';
+import {
+	isSynopsisRequest,
+	selectOlderEntries,
+	stripSynopsisTurns,
+	transcriptMessagesToLogEntries,
+	type TranscriptMessage,
+} from '../../../renderer/utils/transcriptMessages';
+
+function entry(id: string, text: string, source: LogEntry['source'] = 'user', ts = 0): LogEntry {
+	return { id, text, source, timestamp: ts };
+}
+
+function message(overrides: Partial<TranscriptMessage> = {}): TranscriptMessage {
+	return {
+		type: 'user',
+		content: 'hello',
+		timestamp: '2026-01-01T00:00:00.000Z',
+		uuid: 'uuid-1',
+		...overrides,
+	};
+}
+
+describe('transcriptMessagesToLogEntries', () => {
+	it('keeps messages with text and maps user vs assistant to log sources', () => {
+		const entries = transcriptMessagesToLogEntries([
+			message({ uuid: 'a', type: 'user', content: 'question' }),
+			message({ uuid: 'b', type: 'assistant', content: 'answer' }),
+		]);
+
+		expect(entries).toHaveLength(2);
+		expect(entries[0]).toMatchObject({ id: 'a', text: 'question', source: 'user' });
+		expect(entries[1]).toMatchObject({ id: 'b', text: 'answer', source: 'stdout' });
+	});
+
+	it('drops tool-only messages but keeps image-only ones', () => {
+		const entries = transcriptMessagesToLogEntries([
+			message({ uuid: 'tool', content: '   ' }),
+			message({ uuid: 'img', content: '', images: ['data:image/png;base64,AAA'] }),
+		]);
+
+		expect(entries.map((e) => e.id)).toEqual(['img']);
+		expect(entries[0].images).toEqual(['data:image/png;base64,AAA']);
+	});
+});
+
+describe('stripSynopsisTurns', () => {
+	it('removes the Auto Run synopsis request and the reply that follows it', () => {
+		const kept = stripSynopsisTurns([
+			message({ uuid: 'a', content: 'real question' }),
+			message({
+				uuid: 'b',
+				content: 'Give a brief synopsis of what you just accomplished',
+			}),
+			message({ uuid: 'c', type: 'assistant', content: '**Summary:** did things' }),
+			message({ uuid: 'd', type: 'assistant', content: 'real answer' }),
+		]);
+
+		expect(kept.map((m) => m.uuid)).toEqual(['a', 'd']);
+	});
+
+	it('only treats user turns as synopsis requests', () => {
+		expect(
+			isSynopsisRequest({
+				type: 'assistant',
+				content: 'Give a brief synopsis of what you just accomplished',
+			})
+		).toBe(false);
+	});
+});
+
+describe('selectOlderEntries', () => {
+	it('returns everything when the tab is empty', () => {
+		const loaded = [entry('1', 'a'), entry('2', 'b')];
+		expect(selectOlderEntries(loaded, [])).toEqual(loaded);
+	});
+
+	it('prepends only what sits above the first visible entry, matched by id', () => {
+		const loaded = [entry('1', 'a'), entry('2', 'b'), entry('3', 'c'), entry('4', 'd')];
+		const visible = [entry('3', 'c'), entry('4', 'd')];
+
+		expect(selectOlderEntries(loaded, visible).map((e) => e.id)).toEqual(['1', '2']);
+	});
+
+	it('falls back to source+text when the tab holds locally generated ids', () => {
+		// The restart path: same conversation, but the visible entries were built
+		// live so their ids do not match the on-disk uuids.
+		const loaded = [entry('u1', 'a'), entry('u2', 'b'), entry('u3', 'c')];
+		const visible = [entry('local-x', 'c'), entry('local-y', 'd')];
+
+		expect(selectOlderEntries(loaded, visible).map((e) => e.text)).toEqual(['a', 'b']);
+	});
+
+	it('returns nothing when the visible tab already starts at the first message', () => {
+		const loaded = [entry('1', 'a'), entry('2', 'b')];
+		const visible = [entry('1', 'a'), entry('2', 'b')];
+
+		expect(selectOlderEntries(loaded, visible)).toEqual([]);
+	});
+
+	it('picks the boundary nearest the expected splice point when text repeats', () => {
+		// "continue" appears three times. The window is 6 long and the tab shows the
+		// newest 3, so the real boundary is index 3 - not the first or last match.
+		const loaded = [
+			entry('1', 'continue'),
+			entry('2', 'work'),
+			entry('3', 'continue'),
+			entry('4', 'continue'),
+			entry('5', 'more'),
+			entry('6', 'done'),
+		];
+		const visible = [entry('x', 'continue'), entry('y', 'more'), entry('z', 'done')];
+
+		expect(selectOlderEntries(loaded, visible).map((e) => e.id)).toEqual(['1', '2', '3']);
+	});
+
+	it('cuts on timestamp when the boundary entry never reached disk', () => {
+		// Maestro-injected system notices live only in the tab, so there is nothing
+		// on disk to match. Anything strictly older than it is still safe to prepend.
+		const loaded = [entry('1', 'a', 'user', 100), entry('2', 'b', 'user', 300)];
+		const visible = [entry('sys', 'Agent reconnected', 'system', 200)];
+
+		expect(selectOlderEntries(loaded, visible).map((e) => e.id)).toEqual(['1']);
+	});
+});

--- a/src/renderer/components/TerminalOutput.tsx
+++ b/src/renderer/components/TerminalOutput.tsx
@@ -23,6 +23,7 @@ import {
 	Share2,
 	Hammer,
 	GitFork,
+	Loader2,
 } from 'lucide-react';
 import type { Session, Theme, LogEntry, FocusArea, AgentError, QueuedItem } from '../types';
 import type { FileNode } from '../types/fileTree';
@@ -30,6 +31,7 @@ import Convert from 'ansi-to-html';
 import { useLayerStack } from '../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { getActiveTab } from '../utils/tabHelpers';
+import { useTranscriptBackfill } from '../hooks/agent/useTranscriptBackfill';
 import { useDebouncedValue, useThrottledCallback, useProgressiveRenderWindow } from '../hooks';
 import {
 	processLogTextHelper,
@@ -74,6 +76,13 @@ const JUMP_STABILIZE_FRAMES = 10;
 
 /** How long the jump keeps auto-scroll suppressed after landing (~2x the stabilize window). */
 const JUMP_SETTLE_MS = 400;
+
+/**
+ * Distance from the top that triggers loading older history (issue #1407).
+ * Generous enough to fire before the user bottoms out against the first entry,
+ * so the next page is on its way while there is still content to scroll through.
+ */
+const TRANSCRIPT_BACKFILL_TOP_THRESHOLD = 200;
 
 // ============================================================================
 // Tool display helpers (pure functions, hoisted out of render path)
@@ -1858,11 +1867,39 @@ export const TerminalOutput = memo(
 			}
 		}, []);
 
-		const { startIndex: logStartIndex, revealTo: revealLogIndex } = useProgressiveRenderWindow(
-			filteredLogs.length,
-			`${session.id}-${activeTabId ?? ''}`,
-			{ onBeforeExpand: handleBeforeBackfill }
-		);
+		const {
+			startIndex: logStartIndex,
+			revealTo: revealLogIndex,
+			absorbPrepend: absorbLogPrepend,
+		} = useProgressiveRenderWindow(filteredLogs.length, `${session.id}-${activeTabId ?? ''}`, {
+			onBeforeExpand: handleBeforeBackfill,
+		});
+
+		// ============================================================================
+		// Scroll-to-top history backfill (issue #1407)
+		// ============================================================================
+		// The tab only holds the newest slice of its conversation (500 messages on
+		// resume, 100 after a restart), so scrolling up used to hit a hard stop
+		// mid-conversation. Reaching the top now pages older history back in from
+		// the provider transcript on disk. Entries arrive at the HEAD, so hand the
+		// count to the render window: it shifts by exactly that many, keeping the
+		// visible slice stable and letting the idle loop mount the new history a
+		// chunk at a time instead of one page-sized commit.
+		const historyBackfill = useTranscriptBackfill(session, activeTab, {
+			onPrepend: useCallback(
+				(count: number) => {
+					handleBeforeBackfill();
+					absorbLogPrepend(count);
+				},
+				[handleBeforeBackfill, absorbLogPrepend]
+			),
+		});
+
+		// Kept in a ref so the throttled scroll handler below does not have to
+		// re-create itself (and reset its throttle window) when the hook's
+		// callback identity changes.
+		const loadEarlierRef = useRef(historyBackfill.loadEarlier);
+		loadEarlierRef.current = historyBackfill.loadEarlier;
 
 		useLayoutEffect(() => {
 			const container = scrollContainerRef.current;
@@ -2130,6 +2167,14 @@ export const TerminalOutput = memo(
 			if (atBottom !== prevIsAtBottomRef.current) {
 				prevIsAtBottomRef.current = atBottom;
 				onAtBottomChange?.(atBottom);
+			}
+
+			// Reaching the top pulls the next page of older history in from the
+			// provider transcript (issue #1407). Guarded on the container actually
+			// being scrollable so a short transcript that sits at scrollTop 0 does
+			// not fire a read on every scroll event.
+			if (scrollTop < TRANSCRIPT_BACKFILL_TOP_THRESHOLD && scrollHeight > clientHeight) {
+				loadEarlierRef.current();
 			}
 
 			// Clear new message indicator when user scrolls to bottom
@@ -2599,6 +2644,49 @@ export const TerminalOutput = memo(
 					}}
 					onScroll={handleScroll}
 				>
+					{/* Older-history status row (issue #1407). Only meaningful once the
+					    idle render window has reached the head of the list - above that
+					    point there is still local history left to mount, so "beginning of
+					    conversation" would be a lie. Nothing renders until the user has
+					    actually scrolled up far enough to trigger a read. */}
+					{logStartIndex === 0 && filteredLogs.length > 0 && (
+						<>
+							{historyBackfill.isLoading && (
+								<div
+									className="flex items-center justify-center gap-2 py-3 text-xs"
+									style={{ color: theme.colors.textDim }}
+								>
+									<Loader2 className="w-3.5 h-3.5 animate-spin" />
+									Loading earlier messages...
+								</div>
+							)}
+							{!historyBackfill.isLoading && historyBackfill.error && (
+								<div
+									className="flex items-center justify-center gap-2 py-3 text-xs"
+									style={{ color: theme.colors.textDim }}
+								>
+									{historyBackfill.error}
+									<button
+										onClick={historyBackfill.loadEarlier}
+										className="underline hover:opacity-80 transition-opacity"
+										style={{ color: theme.colors.textMain }}
+									>
+										Retry
+									</button>
+								</div>
+							)}
+							{!historyBackfill.isLoading &&
+								!historyBackfill.error &&
+								historyBackfill.reachedStart && (
+									<div
+										className="flex items-center justify-center py-3 text-xs"
+										style={{ color: theme.colors.textDim }}
+									>
+										Beginning of conversation
+									</div>
+								)}
+						</>
+					)}
 					{/* Log entries */}
 					{visibleLogs.map((log, visibleIndex) => {
 						// Absolute index into filteredLogs - sibling lookups (echo stripping)

--- a/src/renderer/hooks/agent/useAgentSessionManagement.ts
+++ b/src/renderer/hooks/agent/useAgentSessionManagement.ts
@@ -8,6 +8,7 @@ import type { RightPanelHandle } from '../../components/RightPanel';
 import { FALLBACK_CONTEXT_WINDOW } from '../../../shared/agentConstants';
 import { logger } from '../../utils/logger';
 import {
+	TRANSCRIPT_RESUME_READ_LIMIT,
 	isSynopsisRequest,
 	stripSynopsisTurns,
 	transcriptMessagesToLogEntries,
@@ -312,7 +313,7 @@ export function useAgentSessionManagement(
 						agentId,
 						resolvedProjectRoot,
 						agentSessionId,
-						{ offset: 0, limit: 500 },
+						{ offset: 0, limit: TRANSCRIPT_RESUME_READ_LIMIT },
 						targetSession.sshRemoteId
 					);
 

--- a/src/renderer/hooks/agent/useAgentSessionManagement.ts
+++ b/src/renderer/hooks/agent/useAgentSessionManagement.ts
@@ -7,26 +7,16 @@ import { buildSharedHistoryContext } from '../../utils/sessionHelpers';
 import type { RightPanelHandle } from '../../components/RightPanel';
 import { FALLBACK_CONTEXT_WINDOW } from '../../../shared/agentConstants';
 import { logger } from '../../utils/logger';
+import {
+	isSynopsisRequest,
+	stripSynopsisTurns,
+	transcriptMessagesToLogEntries,
+	type TranscriptMessage,
+} from '../../utils/transcriptMessages';
 
-/**
- * Matches the Auto Run synopsis prompt that Maestro injects into the agent
- * session after a task ("Give/Provide a brief synopsis of what you just
- * accomplished ..."). The leading verb and trailing wording have drifted across
- * versions and the prompt is user-customizable, so we anchor on the stable core
- * phrase. A restored tab hides this request and the assistant's `**Summary:**`
- * reply since they are bookkeeping, not part of the user's conversation.
- */
-const SYNOPSIS_REQUEST_PATTERN =
-	/^\s*\S+\s+a\s+brief\s+synopsis\s+of\s+what\s+you\s+just\s+accomplished/i;
-
-export function isSynopsisRequest(msg: {
-	type?: string;
-	role?: string;
-	content?: string;
-}): boolean {
-	const isUser = msg.type === 'user' || msg.role === 'user';
-	return isUser && typeof msg.content === 'string' && SYNOPSIS_REQUEST_PATTERN.test(msg.content);
-}
+// Re-exported from its shared home so existing importers keep working; the
+// scroll-to-top history backfill needs the same filter.
+export { isSynopsisRequest };
 
 /**
  * History entry for the addHistoryEntry function.
@@ -326,48 +316,13 @@ export function useAgentSessionManagement(
 						targetSession.sshRemoteId
 					);
 
-					// Drop the Auto Run synopsis request and the assistant reply that
-					// immediately follows it. These are Maestro bookkeeping turns, not part
-					// of the user's conversation, so they shouldn't reappear on restore.
-					const withoutSynopsis = result.messages.filter(
-						(
-							msg: { type: string; role?: string; content: string },
-							i: number,
-							arr: { type: string; role?: string; content: string }[]
-						) => {
-							if (isSynopsisRequest(msg)) return false;
-							const prev = arr[i - 1];
-							const isAssistant = msg.type === 'assistant' || msg.role === 'assistant';
-							if (prev && isSynopsisRequest(prev) && isAssistant) return false;
-							return true;
-						}
+					// Strip the Auto Run synopsis turns, then convert. Shared with the
+					// scroll-to-top backfill (issue #1407), which matches what it reads
+					// against these entries to find where to splice older history in -
+					// so both paths must build entries the same way.
+					messages = transcriptMessagesToLogEntries(
+						stripSynopsisTurns(result.messages as TranscriptMessage[])
 					);
-
-					// Convert to log entries, keeping messages with actual text content or
-					// reconstructed images. Tool-use-only messages (empty text, no images)
-					// are skipped - restored tabs start with thinking off so there's nothing
-					// useful to render for those entries.
-					messages = withoutSynopsis
-						.filter(
-							(msg: { content: string; images?: string[] }) =>
-								(msg.content && msg.content.trim().length > 0) ||
-								(msg.images != null && msg.images.length > 0)
-						)
-						.map(
-							(msg: {
-								type: string;
-								content: string;
-								timestamp: string;
-								uuid: string;
-								images?: string[];
-							}) => ({
-								id: msg.uuid || generateId(),
-								timestamp: new Date(msg.timestamp).getTime(),
-								source: msg.type === 'user' ? ('user' as const) : ('stdout' as const),
-								text: msg.content,
-								...(msg.images && msg.images.length > 0 && { images: msg.images }),
-							})
-						);
 				}
 
 				if (messages.length === 0) {

--- a/src/renderer/hooks/agent/useTranscriptBackfill.ts
+++ b/src/renderer/hooks/agent/useTranscriptBackfill.ts
@@ -1,0 +1,147 @@
+/**
+ * useTranscriptBackfill - page older history into an AI tab when the user
+ * scrolls to the top of the transcript (issue #1407).
+ *
+ * An AI tab only ever holds the newest slice of its conversation. Resuming a
+ * session reads the newest 500 provider messages, and persistence truncates
+ * each tab to the newest 100 entries so `sessions.json` stays small, so after a
+ * restart the tab starts even shorter. The full transcript is still on disk;
+ * nothing was wired up to go back for it, so scrolling up hit a hard stop at an
+ * arbitrary older message with no way to reach the start of the conversation.
+ *
+ * The storage layer already pages from the newest message backwards
+ * (`BaseSessionStorage.applyMessagePagination`), so each step here re-reads a
+ * window that is one page larger and prepends whatever falls above the boundary
+ * (see `selectOlderEntries`). Growing the window rather than tracking a raw
+ * offset is deliberate: the tab's entry count is only a lower bound on the
+ * messages it represents (tool-only messages are dropped on the way in), so
+ * there is no offset the renderer could compute that would stay correct.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { AITab, Session } from '../../types';
+import { selectSessionById, updateSessionWith, useSessionStore } from '../../stores/sessionStore';
+import { logger } from '../../utils/logger';
+import {
+	selectOlderEntries,
+	stripSynopsisTurns,
+	transcriptMessagesToLogEntries,
+	type TranscriptMessage,
+} from '../../utils/transcriptMessages';
+
+/** Provider messages pulled in per "load earlier" step. */
+export const TRANSCRIPT_BACKFILL_PAGE = 250;
+
+export interface UseTranscriptBackfillOptions {
+	/**
+	 * Called synchronously with the number of entries just prepended, in the
+	 * same tick as the store update so both land in one React commit. The
+	 * transcript uses this to keep its progressive render window from mounting a
+	 * whole page of markdown in a single blocking commit (issue #1342).
+	 */
+	onPrepend?: (count: number) => void;
+}
+
+export interface TranscriptBackfill {
+	/** True while a page is being read from disk. */
+	isLoading: boolean;
+	/** True once a read has proven the tab now starts at the first message. */
+	reachedStart: boolean;
+	/** Set when the last read failed; the caller offers a retry. */
+	error: string | null;
+	/** Pull in the next page of older history. No-op when already loading or done. */
+	loadEarlier: () => void;
+}
+
+export function useTranscriptBackfill(
+	session: Session,
+	activeTab: AITab | undefined,
+	options: UseTranscriptBackfillOptions = {}
+): TranscriptBackfill {
+	const sessionId = session.id;
+	const projectRoot = session.projectRoot;
+	const toolType = session.toolType;
+	const sshRemoteId = session.sshRemoteId;
+	const tabId = activeTab?.id ?? null;
+	const agentSessionId = activeTab?.agentSessionId ?? null;
+
+	const [isLoading, setIsLoading] = useState(false);
+	const [reachedStart, setReachedStart] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	// Provider-message count covered by the last read, tracked separately from
+	// `logs.length` for the reason in the file header.
+	const windowRef = useRef<number | null>(null);
+	const inFlightRef = useRef(false);
+
+	const onPrependRef = useRef(options.onPrepend);
+	onPrependRef.current = options.onPrepend;
+
+	// The transcript is remounted per tab today, but reset explicitly so a future
+	// caller that keeps this hook alive across tabs cannot page one tab's window
+	// against another tab's transcript.
+	useEffect(() => {
+		windowRef.current = null;
+		inFlightRef.current = false;
+		setIsLoading(false);
+		setReachedStart(false);
+		setError(null);
+	}, [tabId, agentSessionId]);
+
+	const loadEarlier = useCallback(() => {
+		if (inFlightRef.current || reachedStart) return;
+		if (!tabId || !agentSessionId || !projectRoot) return;
+
+		inFlightRef.current = true;
+		setIsLoading(true);
+		setError(null);
+
+		void (async () => {
+			try {
+				const tab = selectSessionById(sessionId)(useSessionStore.getState())?.aiTabs?.find(
+					(t) => t.id === tabId
+				);
+				const visible = tab?.logs ?? [];
+				const nextWindow = (windowRef.current ?? visible.length) + TRANSCRIPT_BACKFILL_PAGE;
+
+				const result = await window.maestro.agentSessions.read(
+					toolType || 'claude-code',
+					projectRoot,
+					agentSessionId,
+					{ offset: 0, limit: nextWindow },
+					sshRemoteId
+				);
+				windowRef.current = nextWindow;
+
+				const loaded = transcriptMessagesToLogEntries(
+					stripSynopsisTurns((result.messages ?? []) as TranscriptMessage[])
+				);
+				const older = selectOlderEntries(loaded, visible);
+
+				if (older.length > 0) {
+					// Prepend onto the tab's CURRENT logs, not the snapshot above: the
+					// agent may have streamed new entries onto the tail during the read.
+					updateSessionWith(sessionId, (s) => ({
+						...s,
+						aiTabs: s.aiTabs?.map((t) =>
+							t.id === tabId ? { ...t, logs: [...older, ...t.logs] } : t
+						),
+					}));
+					onPrependRef.current?.(older.length);
+				}
+
+				// `hasMore` is false once the window spans the whole file, so there is
+				// nothing left to reach even when this page did prepend entries.
+				if (!result.hasMore) setReachedStart(true);
+			} catch (e) {
+				logger.warn('[useTranscriptBackfill] Failed to load earlier messages', undefined, e);
+				setError('Could not load earlier messages');
+			} finally {
+				inFlightRef.current = false;
+				setIsLoading(false);
+			}
+		})();
+	}, [reachedStart, tabId, agentSessionId, projectRoot, sessionId, toolType, sshRemoteId]);
+
+	return { isLoading, reachedStart, error, loadEarlier };
+}

--- a/src/renderer/hooks/agent/useTranscriptBackfill.ts
+++ b/src/renderer/hooks/agent/useTranscriptBackfill.ts
@@ -16,6 +16,16 @@
  * offset is deliberate: the tab's entry count is only a lower bound on the
  * messages it represents (tool-only messages are dropped on the way in), so
  * there is no offset the renderer could compute that would stay correct.
+ *
+ * That lower bound is why one read is not always enough. A tool-heavy
+ * conversation can show 60 entries for the newest 500 provider messages, so a
+ * window sized from the entry count alone can land entirely INSIDE what is
+ * already on screen, prepend nothing, and leave the user parked at the top with
+ * no way to ask again (they are already at scrollTop 0, so no further scroll
+ * event fires). Two things prevent that: the first window is seeded from the
+ * depth the resume path actually read rather than from `logs.length`, and a
+ * single `loadEarlier()` keeps widening until it either prepends something or
+ * reaches the start of the file.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -23,6 +33,7 @@ import type { AITab, Session } from '../../types';
 import { selectSessionById, updateSessionWith, useSessionStore } from '../../stores/sessionStore';
 import { logger } from '../../utils/logger';
 import {
+	TRANSCRIPT_RESUME_READ_LIMIT,
 	selectOlderEntries,
 	stripSynopsisTurns,
 	transcriptMessagesToLogEntries,
@@ -31,6 +42,17 @@ import {
 
 /** Provider messages pulled in per "load earlier" step. */
 export const TRANSCRIPT_BACKFILL_PAGE = 250;
+
+/**
+ * How many times one `loadEarlier()` will widen its window while the reads keep
+ * coming back entirely inside the visible transcript. Each step costs a full
+ * transcript read, so this is a backstop against a pathological ratio of
+ * tool-only messages, not the expected path: seeding from
+ * `TRANSCRIPT_RESUME_READ_LIMIT` means the common case resolves on the first
+ * read. Hitting the cap is not an error - the user simply gets the next page on
+ * their next scroll instead.
+ */
+const MAX_WIDEN_STEPS_PER_LOAD = 8;
 
 export interface UseTranscriptBackfillOptions {
 	/**
@@ -74,6 +96,13 @@ export function useTranscriptBackfill(
 	const windowRef = useRef<number | null>(null);
 	const inFlightRef = useRef(false);
 
+	// Bumped whenever the hook retargets (tab switch, agent session change). Every
+	// read captures the value it started with and drops its results if it no
+	// longer matches, so a read that outlives its tab cannot prepend into the new
+	// tab's render window, overwrite the new tab's window size, clear the new
+	// tab's in-flight flag, or falsely mark it as having reached the start.
+	const generationRef = useRef(0);
+
 	const onPrependRef = useRef(options.onPrepend);
 	onPrependRef.current = options.onPrepend;
 
@@ -81,6 +110,7 @@ export function useTranscriptBackfill(
 	// caller that keeps this hook alive across tabs cannot page one tab's window
 	// against another tab's transcript.
 	useEffect(() => {
+		generationRef.current += 1;
 		windowRef.current = null;
 		inFlightRef.current = false;
 		setIsLoading(false);
@@ -96,49 +126,75 @@ export function useTranscriptBackfill(
 		setIsLoading(true);
 		setError(null);
 
+		const generation = generationRef.current;
+		const isStale = () => generationRef.current !== generation;
+
 		void (async () => {
 			try {
 				const tab = selectSessionById(sessionId)(useSessionStore.getState())?.aiTabs?.find(
 					(t) => t.id === tabId
 				);
 				const visible = tab?.logs ?? [];
-				const nextWindow = (windowRef.current ?? visible.length) + TRANSCRIPT_BACKFILL_PAGE;
 
-				const result = await window.maestro.agentSessions.read(
-					toolType || 'claude-code',
-					projectRoot,
-					agentSessionId,
-					{ offset: 0, limit: nextWindow },
-					sshRemoteId
-				);
-				windowRef.current = nextWindow;
+				for (let step = 0; step < MAX_WIDEN_STEPS_PER_LOAD; step++) {
+					// Seed the first window from the depth the resume path actually read,
+					// not from `visible.length` - see the note in the file header on why
+					// the entry count is only a lower bound on the messages it covers.
+					const nextWindow =
+						(windowRef.current ?? Math.max(visible.length, TRANSCRIPT_RESUME_READ_LIMIT)) +
+						TRANSCRIPT_BACKFILL_PAGE;
 
-				const loaded = transcriptMessagesToLogEntries(
-					stripSynopsisTurns((result.messages ?? []) as TranscriptMessage[])
-				);
-				const older = selectOlderEntries(loaded, visible);
+					const result = await window.maestro.agentSessions.read(
+						toolType || 'claude-code',
+						projectRoot,
+						agentSessionId,
+						{ offset: 0, limit: nextWindow },
+						sshRemoteId
+					);
+					// The tab may have changed while that read was outstanding. Anything
+					// below this point would write into whatever tab is on screen NOW.
+					if (isStale()) return;
+					windowRef.current = nextWindow;
 
-				if (older.length > 0) {
-					// Prepend onto the tab's CURRENT logs, not the snapshot above: the
-					// agent may have streamed new entries onto the tail during the read.
-					updateSessionWith(sessionId, (s) => ({
-						...s,
-						aiTabs: s.aiTabs?.map((t) =>
-							t.id === tabId ? { ...t, logs: [...older, ...t.logs] } : t
-						),
-					}));
-					onPrependRef.current?.(older.length);
+					const loaded = transcriptMessagesToLogEntries(
+						stripSynopsisTurns((result.messages ?? []) as TranscriptMessage[])
+					);
+					const older = selectOlderEntries(loaded, visible);
+
+					if (older.length > 0) {
+						// Prepend onto the tab's CURRENT logs, not the snapshot above: the
+						// agent may have streamed new entries onto the tail during the read.
+						updateSessionWith(sessionId, (s) => ({
+							...s,
+							aiTabs: s.aiTabs?.map((t) =>
+								t.id === tabId ? { ...t, logs: [...older, ...t.logs] } : t
+							),
+						}));
+						onPrependRef.current?.(older.length);
+					}
+
+					// `hasMore` is false once the window spans the whole file, so there is
+					// nothing left to reach even when this page did prepend entries.
+					if (!result.hasMore) {
+						setReachedStart(true);
+						return;
+					}
+					// Made progress: stop here and let the next scroll ask for more.
+					if (older.length > 0) return;
+					// Otherwise the window is still inside the visible transcript. Widen
+					// again rather than handing back a "load" that changed nothing.
 				}
-
-				// `hasMore` is false once the window spans the whole file, so there is
-				// nothing left to reach even when this page did prepend entries.
-				if (!result.hasMore) setReachedStart(true);
 			} catch (e) {
+				if (isStale()) return;
 				logger.warn('[useTranscriptBackfill] Failed to load earlier messages', undefined, e);
 				setError('Could not load earlier messages');
 			} finally {
-				inFlightRef.current = false;
-				setIsLoading(false);
+				// A stale read must not clear the in-flight flag or the spinner that
+				// belong to the request the CURRENT tab has running.
+				if (!isStale()) {
+					inFlightRef.current = false;
+					setIsLoading(false);
+				}
 			}
 		})();
 	}, [reachedStart, tabId, agentSessionId, projectRoot, sessionId, toolType, sshRemoteId]);

--- a/src/renderer/hooks/utils/useProgressiveRenderWindow.ts
+++ b/src/renderer/hooks/utils/useProgressiveRenderWindow.ts
@@ -15,9 +15,12 @@
  * tasks that yield to input between them instead of one long blocking task.
  *
  * Invariants that make this safe for a live, streaming transcript:
- * - `startIndex` only ever DECREASES for a given conversation. New items are
- *   appended at the tail, so they fall inside the window automatically and an
- *   already-rendered entry never disappears mid-session.
+ * - `startIndex` only ever DECREASES for a given conversation, except via the
+ *   explicit `absorbPrepend` escape hatch. New items are appended at the tail,
+ *   so they fall inside the window automatically and an already-rendered entry
+ *   never disappears mid-session. Items prepended at the HEAD (scroll-to-top
+ *   history backfill, issue #1407) are the one case that grows the index again,
+ *   and only by exactly the number added, so nothing already on screen is hidden.
  * - The returned index is clamped so at least `initial` items stay visible, which
  *   keeps the view populated when entries are deleted and the list shrinks.
  * - `onBeforeExpand` fires synchronously before each expansion so the caller can
@@ -84,6 +87,15 @@ export interface ProgressiveRenderWindow {
 	 * reached yet - waiting for it would blow their timeout. Pass 0 to reveal all.
 	 */
 	revealTo: (index: number) => void;
+	/**
+	 * Account for `count` items just prepended at the HEAD of the list. Shifts
+	 * the window by exactly that many so the visible slice is unchanged, then
+	 * lets the normal idle loop walk back through the new history. Without this
+	 * a scroll-to-top backfill would mount a whole page in one commit - the long
+	 * task this hook exists to avoid. Call it in the same tick as the state
+	 * update that grew the list so both land in one React commit.
+	 */
+	absorbPrepend: (count: number) => void;
 }
 
 /**
@@ -128,6 +140,11 @@ export function useProgressiveRenderWindow(
 		setStartIndex((prev) => Math.min(prev, Math.max(0, index)));
 	}, []);
 
+	const absorbPrepend = useCallback((count: number) => {
+		if (count <= 0) return;
+		setStartIndex((prev) => prev + count);
+	}, []);
+
 	useEffect(() => {
 		if (startIndex <= 0) return;
 		const handle = scheduleIdle(expand);
@@ -139,5 +156,6 @@ export function useProgressiveRenderWindow(
 	return {
 		startIndex: Math.min(startIndex, Math.max(0, totalCount - initial)),
 		revealTo,
+		absorbPrepend,
 	};
 }

--- a/src/renderer/utils/transcriptMessages.ts
+++ b/src/renderer/utils/transcriptMessages.ts
@@ -16,6 +16,14 @@ import type { LogEntry } from '../types';
 import { generateId } from './ids';
 
 /**
+ * How many provider messages the resume path reads when hydrating a tab. The
+ * scroll-to-top backfill seeds its first window from this rather than from the
+ * tab's entry count, because tool-only messages are dropped on the way in and a
+ * window sized from what is on screen can land entirely inside it.
+ */
+export const TRANSCRIPT_RESUME_READ_LIMIT = 500;
+
+/**
  * A single message as returned by the agent session storage layer. Only the
  * fields the transcript needs are modelled; storage returns more.
  */
@@ -102,29 +110,84 @@ export function transcriptMessagesToLogEntries(messages: TranscriptMessage[]): L
  *   identical entries. So search outward from where the splice point is
  *   EXPECTED to be - the two lists differ only by entries that never reached
  *   disk - and take the nearest match rather than the first or last in the array.
+ *
+ * Nearest-to-expected is not enough on its own, though. `expected` is only an
+ * estimate, and it is off by however many renderer-only entries the tab holds
+ * (system notices, outage markers). Shift the estimate past one repetition of a
+ * repeated message and the nearest source+text hit is the WRONG occurrence,
+ * which either drops genuine turns or re-prepends ones already on screen. So
+ * candidates are ranked by how much corroborating evidence they carry, and the
+ * scan returns the best tier it found rather than the first hit of any tier:
+ *
+ *   1. Matching id - unambiguous, the tab was hydrated from this same file.
+ *   2. Same source and text AND the same timestamp - a disk-hydrated entry keeps
+ *      the provider's timestamp verbatim, so this pins the exact occurrence.
+ *   3. Same source and text, and the entry AFTER it lines up with `visible[1]`
+ *      too - two consecutive matches is far stronger than one.
+ *   4. Same source and text alone - the old behavior, kept as a last resort
+ *      because a live tab's entries carry locally generated ids and renderer
+ *      clock timestamps, and their next entry may be a renderer-only notice
+ *      that was never written to disk.
  */
 export function selectOlderEntries(loaded: LogEntry[], visible: LogEntry[]): LogEntry[] {
 	if (loaded.length === 0) return [];
 	const boundary = visible[0];
 	if (!boundary) return loaded;
 
+	// Index of the best (lowest-numbered) tier seen so far. Because the scan
+	// walks outward from `expected`, the first index recorded for a tier is
+	// already the nearest one, so later hits in the same tier are ignored.
+	let bestTier = Number.POSITIVE_INFINITY;
+	let bestIndex = -1;
+	const consider = (index: number): boolean => {
+		const tier = matchTier(loaded, index, visible);
+		if (tier === null) return false;
+		if (tier < bestTier) {
+			bestTier = tier;
+			bestIndex = index;
+		}
+		// Tier 1 is an id match: nothing can beat it, so stop the scan.
+		return tier === MATCH_TIER_ID;
+	};
+
 	const expected = Math.max(0, loaded.length - visible.length);
 	for (let delta = 0; delta <= loaded.length; delta++) {
 		const after = expected + delta;
-		if (after < loaded.length && isSameEntry(loaded[after], boundary)) {
-			return loaded.slice(0, after);
-		}
+		if (after < loaded.length && consider(after)) break;
 		const before = expected - delta;
-		if (delta > 0 && before >= 0 && isSameEntry(loaded[before], boundary)) {
-			return loaded.slice(0, before);
-		}
+		if (delta > 0 && before >= 0 && consider(before)) break;
 	}
+
+	if (bestIndex >= 0) return loaded.slice(0, bestIndex);
 
 	// No match: the boundary entry never reached disk (Maestro-injected system
 	// notices and Agent Resilience outage markers live only in the tab). Cut on
 	// time instead - staying strictly older than what is on screen is what keeps
 	// the prepend duplicate-free.
 	return loaded.filter((entry) => entry.timestamp < boundary.timestamp);
+}
+
+const MATCH_TIER_ID = 1;
+const MATCH_TIER_TIMESTAMP = 2;
+const MATCH_TIER_SEQUENCE = 3;
+const MATCH_TIER_TEXT = 4;
+
+/**
+ * How strongly `loaded[index]` looks like the splice boundary `visible[0]`.
+ * Lower is stronger; `null` means it is not a candidate at all.
+ */
+function matchTier(loaded: LogEntry[], index: number, visible: LogEntry[]): number | null {
+	const candidate = loaded[index];
+	const boundary = visible[0];
+	if (candidate.id === boundary.id) return MATCH_TIER_ID;
+	if (!isSameEntry(candidate, boundary)) return null;
+	if (candidate.timestamp === boundary.timestamp) return MATCH_TIER_TIMESTAMP;
+	const nextLoaded = loaded[index + 1];
+	const nextVisible = visible[1];
+	if (nextLoaded && nextVisible && isSameEntry(nextLoaded, nextVisible)) {
+		return MATCH_TIER_SEQUENCE;
+	}
+	return MATCH_TIER_TEXT;
 }
 
 function isSameEntry(a: LogEntry, b: LogEntry): boolean {

--- a/src/renderer/utils/transcriptMessages.ts
+++ b/src/renderer/utils/transcriptMessages.ts
@@ -1,0 +1,133 @@
+/**
+ * Conversion between provider transcript messages (as returned by
+ * `window.maestro.agentSessions.read`) and the `LogEntry` shape the AI
+ * transcript renders, plus the boundary maths used to splice older history in
+ * above what is already on screen.
+ *
+ * Two call sites must produce IDENTICAL entries from the same message: resuming
+ * a session into a tab (`useAgentSessionManagement`) and backfilling older
+ * history when the user scrolls to the top (`useTranscriptBackfill`, issue
+ * #1407). The backfill matches what it just read against what is already
+ * rendered to find the splice point, so any divergence in id or text between
+ * the two paths would duplicate the overlapping region.
+ */
+
+import type { LogEntry } from '../types';
+import { generateId } from './ids';
+
+/**
+ * A single message as returned by the agent session storage layer. Only the
+ * fields the transcript needs are modelled; storage returns more.
+ */
+export interface TranscriptMessage {
+	type: string;
+	role?: string;
+	content: string;
+	timestamp: string;
+	uuid: string;
+	images?: string[];
+}
+
+/**
+ * Matches the Auto Run synopsis prompt that Maestro injects into the agent
+ * session after a task ("Give/Provide a brief synopsis of what you just
+ * accomplished ..."). The leading verb and trailing wording have drifted across
+ * versions and the prompt is user-customizable, so we anchor on the stable core
+ * phrase. A restored tab hides this request and the assistant's `**Summary:**`
+ * reply since they are bookkeeping, not part of the user's conversation.
+ */
+const SYNOPSIS_REQUEST_PATTERN =
+	/^\s*\S+\s+a\s+brief\s+synopsis\s+of\s+what\s+you\s+just\s+accomplished/i;
+
+export function isSynopsisRequest(msg: {
+	type?: string;
+	role?: string;
+	content?: string;
+}): boolean {
+	const isUser = msg.type === 'user' || msg.role === 'user';
+	return isUser && typeof msg.content === 'string' && SYNOPSIS_REQUEST_PATTERN.test(msg.content);
+}
+
+/** Drop each synopsis request and the assistant reply that immediately follows it. */
+export function stripSynopsisTurns<T extends { type: string; role?: string; content: string }>(
+	messages: T[]
+): T[] {
+	return messages.filter((msg, i, arr) => {
+		if (isSynopsisRequest(msg)) return false;
+		const prev = arr[i - 1];
+		const isAssistant = msg.type === 'assistant' || msg.role === 'assistant';
+		if (prev && isSynopsisRequest(prev) && isAssistant) return false;
+		return true;
+	});
+}
+
+/**
+ * Convert transcript messages to log entries, keeping only messages with actual
+ * text content or reconstructed images. Tool-use-only messages (empty text, no
+ * images) are skipped - restored tabs start with thinking off, so there is
+ * nothing useful to render for those entries.
+ */
+export function transcriptMessagesToLogEntries(messages: TranscriptMessage[]): LogEntry[] {
+	return messages
+		.filter(
+			(msg) =>
+				(msg.content && msg.content.trim().length > 0) ||
+				(msg.images != null && msg.images.length > 0)
+		)
+		.map((msg) => ({
+			// Storage should always supply a uuid; the fallback keeps keys unique if
+			// one is missing. Entries that fall back cannot be matched by id across
+			// two reads, which is why `selectOlderEntries` also compares source+text.
+			id: msg.uuid || generateId(),
+			timestamp: new Date(msg.timestamp).getTime(),
+			source: msg.type === 'user' ? ('user' as const) : ('stdout' as const),
+			text: msg.content,
+			...(msg.images && msg.images.length > 0 && { images: msg.images }),
+		}));
+}
+
+/**
+ * Pick the entries of a freshly-read transcript window that sit strictly BEFORE
+ * what the tab already shows, so they can be prepended without duplicating
+ * anything on screen.
+ *
+ * `loaded` is the newest N messages read from disk and `visible` is the tail of
+ * that same conversation, so the splice point is wherever `visible[0]` appears
+ * inside `loaded`. Two things stop that from being a plain `indexOf`:
+ *
+ * - IDs only line up when the tab was hydrated from disk. A tab that ran live
+ *   and then survived a restart holds locally generated IDs for the same
+ *   messages, so the comparison has to fall back to source + text.
+ * - Text alone is ambiguous: a user who sends "continue" ten times produces ten
+ *   identical entries. So search outward from where the splice point is
+ *   EXPECTED to be - the two lists differ only by entries that never reached
+ *   disk - and take the nearest match rather than the first or last in the array.
+ */
+export function selectOlderEntries(loaded: LogEntry[], visible: LogEntry[]): LogEntry[] {
+	if (loaded.length === 0) return [];
+	const boundary = visible[0];
+	if (!boundary) return loaded;
+
+	const expected = Math.max(0, loaded.length - visible.length);
+	for (let delta = 0; delta <= loaded.length; delta++) {
+		const after = expected + delta;
+		if (after < loaded.length && isSameEntry(loaded[after], boundary)) {
+			return loaded.slice(0, after);
+		}
+		const before = expected - delta;
+		if (delta > 0 && before >= 0 && isSameEntry(loaded[before], boundary)) {
+			return loaded.slice(0, before);
+		}
+	}
+
+	// No match: the boundary entry never reached disk (Maestro-injected system
+	// notices and Agent Resilience outage markers live only in the tab). Cut on
+	// time instead - staying strictly older than what is on screen is what keeps
+	// the prepend duplicate-free.
+	return loaded.filter((entry) => entry.timestamp < boundary.timestamp);
+}
+
+function isSameEntry(a: LogEntry, b: LogEntry): boolean {
+	if (a.id === b.id) return true;
+	return a.source === b.source && a.text.trim() === b.text.trim();
+}


### PR DESCRIPTION
Closes #1407

## The problem

An AI tab only ever holds the **newest slice** of its conversation:

- Resuming a session reads the newest **500** provider messages (`useAgentSessionManagement`, `{ offset: 0, limit: 500 }`).
- Persistence truncates every tab to the newest **100** entries (`MAX_PERSISTED_LOGS_PER_TAB`) so `sessions.json` stays small, so after a restart the tab starts even shorter.

The full transcript is still on disk and the storage layer already supports paging (`BaseSessionStorage.applyMessagePagination` returns a `hasMore` flag), but nothing was ever wired up to go back for it. Scrolling up hit a hard stop at an arbitrary older message with no affordance, no loading indicator, and no way to reach the first message - exactly what the reporter described.

## The fix

Reaching the top pages older history back in. Each step re-reads a window one page (250 messages) larger than the last and prepends whatever falls above the boundary.

**Why grow the window instead of tracking a raw offset:** the tab's entry count is only a *lower bound* on the messages it represents - tool-only messages are dropped on the way in, and restart-restored tabs have no cursor at all. There is no offset the renderer could compute that stays correct, so the window is the honest unit. The main process parses the whole transcript on every read regardless, so an offset would not have been cheaper anyway.

**Finding the splice point** is the load-bearing part (`selectOlderEntries`). It cannot be a plain `indexOf`:

- IDs only line up when the tab was hydrated from disk. A tab that ran live and then survived a restart holds locally generated IDs for the same messages, so the comparison falls back to `source` + text.
- Text alone is ambiguous - a user who sends "continue" ten times produces ten identical entries. So the search runs **outward from where the boundary is expected** (the two lists differ only by entries that never reached disk) and takes the nearest match rather than the first or last in the array.
- If the boundary entry never reached disk at all (Maestro-injected system notices, Agent Resilience outage markers), it cuts on timestamp instead. Staying strictly older than what is on screen is what keeps the prepend duplicate-free.

**Keeping #1342 fixed:** prepended entries arrive at the *head*, which would otherwise mount a whole page of markdown in one commit - the exact long task that `useProgressiveRenderWindow` exists to avoid. The hook gains `absorbPrepend(count)`, which shifts the window by exactly the number added so the visible slice is unchanged, then lets the existing idle loop walk back through the new history a chunk at a time. Scroll position is anchored by distance-from-bottom through the same `onBeforeExpand` path already in place.

**Shared conversion:** the resume path and the backfill must build entries identically or the overlap would duplicate, so both now go through `transcriptMessagesToLogEntries()` / `stripSynopsisTurns()` in `src/renderer/utils/transcriptMessages.ts`. That also removes the inline copy of the converter from `useAgentSessionManagement` (net -68 lines there).

## UX

Nothing renders until the user actually scrolls up far enough to trigger a read - no idle button cluttering short conversations. Then, at the top of the transcript:

- a spinner + "Loading earlier messages..." while a page is in flight,
- "Beginning of conversation" once a read proves the tab starts at the first message,
- an inline error + **Retry** if a read fails (a failed read does not latch the hook shut).

All three are gated on the render window having reached the head of the local list, so "Beginning of conversation" can never appear above history that just has not mounted yet.

## Validation

- `npm run lint` clean (all three tsconfigs)
- `eslint` + `prettier` clean on all touched files
- Full suite: **33714 passed**, 108 skipped, 0 failures
- 19 new tests: `transcriptMessages.test.ts` (splice-point cases: id match, text fallback, repeated text, timestamp fallback, already-at-start), `useTranscriptBackfill.test.tsx` (prepend, prepend count callback, widening window, exhaustion, no-agent-session, retryable error), and `absorbPrepend` cases added to `useProgressiveRenderWindow.test.ts`

## Note for the reviewer

This targets `main`, where the affected code lives. Heads-up that `rc` has since split `TerminalOutput.tsx` into `TerminalOutput/` with a dedicated `useTerminalOutputScroll.ts`, so the `TerminalOutput.tsx` hunks here will need a hand-merge on the next main -> rc merge. The other four files are unchanged between the branches and should merge clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Older transcript messages load automatically as you scroll toward the beginning of a conversation.
  * Transcript history loads progressively while preserving the current scroll position.
  * Added loading, retryable error, and conversation-start indicators.
* **Bug Fixes**
  * Improved transcript conversion and filtering to preserve image messages and remove irrelevant tool-only or synopsis entries.
  * Prevented outdated transcript loads from affecting the active conversation.
* **Tests**
  * Added comprehensive coverage for transcript backfill, progressive rendering, message conversion, filtering, and boundary handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->