### PR TITLE
fix(claude): strip trailing separators when encoding project paths

### DIFF
--- a/src/__tests__/maestro-p/session-watcher.test.ts
+++ b/src/__tests__/maestro-p/session-watcher.test.ts
@@ -90,6 +90,16 @@ describe('session-watcher', () => {
 		it('handles an empty string', () => {
 			expect(cwdSlug('')).toBe('');
 		});
+
+		it('strips trailing separators so a cwd saved with one still resolves', () => {
+			expect(cwdSlug('/Users/test/example-proj/')).toBe('-Users-test-example-proj');
+			expect(cwdSlug('C:\\Users\\test\\repo\\')).toBe('C--Users-test-repo');
+		});
+
+		it('leaves filesystem roots intact', () => {
+			expect(cwdSlug('/')).toBe('-');
+			expect(cwdSlug('C:\\')).toBe('C--');
+		});
 	});
 
 	describe('discoverSessionId()', () => {

--- a/src/__tests__/maestro-p/session-watcher.test.ts
+++ b/src/__tests__/maestro-p/session-watcher.test.ts
@@ -24,6 +24,7 @@ import {
 	cwdSlug,
 	discoverSessionId,
 } from '../../maestro-p/session-watcher';
+import { encodeClaudeProjectPath } from '../../shared/pathUtils';
 
 const FAST_POLL_MS = 10;
 
@@ -99,6 +100,39 @@ describe('session-watcher', () => {
 		it('leaves filesystem roots intact', () => {
 			expect(cwdSlug('/')).toBe('-');
 			expect(cwdSlug('C:\\')).toBe('C--');
+		});
+
+		// cwdSlug deliberately inlines the encoding rule instead of importing
+		// src/shared/pathUtils.ts, because the maestro-p bundle stays lean and
+		// that module pulls in fs/os helpers it has no other use for. The cost
+		// of that choice is drift: if one side learns a normalization the other
+		// doesn't, maestro-p and the desktop app look in different directories
+		// for the same project and session discovery silently returns nothing.
+		// This test is what makes the duplication safe - it fails the moment
+		// the two implementations disagree on any input.
+		it('stays byte-for-byte identical to the canonical encodeClaudeProjectPath()', () => {
+			const paths = [
+				'/Users/test/example-proj',
+				'/Users/test/example-proj/',
+				'/Users/test/example-proj///',
+				'C:\\Users\\test\\repo',
+				'C:\\Users\\test\\repo\\',
+				'C:\\Users\\test\\repo\\\\',
+				'/Users/foo/.claude-mem/observer',
+				'/Users/foo/.claude-mem-observer',
+				'/path/with spaces/and_underscores',
+				'/',
+				'//',
+				'C:\\',
+				'---',
+				'',
+			];
+			for (const input of paths) {
+				expect(
+					cwdSlug(input),
+					`cwdSlug drifted from encodeClaudeProjectPath for ${JSON.stringify(input)}`
+				).toBe(encodeClaudeProjectPath(input));
+			}
 		});
 	});
 

--- a/src/__tests__/shared/pathUtils.test.ts
+++ b/src/__tests__/shared/pathUtils.test.ts
@@ -21,6 +21,7 @@ import {
 	compareVersions,
 	buildExpandedPath,
 	buildExpandedEnv,
+	encodeClaudeProjectPath,
 } from '../../shared/pathUtils';
 
 // Mock os.homedir for consistent test behavior
@@ -406,5 +407,34 @@ describe('buildExpandedEnv', () => {
 
 		expect(process.env.PATH).toBe(originalPathValue);
 		expect(process.env.NEW_VAR).toBeUndefined();
+	});
+});
+
+describe('encodeClaudeProjectPath', () => {
+	it('should replace every non-alphanumeric character with a dash', () => {
+		expect(encodeClaudeProjectPath('/Users/test/my_project.v2')).toBe('-Users-test-my-project-v2');
+	});
+
+	it('should strip a trailing slash so the encoding matches what Claude Code writes', () => {
+		expect(encodeClaudeProjectPath('/Volumes/VRAM/01_Tools/Interceptor/')).toBe(
+			encodeClaudeProjectPath('/Volumes/VRAM/01_Tools/Interceptor')
+		);
+		expect(encodeClaudeProjectPath('/Volumes/VRAM/01_Tools/Interceptor/')).toBe(
+			'-Volumes-VRAM-01-Tools-Interceptor'
+		);
+	});
+
+	it('should strip repeated and backslash trailing separators', () => {
+		expect(encodeClaudeProjectPath('/path/to/repo///')).toBe('-path-to-repo');
+		expect(encodeClaudeProjectPath('C:\\Users\\test\\repo\\')).toBe('C--Users-test-repo');
+	});
+
+	it('should leave filesystem roots intact', () => {
+		expect(encodeClaudeProjectPath('/')).toBe('-');
+		expect(encodeClaudeProjectPath('C:\\')).toBe('C--');
+	});
+
+	it('should handle an empty path', () => {
+		expect(encodeClaudeProjectPath('')).toBe('');
 	});
 });

--- a/src/maestro-p/session-watcher.ts
+++ b/src/maestro-p/session-watcher.ts
@@ -68,7 +68,11 @@ export const DEFAULT_DISCOVERY_POLL_INTERVAL_MS = 75;
  * Electron-adjacent helpers we don't need.
  */
 export function cwdSlug(cwd: string): string {
-	return cwd.replace(/[^a-zA-Z0-9]/g, '-');
+	// Strip trailing separators first, matching the canonical helper: a cwd saved
+	// as "/path/to/repo/" would otherwise slug to a directory claude never writes.
+	const trimmed = cwd.replace(/[/\\]+$/, '');
+	const normalized = trimmed === '' || /^[a-zA-Z]:$/.test(trimmed) ? cwd : trimmed;
+	return normalized.replace(/[^a-zA-Z0-9]/g, '-');
 }
 
 interface Candidate {

--- a/src/maestro-p/session-watcher.ts
+++ b/src/maestro-p/session-watcher.ts
@@ -65,7 +65,10 @@ export const DEFAULT_DISCOVERY_POLL_INTERVAL_MS = 75;
  * `-`. The canonical implementation lives in `src/shared/pathUtils.ts`
  * as `encodeClaudeProjectPath`; we inline the rule here because the
  * maestro-p bundle is intentionally lean and the shared module pulls in
- * Electron-adjacent helpers we don't need.
+ * Electron-adjacent helpers we don't need. The duplication is kept honest by
+ * a parity test in src/__tests__/maestro-p/session-watcher.test.ts that asserts
+ * this function and encodeClaudeProjectPath() agree on every input - if you
+ * change the rule here, change it there too or that test will tell you.
  */
 export function cwdSlug(cwd: string): string {
 	// Strip trailing separators first, matching the canonical helper: a cwd saved

--- a/src/shared/pathUtils.ts
+++ b/src/shared/pathUtils.ts
@@ -58,9 +58,25 @@ export function expandTilde(filePath: string, homeDir?: string): string {
  * Encode a project path the same way Claude Code does.
  * Claude replaces all non-alphanumeric characters with '-'.
  * See: https://github.com/RunMaestro/Maestro/issues/348
+ *
+ * Trailing separators are stripped first. Claude Code encodes its own resolved
+ * cwd, which never carries one, but an agent's projectRoot can be saved with a
+ * trailing slash (e.g. "/path/to/repo/"). Encoding that verbatim yields a
+ * "...-repo-" directory that never exists, so every lookup silently comes back
+ * empty. See: https://github.com/RunMaestro/Maestro/issues/1409
  */
 export function encodeClaudeProjectPath(projectPath: string): string {
-	return projectPath.replace(/[^a-zA-Z0-9]/g, '-');
+	return stripTrailingSeparators(projectPath).replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+/**
+ * Remove trailing '/' or '\\' separators from a path, leaving filesystem roots
+ * ("/" and "C:\\") untouched since trimming those yields "" or a bare drive letter.
+ */
+function stripTrailingSeparators(filePath: string): string {
+	const trimmed = filePath.replace(/[/\\]+$/, '');
+	if (trimmed === '' || /^[a-zA-Z]:$/.test(trimmed)) return filePath;
+	return trimmed;
 }
 
 /**


### PR DESCRIPTION
Closes #1409

## Problem

An agent whose `projectRoot`/`cwd` was saved with a trailing slash (e.g. `/Volumes/VRAM/01_Tools/Interceptor/`) made the Agent Sessions browser show an empty list, with no error.

`encodeClaudeProjectPath` (`src/shared/pathUtils.ts`) replaced every non-alphanumeric character with `-` without first stripping the trailing separator, producing `~/.claude/projects/-Volumes-VRAM-01-Tools-Interceptor-`. Claude Code encodes its own resolved cwd, which never carries a trailing separator, so it writes to `-Volumes-VRAM-01-Tools-Interceptor` instead. `statProjectSessionFiles` maps the resulting ENOENT to an empty array, so the failure was completely silent.

Call path from the report: `AgentSessionsBrowser.tsx` -> `useSessionPagination.ts` -> `agentSessions.ts` handler -> `ClaudeSessionStorage.listSessionsPaginated` -> `getEncodedProjectDir` -> `encodeClaudeProjectPath`.

## Fix

Strip trailing `/` and `\` in `encodeClaudeProjectPath` before encoding. Doing it in the shared helper rather than at a single call site covers every consumer at once:

- `ClaudeSessionStorage` local and SSH remote directory resolution (all 6 `getEncodedProjectDir` call sites plus `getRemoteEncodedProjectDir`)
- `src/main/ipc/handlers/claude.ts` (9 call sites)
- `src/main/utils/statsCache.ts` and `src/main/memory-manager.ts`
- `src/cli/services/agent-sessions.ts`

Filesystem roots (`/` and `C:\`) are left untouched, since trimming those would yield `""` or a bare drive letter and change existing behavior.

`maestro-p`'s `cwdSlug` deliberately inlines the same rule (the bundle stays lean and avoids the Electron-adjacent shared module), so it gets the matching normalization to keep the two in sync.

## Tests

- `src/__tests__/shared/pathUtils.test.ts`: new `encodeClaudeProjectPath` block covering the base encoding, trailing slash equivalence with the un-slashed path, repeated and backslash separators, filesystem roots, and the empty path.
- `src/__tests__/maestro-p/session-watcher.test.ts`: trailing separator and root cases for `cwdSlug`.

Full suite passes locally (33819 passed, 108 skipped); `npm run lint` is clean.

## Not addressed

The report's secondary observation about `listSessionsPaginated` not threading `configDir` (alternate `CLAUDE_CONFIG_DIR` trees never being listed) is a separate concern and is left out of this PR to keep the change surgical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project path handling by removing unnecessary trailing separators.
  * Preserved filesystem roots, including `/` and Windows drive roots.
  * Ensured consistent encoded project directory names across POSIX and Windows paths.

* **Tests**
  * Added coverage for trailing separators, repeated separators, Windows paths, filesystem roots, and empty paths.
  * Added parity checks to verify consistent path handling across session and project directory discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->