### PR TITLE
fix(notifications): stop a zero duration rendering a stray "0" on a toast

### DIFF
--- a/src/__tests__/renderer/components/Toast.test.tsx
+++ b/src/__tests__/renderer/components/Toast.test.tsx
@@ -371,6 +371,43 @@ describe('Toast', () => {
 			render(<ToastContainer theme={mockTheme} />);
 			expect(document.body.querySelector('.h-1.rounded-b-lg')).not.toBeInTheDocument();
 		});
+
+		// Regression: these guards used to read `toast.duration && toast.duration > 0`.
+		// With a duration of 0 the leading truthiness check evaluates to the NUMBER
+		// 0 rather than a boolean, and React renders a bare `0` text node where the
+		// element should have been. The "never auto-dismiss" setting makes
+		// `duration` 0 without setting `dismissible`, so the combination is
+		// reachable. Asserting on whole-element text would not catch it (the stray
+		// node sits among real content, and the arrival timestamp legitimately
+		// contains digits), so look for a text node that is literally "0".
+		const strayZeroCount = (): number => {
+			const root = document.body.querySelector('.fixed.bottom-0.right-4');
+			if (!root) return 0;
+			const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+			let count = 0;
+			while (walker.nextNode()) {
+				if (walker.currentNode.textContent?.trim() === '0') count++;
+			}
+			return count;
+		};
+
+		it('renders no stray zero when duration is 0 and the toast is not dismissible', () => {
+			setStoreToasts([createMockToast({ duration: 0, dismissible: false })]);
+
+			render(<ToastContainer theme={mockTheme} />);
+			expect(document.body.querySelector('.h-1.rounded-b-lg')).not.toBeInTheDocument();
+			expect(strayZeroCount()).toBe(0);
+		});
+
+		// Same shape on the duration badge: a task that rounds to 0ms printed a
+		// bare "0" instead of rendering nothing.
+		it('renders no stray zero when taskDuration is 0', () => {
+			setStoreToasts([createMockToast({ taskDuration: 0, duration: 5000 })]);
+
+			render(<ToastContainer theme={mockTheme} />);
+			expect(screen.queryByText(/Completed in/)).not.toBeInTheDocument();
+			expect(strayZeroCount()).toBe(0);
+		});
 	});
 
 	describe('action URL link', () => {

--- a/src/renderer/components/Toast.tsx
+++ b/src/renderer/components/Toast.tsx
@@ -308,7 +308,7 @@ const ToastItem = memo(function ToastItem({
 					)}
 
 					{/* Duration badge */}
-					{toast.taskDuration && toast.taskDuration > 0 && (
+					{typeof toast.taskDuration === 'number' && toast.taskDuration > 0 && (
 						<div
 							className="flex items-center gap-1 text-xs mt-2"
 							style={{ color: theme.colors.textDim }}
@@ -366,7 +366,7 @@ const ToastItem = memo(function ToastItem({
 			</div>
 
 			{/* Progress bar - hidden for dismissible (sticky) toasts */}
-			{!toast.dismissible && toast.duration && toast.duration > 0 && (
+			{!toast.dismissible && typeof toast.duration === 'number' && toast.duration > 0 && (
 				<div
 					className="absolute bottom-0 left-0 h-1 rounded-b-lg transition-all ease-linear"
 					style={{


### PR DESCRIPTION
Follow-up to #1397 (merged). Its author spotted this while testing and deliberately left it out of that diff to keep it to one concern:

> `Toast.tsx:369` reads `{!toast.dismissible && toast.duration && toast.duration > 0 && (`. When `duration` is `0` and `dismissible` is falsy, the expression evaluates to the number `0`, and React renders a stray `0` under the toast body.

## The bug

Both guards lead with a truthiness check on a number:

```tsx
{toast.taskDuration && toast.taskDuration > 0 && (          // duration badge
{!toast.dismissible && toast.duration && toast.duration > 0 && (   // progress bar
```

When the value is `0`, `&&` short-circuits and yields the number `0` rather than a boolean, and React renders a bare `0` text node where the element should have been.

The progress-bar case is reachable from the UI: the "never auto-dismiss" setting makes `durationMs` `0` without setting `dismissible`. The `taskDuration` badge has the same shape.

## The fix

Narrow with `typeof x === 'number'` instead. That keeps the expression boolean and still narrows away `undefined` for `formatDuration`'s non-optional argument (plain `(x ?? 0) > 0` type-checks the guard but not the call site).

## Testing

Two regression tests in `Toast.test.tsx`, both verified to fail against the old guards (`expected 1 to be +0`).

They assert on **text nodes that are literally `"0"`** rather than on whole-element text. Whole-element text would not catch it: the stray node sits among real content, and the arrival timestamp #1397 just added legitimately contains digits (`10:19 AM`).

```
npx vitest run src/__tests__/renderer/components/Toast.test.tsx   40 passed
npx tsc -p tsconfig.json --noEmit                                 clean
npx eslint / prettier --check                                     clean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed toast notifications displaying stray “0” text when duration or task duration is zero.
  - Prevented progress bars and duration badges from appearing for zero or invalid duration values.

- **Tests**
  - Added regression coverage to verify correct toast rendering across zero-duration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->