### PR TITLE
fix(web-desktop): attach files dropped into chat from a browser

### DIFF
--- a/src/__tests__/renderer/hooks/useInputHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useInputHandlers.test.ts
@@ -1970,9 +1970,95 @@ describe('useInputHandlers', () => {
 				expect(window.maestro.attachments.save).toHaveBeenCalledWith(
 					'session-1',
 					'cGRmLWJ5dGVz',
-					'doc.pdf'
+					// Uniquified so a second `doc.pdf` cannot overwrite this one.
+					expect.stringMatching(/^doc-[0-9a-z]+\.pdf$/)
 				);
-				expect(inputVal()).toBe('@/userData/attachments/session-1/doc.pdf ');
+				expect(inputVal()).toMatch(/^@\/userData\/attachments\/session-1\/doc-[0-9a-z]+\.pdf $/);
+			});
+
+			// Regression: the upload awaits the host, and the composer store holds
+			// whichever draft is on screen when it resolves. Without a pin the
+			// mention landed in the tab the user had switched to.
+			it('mentions the tab the file was dropped into, not the one switched to', async () => {
+				useSessionStore.setState({
+					sessions: [
+						createMockSession({
+							id: 'session-1',
+							inputMode: 'ai',
+							aiTabs: [
+								{ id: 'tab-1', name: 'Tab 1', inputValue: '', data: [], stagedImages: [] },
+								{ id: 'tab-2', name: 'Tab 2', inputValue: '', data: [], stagedImages: [] },
+							] as any,
+							activeTabId: 'tab-1',
+						}),
+					],
+					activeSessionId: 'session-1',
+				} as any);
+
+				let landTheUpload: () => void = () => {};
+				vi.mocked(window.maestro.attachments.save).mockImplementationOnce(
+					(sessionId: string, _b64: string, filename: string) =>
+						new Promise((resolve) => {
+							landTheUpload = () =>
+								resolve({
+									success: true,
+									path: `/userData/attachments/${sessionId}/${filename}`,
+								});
+						})
+				);
+
+				const deps = createMockDeps();
+				const { result, rerender } = renderHook(() => useInputHandlers(deps));
+
+				// Awaited so the read finishes and the upload is actually in flight
+				// (pending on the host) before the user moves on.
+				await act(async () => {
+					result.current.handleDrop(dropPathlessPdf());
+				});
+
+				// The user moves on while the bytes are still crossing the bridge.
+				act(() => {
+					useSessionStore.setState({
+						sessions: useSessionStore
+							.getState()
+							.sessions.map((sn: any) => ({ ...sn, activeTabId: 'tab-2' })),
+					} as any);
+				});
+				rerender();
+
+				await act(async () => {
+					landTheUpload();
+				});
+
+				const tabs = (useSessionStore.getState().sessions[0] as any).aiTabs;
+				const droppedInto = tabs.find((t: any) => t.id === 'tab-1');
+				const switchedTo = tabs.find((t: any) => t.id === 'tab-2');
+				expect(droppedInto.inputValue).toMatch(
+					/^@\/userData\/attachments\/session-1\/doc-[0-9a-z]+\.pdf $/
+				);
+				expect(switchedTo.inputValue).toBe('');
+				// The on-screen composer (now tab-2's) was left alone.
+				expect(inputVal()).toBe('');
+			});
+
+			it('normalises a Windows host path into the mention', async () => {
+				// The host is whichever machine runs Maestro, so a browser drop can
+				// land on a Windows path even when the browser is elsewhere.
+				vi.mocked(window.maestro.attachments.save).mockResolvedValueOnce({
+					success: true,
+					path: 'C:\\Users\\dev\\AppData\\maestro\\attachments\\session-1\\doc-abc123.pdf',
+				});
+
+				const deps = createMockDeps();
+				const { result } = renderHook(() => useInputHandlers(deps));
+
+				await act(async () => {
+					result.current.handleDrop(dropPathlessPdf());
+				});
+
+				expect(inputVal()).toBe(
+					'@C:/Users/dev/AppData/maestro/attachments/session-1/doc-abc123.pdf '
+				);
 			});
 
 			it('raises a toast when the upload fails', async () => {

--- a/src/__tests__/renderer/hooks/useInputHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useInputHandlers.test.ts
@@ -129,6 +129,7 @@ import { useComposerInputStore } from '../../../renderer/stores/composerInputSto
 import { notifyCenterFlash } from '../../../renderer/stores/centerFlashStore';
 
 const mockNotifyCenterFlash = vi.mocked(notifyCenterFlash);
+import { useNotificationStore } from '../../../renderer/stores/notificationStore';
 import { useSettingsStore } from '../../../renderer/stores/settingsStore';
 import { useGroupChatStore } from '../../../renderer/stores/groupChatStore';
 import { useUIStore } from '../../../renderer/stores/uiStore';
@@ -1888,7 +1889,7 @@ describe('useInputHandlers', () => {
 	// ========================================================================
 
 	describe('handleDrop edge cases', () => {
-		it('ignores drop with non-image file types', () => {
+		it('does not stage non-image file drops as images', () => {
 			const deps = createMockDeps();
 			const { result } = renderHook(() => useInputHandlers(deps));
 
@@ -1898,8 +1899,8 @@ describe('useInputHandlers', () => {
 					getData: () => '',
 					files: {
 						length: 2,
-						0: { type: 'application/pdf', name: 'doc.pdf' },
-						1: { type: 'text/plain', name: 'readme.txt' },
+						0: { type: 'application/pdf', name: 'doc.pdf', path: '/tmp/doc.pdf' },
+						1: { type: 'text/plain', name: 'readme.txt', path: '/tmp/readme.txt' },
 					} as any,
 				},
 			} as unknown as React.DragEvent;
@@ -1910,10 +1911,91 @@ describe('useInputHandlers', () => {
 
 			// preventDefault is always called (for drag cleanup)
 			expect(dropEvent.preventDefault).toHaveBeenCalled();
-			// But no images should be staged
+			// They become @mentions, not image attachments.
 			const sessions = useSessionStore.getState().sessions;
 			const tab = sessions[0].aiTabs.find((t: any) => t.id === 'tab-1');
 			expect(tab?.stagedImages).toEqual([]);
+			expect(inputVal()).toBe('@/tmp/doc.pdf @/tmp/readme.txt ');
+		});
+
+		// Regression: in the web-desktop (browser) build a dropped `File` has no
+		// filesystem path, so these used to be skipped with no chip, no mention,
+		// and no error - a completely silent failure. See issue #1411.
+		describe('path-less (browser) file drops', () => {
+			// This suite runs on fake timers, so jsdom's real async FileReader would
+			// never fire. Stub it the way the image-drop tests above do.
+			let originalFileReader: typeof FileReader;
+
+			beforeEach(() => {
+				originalFileReader = global.FileReader;
+				class MockFileReaderLocal {
+					result: string | null = null;
+					onload: ((ev: any) => void) | null = null;
+					onerror: ((ev: any) => void) | null = null;
+					readAsDataURL = vi.fn(function (this: MockFileReaderLocal) {
+						this.result = 'data:application/pdf;base64,cGRmLWJ5dGVz';
+						this.onload?.({ target: { result: this.result } });
+					});
+				}
+				global.FileReader = MockFileReaderLocal as unknown as typeof FileReader;
+			});
+
+			afterEach(() => {
+				global.FileReader = originalFileReader;
+			});
+
+			function dropPathlessPdf() {
+				return {
+					preventDefault: vi.fn(),
+					dataTransfer: {
+						getData: () => '',
+						files: {
+							length: 1,
+							// A browser `File` - no `path`, so `getPathForFile` returns ''.
+							0: new File(['pdf-bytes'], 'doc.pdf', { type: 'application/pdf' }),
+						} as any,
+					},
+				} as unknown as React.DragEvent;
+			}
+
+			it('uploads the file and @mentions the host copy', async () => {
+				const deps = createMockDeps();
+				const { result } = renderHook(() => useInputHandlers(deps));
+				const dropEvent = dropPathlessPdf();
+
+				await act(async () => {
+					result.current.handleDrop(dropEvent);
+				});
+
+				expect(window.maestro.attachments.save).toHaveBeenCalledWith(
+					'session-1',
+					'cGRmLWJ5dGVz',
+					'doc.pdf'
+				);
+				expect(inputVal()).toBe('@/userData/attachments/session-1/doc.pdf ');
+			});
+
+			it('raises a toast when the upload fails', async () => {
+				vi.mocked(window.maestro.attachments.save).mockResolvedValueOnce({
+					success: false,
+					error: 'disk full',
+				});
+				useNotificationStore.setState({ toasts: [] });
+
+				const deps = createMockDeps();
+				const { result } = renderHook(() => useInputHandlers(deps));
+
+				await act(async () => {
+					result.current.handleDrop(dropPathlessPdf());
+				});
+
+				const toasts = useNotificationStore.getState().toasts;
+				expect(toasts).toHaveLength(1);
+				expect(toasts[0].message).toBe('disk full');
+				expect(toasts[0].color).toBe('red');
+				// Nothing was mentioned, but the failure is visible.
+				expect(inputVal()).toBe('');
+			});
 		});
 
 		it('processes all image files when dropping multiple images', () => {

--- a/src/__tests__/renderer/utils/osFileDrop.test.ts
+++ b/src/__tests__/renderer/utils/osFileDrop.test.ts
@@ -1,9 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { dragHasOsFiles, getDroppedPaths } from '../../../renderer/utils/osFileDrop';
+import {
+	dragHasOsFiles,
+	getDroppedPaths,
+	uploadPathlessFile,
+	MAX_BROWSER_UPLOAD_BYTES,
+} from '../../../renderer/utils/osFileDrop';
 
 const mockGetPathForFile = vi.fn();
+const mockSaveAttachment = vi.fn();
 (window as any).maestro = {
 	fs: { getPathForFile: (file: unknown) => mockGetPathForFile(file) },
+	attachments: {
+		save: (sessionId: string, base64: string, filename: string) =>
+			mockSaveAttachment(sessionId, base64, filename),
+	},
 };
 
 function makeDataTransfer(types: string[], files: Array<{ path: string }> = []): DataTransfer {
@@ -14,6 +24,10 @@ describe('osFileDrop', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockGetPathForFile.mockImplementation((file: { path?: string }) => file.path ?? '');
+		mockSaveAttachment.mockResolvedValue({
+			success: true,
+			path: '/userData/attachments/session-1/notes.pdf',
+		});
 	});
 
 	describe('dragHasOsFiles', () => {
@@ -43,6 +57,38 @@ describe('osFileDrop', () => {
 
 		it('returns an empty array for a null dataTransfer', () => {
 			expect(getDroppedPaths(null)).toEqual([]);
+		});
+	});
+
+	describe('uploadPathlessFile', () => {
+		it('uploads the bytes as raw base64 and resolves with the host path', async () => {
+			const file = new File(['hello'], 'notes.pdf', { type: 'application/pdf' });
+
+			const saved = await uploadPathlessFile(file, 'session-1');
+
+			expect(saved).toBe('/userData/attachments/session-1/notes.pdf');
+			const [sessionId, base64, filename] = mockSaveAttachment.mock.calls[0];
+			expect(sessionId).toBe('session-1');
+			expect(filename).toBe('notes.pdf');
+			// Raw base64 only - the `data:...;base64,` prefix would be written to
+			// disk verbatim by attachments:save and corrupt the file.
+			expect(base64).not.toContain('base64,');
+			expect(atob(base64)).toBe('hello');
+		});
+
+		it('rejects files above the upload limit without calling the host', async () => {
+			const file = new File(['x'], 'huge.zip');
+			Object.defineProperty(file, 'size', { value: MAX_BROWSER_UPLOAD_BYTES + 1 });
+
+			await expect(uploadPathlessFile(file, 'session-1')).rejects.toThrow(/upload limit/);
+			expect(mockSaveAttachment).not.toHaveBeenCalled();
+		});
+
+		it('rejects with the host error when the save fails', async () => {
+			mockSaveAttachment.mockResolvedValue({ success: false, error: 'disk full' });
+			const file = new File(['hello'], 'notes.pdf');
+
+			await expect(uploadPathlessFile(file, 'session-1')).rejects.toThrow('disk full');
 		});
 	});
 });

--- a/src/__tests__/renderer/utils/osFileDrop.test.ts
+++ b/src/__tests__/renderer/utils/osFileDrop.test.ts
@@ -24,10 +24,10 @@ describe('osFileDrop', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockGetPathForFile.mockImplementation((file: { path?: string }) => file.path ?? '');
-		mockSaveAttachment.mockResolvedValue({
-			success: true,
-			path: '/userData/attachments/session-1/notes.pdf',
-		});
+		// Mirror the host: the file lands under whatever name it was saved as.
+		mockSaveAttachment.mockImplementation((sessionId: string, _b64: string, filename: string) =>
+			Promise.resolve({ success: true, path: `/userData/attachments/${sessionId}/${filename}` })
+		);
 	});
 
 	describe('dragHasOsFiles', () => {
@@ -66,14 +66,39 @@ describe('osFileDrop', () => {
 
 			const saved = await uploadPathlessFile(file, 'session-1');
 
-			expect(saved).toBe('/userData/attachments/session-1/notes.pdf');
+			expect(saved).toMatch(/^\/userData\/attachments\/session-1\/notes-[0-9a-z]+\.pdf$/);
 			const [sessionId, base64, filename] = mockSaveAttachment.mock.calls[0];
 			expect(sessionId).toBe('session-1');
-			expect(filename).toBe('notes.pdf');
+			// The readable name survives, with a token that keeps the write from
+			// clobbering an earlier attachment of the same name.
+			expect(filename).toMatch(/^notes-[0-9a-z]+\.pdf$/);
 			// Raw base64 only - the `data:...;base64,` prefix would be written to
 			// disk verbatim by attachments:save and corrupt the file.
 			expect(base64).not.toContain('base64,');
 			expect(atob(base64)).toBe('hello');
+		});
+
+		it('does not overwrite an earlier attachment with the same name', async () => {
+			// `attachments:save` writes straight to <dir>/<filename>, so two
+			// different files dropped as `notes.pdf` must not land on each other -
+			// the first drop's @mention would silently start reading the second
+			// file's bytes.
+			const first = await uploadPathlessFile(new File(['one'], 'notes.pdf'), 'session-1');
+			const second = await uploadPathlessFile(new File(['two'], 'notes.pdf'), 'session-1');
+
+			expect(first).not.toBe(second);
+		});
+
+		it('keeps an extensionless name intact', async () => {
+			await uploadPathlessFile(new File(['x'], 'Makefile'), 'session-1');
+
+			expect(mockSaveAttachment.mock.calls[0][2]).toMatch(/^Makefile-[0-9a-z]+$/);
+		});
+
+		it('treats a dotfile name as a name, not an extension', async () => {
+			await uploadPathlessFile(new File(['x'], '.env'), 'session-1');
+
+			expect(mockSaveAttachment.mock.calls[0][2]).toMatch(/^\.env-[0-9a-z]+$/);
 		});
 
 		it('rejects files above the upload limit without calling the host', async () => {

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -328,6 +328,16 @@ const mockMaestro = {
 			uncommittedChanges: 0,
 		}),
 	},
+	attachments: {
+		// Mirrors userData/attachments/{sessionId}/{filename} on the host.
+		save: vi.fn((sessionId: string, _base64: string, filename: string) =>
+			Promise.resolve({ success: true, path: `/userData/attachments/${sessionId}/${filename}` })
+		),
+		load: vi.fn().mockResolvedValue({ success: true, dataUrl: '' }),
+		delete: vi.fn().mockResolvedValue({ success: true }),
+		list: vi.fn().mockResolvedValue({ success: true, files: [] }),
+		getPath: vi.fn().mockResolvedValue({ success: true, path: '/userData/attachments' }),
+	},
 	fs: {
 		readDir: vi.fn().mockResolvedValue([]),
 		readFile: vi.fn().mockResolvedValue(''),

--- a/src/renderer/hooks/input/useInputHandlers.ts
+++ b/src/renderer/hooks/input/useInputHandlers.ts
@@ -829,20 +829,68 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 		[setInputValue, setStagedImages, getCommandMode]
 	);
 
+	/**
+	 * Append `@` mentions to the AI composer.
+	 *
+	 * `pinnedTabId` names the tab the mentions belong to. Pass it whenever the
+	 * append can land after the active tab may have moved (an upload that awaits
+	 * the host, say): the composer store holds whatever draft is on screen right
+	 * now, so an unpinned write would drop the mention into whichever
+	 * conversation the user switched to. When the pinned tab is no longer the one
+	 * on screen the mention goes onto that tab's own persisted draft instead.
+	 *
+	 * The background write deliberately does not go through
+	 * `syncAiInputToSession`: that reads `aiCommandMode` from the live composer
+	 * and would stamp the on-screen tab's bang-ladder rung onto the background
+	 * tab, and it cancels the queued flush that belongs to the tab being typed
+	 * in. Only `inputValue` is touched here.
+	 *
+	 * Returns true when the live composer was the one updated, so the caller
+	 * knows whether focusing the textarea is the right follow-up.
+	 */
 	const appendMentionsToAiInput = useCallback(
-		(paths: string[]) => {
-			if (paths.length === 0) return;
+		(paths: string[], pinnedTabId?: string): boolean => {
+			if (paths.length === 0) return false;
 			const joined = paths.map((p) => formatFileMention(p)).join(' ');
-			setInputValue((prev) => {
+			const append = (prev: string) => {
 				if (!prev) return joined + ' ';
 				const sep = /\s$/.test(prev) ? '' : ' ';
 				return prev + sep + joined + ' ';
-			});
+			};
+			const pinIsOnScreen =
+				!pinnedTabId || (isAiModeRef.current && pinnedTabId === activeTabIdRef.current);
+			if (!pinIsOnScreen) {
+				let found = false;
+				setSessions((prev) =>
+					prev.map((s) => {
+						if (!s.aiTabs?.some((t) => t.id === pinnedTabId)) return s;
+						found = true;
+						return {
+							...s,
+							aiTabs: s.aiTabs.map((t) =>
+								t.id === pinnedTabId ? { ...t, inputValue: append(t.inputValue ?? '') } : t
+							),
+						};
+					})
+				);
+				// `found` stays false when the tab was closed mid-upload; the file is
+				// still on the host, there is just no draft left to mention it in.
+				if (!found) {
+					notifyToast({
+						color: 'yellow',
+						title: 'Attachment has nowhere to go',
+						message: 'The tab it was dropped into was closed before the upload finished',
+					});
+				}
+				return false;
+			}
+			setInputValue(append);
+			return true;
 		},
-		[setInputValue]
+		[setInputValue, setSessions]
 	);
 
-	const appendMentionsToGroupChatDraft = useCallback((paths: string[]) => {
+	const appendMentionsToGroupChatDraft = useCallback((paths: string[], pinnedChatId?: string) => {
 		if (paths.length === 0) return;
 		const joined = paths.map((p) => formatFileMention(p)).join(' ');
 		// Reading the store via getState() (instead of subscribing) is intentional:
@@ -850,7 +898,13 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 		// chatId / setter at fire time and don't want stale-closure invalidation to
 		// re-create the callback (and bust handleDrop's useCallback deps) on every
 		// store update.
-		const { activeGroupChatId: chatId, setGroupChats } = useGroupChatStore.getState();
+		//
+		// `pinnedChatId` is the chat the drop happened in. An upload resolves
+		// asynchronously, so without the pin a mention would land in whichever chat
+		// is open when it finishes - or vanish entirely once the user has left
+		// group chat.
+		const { activeGroupChatId, setGroupChats } = useGroupChatStore.getState();
+		const chatId = pinnedChatId ?? activeGroupChatId;
 		if (!chatId) return;
 		setGroupChats((prev) =>
 			prev.map((c) => {
@@ -876,7 +930,8 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 			files: File[],
 			ownerId: string,
 			projectRoot: string | undefined,
-			toGroupChat: boolean
+			toGroupChat: boolean,
+			pinnedTabId: string | undefined
 		) => {
 			const mentions: string[] = [];
 			for (const file of files) {
@@ -893,9 +948,11 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 			}
 			if (mentions.length === 0) return;
 			if (toGroupChat) {
-				appendMentionsToGroupChatDraft(mentions);
-			} else {
-				appendMentionsToAiInput(mentions);
+				// `ownerId` is the group chat the drop happened in.
+				appendMentionsToGroupChatDraft(mentions, ownerId);
+			} else if (appendMentionsToAiInput(mentions, pinnedTabId)) {
+				// Only steal focus when the mention actually went into the composer
+				// that is on screen.
 				inputRef.current?.focus();
 			}
 		},
@@ -1057,7 +1114,10 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 						pathlessFiles,
 						ownerId,
 						projectRoot,
-						isGroupChatActive
+						isGroupChatActive,
+						// Pin the tab from drop time so switching tabs or agents while
+						// the bytes are in flight cannot retarget the mention.
+						activeSession ? getActiveTab(activeSession)?.id : undefined
 					);
 				} else {
 					notifyToast({

--- a/src/renderer/hooks/input/useInputHandlers.ts
+++ b/src/renderer/hooks/input/useInputHandlers.ts
@@ -30,6 +30,8 @@ import { useInputContext } from '../../contexts/InputContext';
 import { getActiveTab } from '../../utils/tabHelpers';
 import { setLiveDraft } from '../../utils/liveDraftStore';
 import { notifyCenterFlash } from '../../stores/centerFlashStore';
+import { notifyToast } from '../../stores/notificationStore';
+import { uploadPathlessFile } from '../../utils/osFileDrop';
 import { useComposerInputStore } from '../../stores/composerInputStore';
 import { useDebouncedValue } from '../utils';
 import { useInputSync } from './useInputSync';
@@ -861,6 +863,45 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 		);
 	}, []);
 
+	/**
+	 * Attach dropped files that carry no filesystem path (the web-desktop build
+	 * runs in a browser, so `getPathForFile` comes back empty and the file may
+	 * live on a different machine than the agent). The bytes are uploaded into
+	 * the session's attachments directory and the resulting host path is
+	 * @mentioned. Anything that fails raises a toast - dropping a file into the
+	 * chat and getting nothing back at all is the bug this exists to avoid.
+	 */
+	const uploadAndMentionPathlessFiles = useCallback(
+		async (
+			files: File[],
+			ownerId: string,
+			projectRoot: string | undefined,
+			toGroupChat: boolean
+		) => {
+			const mentions: string[] = [];
+			for (const file of files) {
+				try {
+					const savedPath = await uploadPathlessFile(file, ownerId);
+					mentions.push(toMentionPath(savedPath, projectRoot));
+				} catch (error) {
+					notifyToast({
+						color: 'red',
+						title: 'Could not attach file',
+						message: error instanceof Error ? error.message : `Could not attach ${file.name}`,
+					});
+				}
+			}
+			if (mentions.length === 0) return;
+			if (toGroupChat) {
+				appendMentionsToGroupChatDraft(mentions);
+			} else {
+				appendMentionsToAiInput(mentions);
+				inputRef.current?.focus();
+			}
+		},
+		[appendMentionsToAiInput, appendMentionsToGroupChatDraft, inputRef]
+	);
+
 	const handleDrop = useCallback(
 		(e: React.DragEvent) => {
 			e.preventDefault();
@@ -958,6 +999,8 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 
 			const files = e.dataTransfer.files;
 			const externalPaths: string[] = [];
+			// Files with no resolvable path (browser drops) get uploaded instead.
+			const pathlessFiles: File[] = [];
 			const projectRoot = activeSession?.projectRoot ?? activeSession?.fullPath;
 
 			for (let i = 0; i < files.length; i++) {
@@ -996,7 +1039,32 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 					const filePath = window.maestro.fs.getPathForFile(file);
 					if (filePath) {
 						externalPaths.push(toMentionPath(filePath, projectRoot));
+					} else {
+						// No path to mention: the web-desktop build is a browser, where
+						// `File` objects have no path at all. Upload the bytes to the host
+						// so the agent has something real to read.
+						pathlessFiles.push(file);
 					}
+				}
+			}
+
+			if (pathlessFiles.length > 0) {
+				const ownerId = isGroupChatActive
+					? useGroupChatStore.getState().activeGroupChatId
+					: activeSession?.id;
+				if (ownerId) {
+					void uploadAndMentionPathlessFiles(
+						pathlessFiles,
+						ownerId,
+						projectRoot,
+						isGroupChatActive
+					);
+				} else {
+					notifyToast({
+						color: 'red',
+						title: 'Could not attach file',
+						message: 'There is no active agent to attach it to',
+					});
 				}
 			}
 
@@ -1009,7 +1077,13 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 				}
 			}
 		},
-		[setStagedImages, appendMentionsToAiInput, appendMentionsToGroupChatDraft, getCommandMode]
+		[
+			setStagedImages,
+			appendMentionsToAiInput,
+			appendMentionsToGroupChatDraft,
+			uploadAndMentionPathlessFiles,
+			getCommandMode,
+		]
 	);
 
 	// ====================================================================

--- a/src/renderer/utils/osFileDrop.ts
+++ b/src/renderer/utils/osFileDrop.ts
@@ -14,6 +14,8 @@
  * Maestro instead.
  */
 
+import { generateId } from './ids';
+
 /** True when a drag carries OS files (as opposed to an internal element drag). */
 export function dragHasOsFiles(dataTransfer: DataTransfer | null): boolean {
 	if (!dataTransfer) return false;
@@ -64,6 +66,25 @@ function readFileAsBase64(file: File): Promise<string> {
 }
 
 /**
+ * Give every upload its own filename.
+ *
+ * `attachments:save` writes straight to `<attachments>/<sessionId>/<filename>`
+ * with no collision handling, so two different files dropped under the same
+ * name (a `report.pdf` from two different folders, say) would leave the first
+ * drop's `@mention` silently pointing at the second file's bytes. A short
+ * unique token keeps the original name readable in the mention while making
+ * the write non-destructive.
+ */
+function uniqueAttachmentName(name: string): string {
+	const token = generateId().replace(/-/g, '').slice(0, 8);
+	const dot = name.lastIndexOf('.');
+	// `dot <= 0` covers both "no extension" and a leading-dot dotfile, where
+	// everything before the dot is the name rather than the extension.
+	if (dot <= 0) return `${name}-${token}`;
+	return `${name.slice(0, dot)}-${token}${name.slice(dot)}`;
+}
+
+/**
  * Copy a dropped `File` that has no filesystem path onto the machine running
  * Maestro, and resolve with the absolute path it landed on.
  *
@@ -82,7 +103,11 @@ export async function uploadPathlessFile(file: File, ownerId: string): Promise<s
 		throw new Error(`${file.name} is larger than the ${limitMb} MB upload limit`);
 	}
 	const base64 = await readFileAsBase64(file);
-	const result = await window.maestro.attachments.save(ownerId, base64, file.name);
+	const result = await window.maestro.attachments.save(
+		ownerId,
+		base64,
+		uniqueAttachmentName(file.name)
+	);
 	if (!result.success || !result.path) {
 		throw new Error(result.error || `Could not attach ${file.name}`);
 	}

--- a/src/renderer/utils/osFileDrop.ts
+++ b/src/renderer/utils/osFileDrop.ts
@@ -8,6 +8,10 @@
  * bridges to it. Folders dropped from the OS arrive as a single `File` entry
  * (the directory itself); the resolved path points at the folder and the main
  * process copies it recursively.
+ *
+ * In the web-desktop (browser) build there is no `webUtils` and no path to
+ * recover, so `uploadPathlessFile` uploads the bytes to the machine running
+ * Maestro instead.
  */
 
 /** True when a drag carries OS files (as opposed to an internal element drag). */
@@ -30,4 +34,57 @@ export function getDroppedPaths(dataTransfer: DataTransfer | null): string[] {
 		if (path) out.push(path);
 	}
 	return out;
+}
+
+/**
+ * Largest browser upload we accept. The bytes travel to the host as base64
+ * inside a single WebSocket bridge message, so an unbounded file would stall
+ * the bridge for every other call.
+ */
+export const MAX_BROWSER_UPLOAD_BYTES = 25 * 1024 * 1024;
+
+/** Read a `File` as raw base64, with the `data:<mime>;base64,` prefix stripped. */
+function readFileAsBase64(file: File): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onload = () => {
+			const result = typeof reader.result === 'string' ? reader.result : '';
+			const comma = result.indexOf(',');
+			if (comma === -1) {
+				reject(new Error(`Could not read ${file.name}`));
+				return;
+			}
+			resolve(result.slice(comma + 1));
+		};
+		// Folders dragged into a browser arrive as `File` entries that cannot be
+		// read, so this is the folder case as well as genuine read failures.
+		reader.onerror = () => reject(new Error(`Could not read ${file.name}`));
+		reader.readAsDataURL(file);
+	});
+}
+
+/**
+ * Copy a dropped `File` that has no filesystem path onto the machine running
+ * Maestro, and resolve with the absolute path it landed on.
+ *
+ * The web-desktop build runs the renderer in a plain browser, where `File`
+ * objects carry no path (`getPathForFile` returns `''`) and the file may not
+ * even live on the same machine as the agent. Uploading the bytes into the
+ * session's attachments directory gives the agent a real path to read. Rejects
+ * with a user-readable message so callers can surface the failure instead of
+ * dropping the file silently.
+ *
+ * @param ownerId - Session (or group chat) id the attachment belongs to.
+ */
+export async function uploadPathlessFile(file: File, ownerId: string): Promise<string> {
+	if (file.size > MAX_BROWSER_UPLOAD_BYTES) {
+		const limitMb = Math.round(MAX_BROWSER_UPLOAD_BYTES / (1024 * 1024));
+		throw new Error(`${file.name} is larger than the ${limitMb} MB upload limit`);
+	}
+	const base64 = await readFileAsBase64(file);
+	const result = await window.maestro.attachments.save(ownerId, base64, file.name);
+	if (!result.success || !result.path) {
+		throw new Error(result.error || `Could not attach ${file.name}`);
+	}
+	return result.path;
 }

--- a/src/renderer/utils/osFileDrop.ts
+++ b/src/renderer/utils/osFileDrop.ts
@@ -71,12 +71,18 @@ function readFileAsBase64(file: File): Promise<string> {
  * `attachments:save` writes straight to `<attachments>/<sessionId>/<filename>`
  * with no collision handling, so two different files dropped under the same
  * name (a `report.pdf` from two different folders, say) would leave the first
- * drop's `@mention` silently pointing at the second file's bytes. A short
- * unique token keeps the original name readable in the mention while making
- * the write non-destructive.
+ * drop's `@mention` silently pointing at the second file's bytes. A token from
+ * the shared id generator keeps the original name readable in the mention
+ * while making the write non-destructive.
+ *
+ * The token is truncated because the whole filename lands in the user's draft
+ * as an `@mention` they have to read past. 48 bits is far more than the job
+ * needs: two names only ever collide within one session's attachments
+ * directory and only when the base name already matches, so the space being
+ * drawn from is a handful of same-named drops, not the whole store.
  */
 function uniqueAttachmentName(name: string): string {
-	const token = generateId().replace(/-/g, '').slice(0, 8);
+	const token = generateId().replace(/-/g, '').slice(0, 12);
 	const dot = name.lastIndexOf('.');
 	// `dot <= 0` covers both "no extension" and a leading-dot dotfile, where
 	// everything before the dot is the name rather than the extension.


### PR DESCRIPTION
closes #1411

## Problem

Dropping a non-image file (a `.pdf`, a `.html`, anything) onto the chat in the **web-desktop** build did nothing at all: the drop zone highlighted, then no chip, no @mention, no spinner, no error. A completely silent failure.

Root cause is in `handleDrop` (`src/renderer/hooks/input/useInputHandlers.ts`). Non-image drops are turned into `@<path>` mentions, and the path comes from `window.maestro.fs.getPathForFile(file)`, which is backed by Electron's `webUtils`. The web-desktop build runs the renderer in a plain browser, where the web-desktop `electron` shim can only read the non-standard `File.path` - which browsers do not set. So it returns `''` and the old code skipped the file with no branch for the empty case:

```ts
const filePath = window.maestro.fs.getPathForFile(file);
if (filePath) {
    externalPaths.push(toMentionPath(filePath, projectRoot));
}
// ...and nothing at all otherwise
```

Images were unaffected (they go through `FileReader` and stage as data URLs), which matches the report that both `.html` and `.pdf` fail while the behavior is not file-type specific.

## Fix

A dropped file with no resolvable path is now uploaded to the machine running Maestro rather than skipped. `uploadPathlessFile()` (new, in `src/renderer/utils/osFileDrop.ts`) reads the file as raw base64 and hands it to the existing `attachments:save` IPC handler, which writes it to `userData/attachments/<sessionId>/<filename>` and returns the absolute host path. That path is then @mentioned exactly like a desktop drop, so the agent has a real file to read.

Note this is also the right shape for the remote case: in web-desktop the browser may not be the same machine as the agent, so a client-side path would be useless even if the browser gave us one.

Details:

- **Size cap:** 25 MB. The bytes cross the WebSocket bridge as base64 inside a single message, so an unbounded file would stall the bridge for every other call.
- **No more silent failures:** oversize files, unreadable files, and failed host writes each raise a red toast naming the file. Folders dragged in from a browser arrive as unreadable `File` entries and land in the same path, so they report an error instead of disappearing.
- **Coverage:** the main-panel drop zone, the chat textarea, and group chat all funnel into this one `handleDrop`, so all three are fixed.
- Desktop (Electron) behavior is unchanged - `getPathForFile` still returns a real path there, and the upload branch is only reached when it comes back empty.

## Testing

- `src/__tests__/renderer/utils/osFileDrop.test.ts` - `uploadPathlessFile` sends raw base64 (not the `data:...;base64,` prefix, which `attachments:save` would write to disk verbatim and corrupt the file), rejects over the size cap without touching the host, and surfaces the host error.
- `src/__tests__/renderer/hooks/useInputHandlers.test.ts` - a path-less drop uploads and @mentions the host copy; a failed upload raises a red toast and mentions nothing.
- Full suite green locally: 37,386 passed.

## Not covered

Other `getDroppedPaths()` callers (dragging OS files into the Files panel to import them) have the same browser limitation and still silently drop path-less files. That is a separate surface from the one reported here and is left for a follow-up.

Targets `rc` rather than `main`: `src/web-desktop/` does not exist on `main` yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for browser file drops without filesystem paths.
  * Dropped files are uploaded as attachments and inserted into drafts as project-relative `@` mentions.
  * Added support for pathless PDFs and other non-image files.
  * Uploads remain associated with the original conversation when navigating during processing.
  * Added unique attachment naming and Windows path normalization.
  * Added a 25 MB upload limit with clear notifications for oversized or failed uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->