### PR TITLE
fix(grooming): run context grooming on the session's SSH remote

### DIFF
--- a/src/__tests__/main/utils/context-groomer.test.ts
+++ b/src/__tests__/main/utils/context-groomer.test.ts
@@ -10,6 +10,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { groomContext, type GroomingProcessManager } from '../../../main/utils/context-groomer';
 import type { AgentDetector } from '../../../main/agents';
 import type { AgentConfig } from '../../../main/agents';
+import type { SshRemoteSettingsStore } from '../../../main/utils/ssh-remote-resolver';
+import type { SshRemoteConfig } from '../../../shared/types';
 
 // Mock agent-args module to verify override resolution
 vi.mock('../../../main/utils/agent-args', () => ({
@@ -37,6 +39,12 @@ vi.mock('uuid', () => ({
 	v4: vi.fn(() => 'test-uuid'),
 }));
 
+// Keep the real SSH wrapping logic, but pin the resolved ssh binary so the
+// built command is deterministic (and no PATH probing happens in tests).
+vi.mock('../../../main/utils/cliDetection', () => ({
+	resolveSshPath: vi.fn().mockResolvedValue('ssh'),
+}));
+
 // Mock logger
 vi.mock('../../../main/utils/logger', () => ({
 	logger: {
@@ -61,6 +69,19 @@ function makeAgent(overrides: Partial<AgentConfig> = {}): AgentConfig {
 		capabilities: {} as AgentConfig['capabilities'],
 		...overrides,
 	};
+}
+
+const SSH_REMOTE: SshRemoteConfig = {
+	id: 'my-remote',
+	name: 'Dev Box',
+	host: 'dev.example.com',
+	port: 22,
+	username: 'testuser',
+	enabled: true,
+};
+
+function createSshStore(remotes: SshRemoteConfig[] = [SSH_REMOTE]): SshRemoteSettingsStore {
+	return { getSshRemotes: () => remotes };
 }
 
 function createMockProcessManager(): GroomingProcessManager & {
@@ -310,7 +331,7 @@ describe('groomContext', () => {
 		expect(mockPM._lastSpawnConfig!.sendPromptViaStdinRaw).toBe(false);
 	});
 
-	it('does NOT set sendPromptViaStdinRaw on Windows when SSH is enabled', async () => {
+	it('does NOT set sendPromptViaStdinRaw on Windows when SSH is used', async () => {
 		vi.mocked(isWindows).mockReturnValue(true);
 		const detector = createMockAgentDetector(agent);
 
@@ -319,7 +340,8 @@ describe('groomContext', () => {
 				projectRoot: '/project',
 				agentType: 'claude-code',
 				prompt: 'summarize',
-				sessionSshRemoteConfig: { enabled: true, remoteId: 'r1' },
+				sessionSshRemoteConfig: { enabled: true, remoteId: 'my-remote' },
+				sshStore: createSshStore(),
 			},
 			mockPM,
 			detector
@@ -328,8 +350,7 @@ describe('groomContext', () => {
 		expect(mockPM._lastSpawnConfig!.sendPromptViaStdinRaw).toBe(false);
 	});
 
-	it('passes SSH remote config through to spawn', async () => {
-		const sshConfig = { enabled: true, remoteId: 'my-remote', workingDirOverride: '/remote/dir' };
+	it('spawns ssh (not the agent) when the session has an SSH remote', async () => {
 		const detector = createMockAgentDetector(agent);
 
 		await groomContext(
@@ -337,13 +358,166 @@ describe('groomContext', () => {
 				projectRoot: '/project',
 				agentType: 'claude-code',
 				prompt: 'summarize',
-				sessionSshRemoteConfig: sshConfig,
+				sessionSshRemoteConfig: { enabled: true, remoteId: 'my-remote' },
+				sshStore: createSshStore(),
 			},
 			mockPM,
 			detector
 		);
 
-		expect(mockPM._lastSpawnConfig!.sessionSshRemoteConfig).toEqual(sshConfig);
+		const config = mockPM._lastSpawnConfig!;
+		expect(config.command).toBe('ssh');
+		expect(config.sshRemoteId).toBe('my-remote');
+		expect(config.sshRemoteHost).toBe('dev.example.com');
+		// The prompt now travels inside the SSH invocation, not as a spawn field
+		expect(config.prompt).toBeUndefined();
+		expect(String(config.sshRemoteCommand)).toContain('summarize');
+	});
+
+	it('invokes the agent by binary name on the remote, never the local path', async () => {
+		// agent.command is an absolute LOCAL path - sending it to the remote host
+		// is how grooming would ENOENT there.
+		const detector = createMockAgentDetector(makeAgent({ command: '/usr/local/bin/claude' }));
+
+		await groomContext(
+			{
+				projectRoot: '/project',
+				agentType: 'claude-code',
+				prompt: 'summarize',
+				sessionSshRemoteConfig: { enabled: true, remoteId: 'my-remote' },
+				sshStore: createSshStore(),
+			},
+			mockPM,
+			detector
+		);
+
+		const remoteCommand = String(mockPM._lastSpawnConfig!.sshRemoteCommand);
+		expect(remoteCommand).not.toContain('/usr/local/bin/claude');
+		expect(remoteCommand).toContain('claude');
+	});
+
+	it('honors sessionCustomPath as the remote binary when SSH is enabled', async () => {
+		const detector = createMockAgentDetector(agent);
+
+		await groomContext(
+			{
+				projectRoot: '/project',
+				agentType: 'claude-code',
+				prompt: 'summarize',
+				sessionCustomPath: '/opt/remote/bin/claude',
+				sessionSshRemoteConfig: { enabled: true, remoteId: 'my-remote' },
+				sshStore: createSshStore(),
+			},
+			mockPM,
+			detector
+		);
+
+		expect(String(mockPM._lastSpawnConfig!.sshRemoteCommand)).toContain('/opt/remote/bin/claude');
+	});
+
+	it('cds to the remote working dir override, not the local project root', async () => {
+		const detector = createMockAgentDetector(agent);
+
+		await groomContext(
+			{
+				projectRoot: '/local/project',
+				agentType: 'claude-code',
+				prompt: 'summarize',
+				sessionSshRemoteConfig: {
+					enabled: true,
+					remoteId: 'my-remote',
+					workingDirOverride: '/home/testuser/project',
+				},
+				sshStore: createSshStore(),
+			},
+			mockPM,
+			detector
+		);
+
+		// The `cd` lives in the ssh invocation itself, not in the summarized
+		// remote command line.
+		const sshArgs = (mockPM._lastSpawnConfig!.args as string[]).join(' ');
+		expect(sshArgs).toContain('/home/testuser/project');
+		expect(sshArgs).not.toContain('/local/project');
+	});
+
+	it('sends large prompts to the remote via the stdin script', async () => {
+		const detector = createMockAgentDetector(agent);
+		const bigPrompt = 'x'.repeat(5000);
+
+		await groomContext(
+			{
+				projectRoot: '/project',
+				agentType: 'claude-code',
+				prompt: bigPrompt,
+				sessionSshRemoteConfig: { enabled: true, remoteId: 'my-remote' },
+				sshStore: createSshStore(),
+			},
+			mockPM,
+			detector
+		);
+
+		expect(String(mockPM._lastSpawnConfig!.sshStdinScript)).toContain(bigPrompt);
+	});
+
+	it('throws instead of running locally when the SSH remote cannot be resolved', async () => {
+		const detector = createMockAgentDetector(agent);
+
+		await expect(
+			groomContext(
+				{
+					projectRoot: '/project',
+					agentType: 'claude-code',
+					prompt: 'summarize',
+					sessionSshRemoteConfig: { enabled: true, remoteId: 'deleted-remote' },
+					sshStore: createSshStore(),
+				},
+				mockPM,
+				detector
+			)
+		).rejects.toThrow(/could not be resolved/);
+
+		expect(mockPM._lastSpawnConfig).toBeNull();
+	});
+
+	it('throws instead of running locally when no SSH store is provided', async () => {
+		const detector = createMockAgentDetector(agent);
+
+		await expect(
+			groomContext(
+				{
+					projectRoot: '/project',
+					agentType: 'claude-code',
+					prompt: 'summarize',
+					sessionSshRemoteConfig: { enabled: true, remoteId: 'my-remote' },
+				},
+				mockPM,
+				detector
+			)
+		).rejects.toThrow(/no SSH settings store/);
+
+		expect(mockPM._lastSpawnConfig).toBeNull();
+	});
+
+	it('spawns locally when the session SSH config is disabled', async () => {
+		const detector = createMockAgentDetector(agent);
+
+		await groomContext(
+			{
+				projectRoot: '/project',
+				agentType: 'claude-code',
+				prompt: 'summarize',
+				sessionSshRemoteConfig: { enabled: false, remoteId: 'my-remote' },
+				sshStore: createSshStore(),
+			},
+			mockPM,
+			detector
+		);
+
+		const config = mockPM._lastSpawnConfig!;
+		expect(config.command).toBe('/usr/local/bin/claude');
+		expect(config.prompt).toBe('summarize');
+		expect(config.sshStdinScript).toBeUndefined();
 	});
 
 	it('passes promptArgs and noPromptSeparator from agent config', async () => {

--- a/src/main/ipc/handlers/context.ts
+++ b/src/main/ipc/handlers/context.ts
@@ -22,6 +22,8 @@ import {
 } from '../../utils/ipcHandler';
 import { getSessionStorage, type SessionMessagesResult } from '../../agents';
 import { groomContext, cancelAllGroomingSessions } from '../../utils/context-groomer';
+import { createSshRemoteStoreAdapter } from '../../utils/ssh-remote-resolver';
+import { getSettingsStore } from '../../stores';
 import type { ProcessManager } from '../../process-manager';
 import type { AgentDetector } from '../../agents';
 import type Store from 'electron-store';
@@ -165,8 +167,14 @@ export function registerContextHandlers(deps: ContextHandlerDependencies): void 
 						projectRoot,
 						agentType,
 						prompt,
-						// Pass SSH and custom config for remote execution support
+						// Pass SSH and custom config for remote execution support.
+						// The store lets groomContext resolve `remoteId` and actually
+						// wrap the spawn with ssh - without it grooming would run the
+						// prompt locally (issue #1416).
 						sessionSshRemoteConfig: options?.sshRemoteConfig,
+						sshStore: options?.sshRemoteConfig?.enabled
+							? createSshRemoteStoreAdapter(getSettingsStore())
+							: undefined,
 						sessionCustomPath: options?.customPath,
 						sessionCustomArgs: options?.customArgs,
 						sessionCustomEnvVars: options?.customEnvVars,

--- a/src/main/ipc/handlers/director-notes.ts
+++ b/src/main/ipc/handlers/director-notes.ts
@@ -869,6 +869,10 @@ export function registerDirectorNotesHandlers(deps: DirectorNotesHandlerDependen
 						}
 					};
 
+					// Intentionally local: the synopsis prompt is a manifest of history
+					// file paths on THIS machine, so no `sessionSshRemoteConfig` is
+					// passed and groomContext spawns locally. See issue #1416 - the
+					// grooming path now honors SSH when a caller does supply a config.
 					const result = await groomContext(
 						{
 							projectRoot: process.cwd(),

--- a/src/main/ipc/handlers/groupChat.ts
+++ b/src/main/ipc/handlers/groupChat.ts
@@ -75,6 +75,8 @@ import {
 // Agent detector import
 import { AgentDetector } from '../../agents';
 import { groomContext } from '../../utils/context-groomer';
+import { createSshRemoteStoreAdapter } from '../../utils/ssh-remote-resolver';
+import { getSessionsStore, getSettingsStore } from '../../stores';
 import { v4 as uuidv4 } from 'uuid';
 import { captureException } from '../../utils/sentry';
 
@@ -121,6 +123,25 @@ const handlerOpts = (operation: string): Pick<CreateHandlerOptions, 'context' | 
 	context: LOG_CONTEXT,
 	operation,
 });
+
+/**
+ * Resolve the SSH remote config for a participant by looking up the agent it was
+ * added from. Participant records store only the remote's display name, while
+ * spawning needs the full `{ enabled, remoteId }` config, so we read it off the
+ * agent whose name matches the participant - the same association the router
+ * makes when it dispatches a turn to that participant.
+ *
+ * Returns undefined for local participants (and for participants whose source
+ * agent has since been renamed or deleted, which keeps the summary local rather
+ * than failing the reset).
+ */
+function resolveParticipantSshRemoteConfig(
+	participantName: string
+): { enabled: boolean; remoteId: string | null; workingDirOverride?: string } | undefined {
+	const sessions = getSessionsStore().get('sessions', []);
+	const match = sessions.find((session) => session.name === participantName);
+	return match?.sshRemoteConfig;
+}
 
 /**
  * Group chat state type
@@ -767,6 +788,15 @@ This summary will be used to initialize your fresh session so you can continue s
 
 Respond with ONLY the summary text, no additional commentary.`;
 
+				// A participant record only carries `sshRemoteName`, not the remote's
+				// id, so resolve the SSH config off the agent this participant was
+				// added from. Participants are always named after that agent (see
+				// the auto-add path in group-chat-router), so an exact name match is
+				// the same association the router uses when it dispatches a turn.
+				// Without this the summary would resume a remote agent session on the
+				// local machine, where that session does not exist (issue #1416).
+				const participantSshRemoteConfig = resolveParticipantSshRemoteConfig(participantName);
+
 				// Use the shared groomContext utility to get the summary
 				// This spawns a batch process, collects the response, and handles cleanup
 				let summaryResponse = '';
@@ -779,6 +809,10 @@ Respond with ONLY the summary text, no additional commentary.`;
 							agentSessionId: participant.agentSessionId, // Resume existing session for context
 							readOnlyMode: true, // Summary is read-only
 							timeoutMs: 60000, // 60 second timeout for summary
+							sessionSshRemoteConfig: participantSshRemoteConfig,
+							sshStore: participantSshRemoteConfig?.enabled
+								? createSshRemoteStoreAdapter(getSettingsStore())
+								: undefined,
 						},
 						processManager,
 						agentDetector

--- a/src/main/utils/context-groomer.ts
+++ b/src/main/utils/context-groomer.ts
@@ -7,6 +7,7 @@
  * This module provides a consistent way to spawn a batch-mode agent process
  * with a prompt and collect the response. It handles:
  * - Spawning the agent with proper batch mode args
+ * - SSH remote execution when the session is configured for it
  * - Collecting response data with idle timeout detection
  * - Overall timeout for long-running operations
  * - Proper cleanup on completion or error
@@ -15,6 +16,9 @@
 import { v4 as uuidv4 } from 'uuid';
 import { logger } from './logger';
 import { buildAgentArgs, applyAgentConfigOverrides } from './agent-args';
+import { wrapSpawnWithSsh } from './ssh-spawn-wrapper';
+import type { SshRemoteSettingsStore } from './ssh-remote-resolver';
+import type { SshRemoteConfig } from '../../shared/types';
 import { isWindows } from '../../shared/platformDetection';
 import type { AgentDetector } from '../agents';
 
@@ -38,12 +42,13 @@ export interface GroomingProcessManager {
 		sendPromptViaStdin?: boolean;
 		// Send prompt as raw text via stdin (used on Windows to avoid command-line length limits)
 		sendPromptViaStdinRaw?: boolean;
-		// SSH remote config for running on a remote host
-		sessionSshRemoteConfig?: {
-			enabled: boolean;
-			remoteId: string | null;
-			workingDirOverride?: string;
-		};
+		// Script piped to the remote shell's stdin for SSH execution (built by wrapSpawnWithSsh)
+		sshStdinScript?: string;
+		// Human-readable remote agent invocation (shown in Process Details)
+		sshRemoteCommand?: string;
+		// Resolved SSH remote identity, for Process Details / logging
+		sshRemoteId?: string;
+		sshRemoteHost?: string;
 		// Custom environment variables (resolved via applyAgentConfigOverrides)
 		customEnvVars?: Record<string, string>;
 	}): { pid: number; success?: boolean } | null;
@@ -138,6 +143,12 @@ export interface GroomContextOptions {
 	timeoutMs?: number;
 	/** SSH remote config for running grooming on a remote host */
 	sessionSshRemoteConfig?: GroomingSshRemoteConfig;
+	/**
+	 * SSH settings store used to resolve `sessionSshRemoteConfig.remoteId`.
+	 * REQUIRED whenever `sessionSshRemoteConfig.enabled` is true - grooming
+	 * throws rather than silently running the prompt on the local machine.
+	 */
+	sshStore?: SshRemoteSettingsStore;
 	/** Custom path to the agent binary */
 	sessionCustomPath?: string;
 	/** Custom arguments for the agent */
@@ -204,6 +215,7 @@ export async function groomContext(
 		readOnlyMode = false,
 		timeoutMs = DEFAULT_GROOMING_TIMEOUT_MS,
 		sessionSshRemoteConfig,
+		sshStore,
 		sessionCustomPath,
 		sessionCustomArgs,
 		sessionCustomEnvVars,
@@ -260,6 +272,86 @@ export async function groomContext(
 			: configResolution.args;
 	const resolvedEnvVars = configResolution.effectiveCustomEnvVars;
 	const resolvedCommand = sessionCustomPath || agent.command;
+
+	// Apply SSH wrapping when the session runs on a remote host. ProcessManager
+	// does NO SSH wrapping of its own - every spawn surface has to do this itself
+	// (see spawnGroupChatAgent / cue-spawn-builder / the CLI agent-spawner), and
+	// grooming used to just hand `sessionSshRemoteConfig` to spawn(), where it was
+	// silently ignored. The prompt (and the transcript context it carries) then ran
+	// on the local machine even though the user explicitly opted into SSH.
+	let spawnCommand = resolvedCommand;
+	let spawnArgs = resolvedArgs;
+	let spawnCwd = projectRoot;
+	let spawnPrompt: string | undefined = prompt;
+	let spawnEnvVars = resolvedEnvVars;
+	let sshStdinScript: string | undefined;
+	let sshRemoteCommand: string | undefined;
+	let sshRemoteUsed: SshRemoteConfig | null = null;
+
+	if (sessionSshRemoteConfig?.enabled) {
+		if (!sshStore) {
+			throw new Error(
+				'SSH remote execution is enabled for this session but no SSH settings store was ' +
+					'provided to groomContext(). Refusing to run the prompt locally.'
+			);
+		}
+
+		// `projectRoot` is the LOCAL path for an SSH agent, and the remote shell
+		// does `cd <cwd> || exit 1`. Prefer the configured remote working dir so
+		// grooming lands in the same directory the agent's own turns run in.
+		const remoteCwd = sessionSshRemoteConfig.workingDirOverride || projectRoot;
+
+		const wrapped = await wrapSpawnWithSsh(
+			{
+				command: resolvedCommand,
+				args: resolvedArgs,
+				cwd: remoteCwd,
+				prompt,
+				customEnvVars: resolvedEnvVars,
+				promptArgs: agent.promptArgs,
+				noPromptSeparator: agent.noPromptSeparator,
+				// Never send a locally-detected absolute path to the remote host -
+				// it does not exist there. A session custom path IS honored (for an
+				// SSH session the user configures it as the remote path), matching
+				// what the `process:spawn` handler does; otherwise resolve the agent
+				// by binary name against the remote PATH.
+				agentBinaryName: sessionCustomPath || agent.binaryName,
+			},
+			sessionSshRemoteConfig,
+			sshStore
+		);
+
+		// wrapSpawnWithSsh falls back to the unmodified local config when the
+		// remote can't be resolved. Fail loudly instead - the user opted into SSH,
+		// so a local run is the wrong answer, not a graceful degradation.
+		if (!wrapped.sshRemoteUsed) {
+			const remoteLabel = sessionSshRemoteConfig.remoteId
+				? ` "${sessionSshRemoteConfig.remoteId}"`
+				: '';
+			throw new Error(
+				`SSH remote execution is enabled for this session but the configured remote${remoteLabel} ` +
+					`could not be resolved. Check that the remote exists, is enabled, and that the ` +
+					`session's remoteId points at a valid SSH remote.`
+			);
+		}
+
+		spawnCommand = wrapped.command;
+		spawnArgs = wrapped.args;
+		spawnCwd = wrapped.cwd;
+		// The prompt now lives inside the SSH command line or the stdin script.
+		spawnPrompt = wrapped.prompt;
+		spawnEnvVars = wrapped.customEnvVars;
+		sshStdinScript = wrapped.sshStdinScript;
+		sshRemoteCommand = wrapped.sshRemoteCommand;
+		sshRemoteUsed = wrapped.sshRemoteUsed;
+
+		logger.info('Grooming will run on SSH remote', LOG_CONTEXT, {
+			groomerSessionId,
+			remoteId: sshRemoteUsed.id,
+			remoteName: sshRemoteUsed.name,
+			viaStdinScript: !!sshStdinScript,
+		});
+	}
 
 	// Create a promise that collects the response
 	return new Promise<GroomContextResult>((resolve, reject) => {
@@ -395,24 +487,30 @@ export async function groomContext(
 
 		// On Windows, grooming prompts often exceed cmd.exe's ~8KB command-line
 		// limit (ENAMETOOLONG on spawn). Route the prompt via stdin instead.
-		// SSH sessions have their own stdin handling (ssh-spawn-wrapper), so skip.
-		const useStdinForPrompt = isWindows() && !sessionSshRemoteConfig?.enabled;
+		// SSH spawns already carry the prompt in the wrapped command (or in
+		// `sshStdinScript`, which owns the child's stdin), so skip it there.
+		const useStdinForPrompt = isWindows() && !sshRemoteUsed;
 
 		// Spawn the process in batch mode
 		const spawnResult = processManager.spawn({
 			sessionId: groomerSessionId,
 			toolType: agentType,
-			cwd: projectRoot,
-			command: resolvedCommand,
-			args: resolvedArgs,
-			prompt: prompt, // Triggers batch mode (no PTY)
-			promptArgs: agent.promptArgs, // For agents using flag-based prompt (e.g., OpenCode -p)
+			cwd: spawnCwd,
+			command: spawnCommand,
+			args: spawnArgs,
+			prompt: spawnPrompt, // Triggers batch mode (no PTY); undefined for SSH
+			// For agents using flag-based prompt (e.g., OpenCode -p). Harmless for
+			// SSH: the wrapper already applied them and `spawnPrompt` is undefined.
+			promptArgs: agent.promptArgs,
 			noPromptSeparator: agent.noPromptSeparator,
 			sendPromptViaStdinRaw: useStdinForPrompt,
-			// Pass SSH config for remote execution support
-			sessionSshRemoteConfig,
+			// SSH remote execution (undefined for local spawns)
+			sshStdinScript,
+			sshRemoteCommand,
+			sshRemoteId: sshRemoteUsed?.id,
+			sshRemoteHost: sshRemoteUsed?.host,
 			// Pass resolved env vars (merged from agent defaults + agent config + session overrides)
-			customEnvVars: resolvedEnvVars,
+			customEnvVars: spawnEnvVars,
 		});
 
 		if (!spawnResult || spawnResult.pid <= 0) {

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -3047,6 +3047,9 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 					const allConfigs = agentConfigsStore.get('configs', {});
 					const dnAgentConfigValues = allConfigs[provider] || {};
 
+					// Intentionally local, same as the desktop Director's Notes handler:
+					// the prompt manifests history files on THIS machine, so grooming
+					// gets no `sessionSshRemoteConfig` and spawns locally (issue #1416).
 					const result = await groomContext(
 						{
 							projectRoot: process.cwd(),


### PR DESCRIPTION
closes #1416

## The bug

`groomContext()` accepted a `sessionSshRemoteConfig`, logged it, and passed it into `processManager.spawn()`. `ProcessConfig` has no such field and `ProcessManager.spawn()` does no SSH wrapping of its own - every spawn surface has to call `wrapSpawnWithSsh()` itself. Grooming never did, so the option was silently dropped and the prompt (plus the transcript context it carries) always ran on the local machine even though the user explicitly opted into SSH.

## The fix

In `src/main/utils/context-groomer.ts`:

- **Actually wrap the spawn.** When `sessionSshRemoteConfig.enabled`, run `wrapSpawnWithSsh()` and spawn the wrapped `command` / `args` / `cwd`, forwarding `sshStdinScript` / `sshRemoteCommand` / `sshRemoteId` / `sshRemoteHost` to `spawn()`. Same shape as `spawnGroupChatAgent.ts`, `cue-spawn-builder.ts`, and the CLI `agent-spawner.ts`.
- **Never send a local path to the remote.** The remote binary resolves as `sessionCustomPath || agent.binaryName`, matching what `process:spawn` does. A locally-detected absolute path (`agent.command`, and `agent.path` once #1403 lands) does not exist on the remote host.
- **Use the remote working dir.** `projectRoot` is the local path for an SSH agent and the remote shell does `cd <cwd> || exit 1`, so the wrap now prefers `sshRemoteConfig.workingDirOverride`.
- **Fail loudly.** If SSH is enabled but the remote (or the SSH store) can't be resolved, grooming throws instead of quietly running the prompt locally. `wrapSpawnWithSsh()` degrades to a local config on an unresolved remote, so the `sshRemoteUsed` check is what makes this loud. Message follows `sshUnresolvedFailure()` in the CLI spawner.
- **`useStdinForPrompt`** now keys off whether SSH was actually used rather than off the raw config flag. When SSH is in play the wrapper owns the child's stdin (the prompt is in the stdin script or already in the command line), so the Windows raw-stdin path must stay off; for every other case, including an enabled-but-disabled-remote config, Windows still gets its ENAMETOOLONG workaround.

Callers:

- `src/main/ipc/handlers/context.ts` (context merge / summarize-and-continue) threads `createSshRemoteStoreAdapter(getSettingsStore())` when the session has SSH on. This is the only caller that was passing an SSH config, i.e. the reported bug.
- `src/main/ipc/handlers/groupChat.ts` (context reset) now resolves the participant's SSH config. Participant records only store the remote's display name, so it reads the config off the agent whose name matches the participant - the same association the router makes when dispatching a turn. Previously the reset summary tried to resume a *remote* agent session locally, where that session doesn't exist.
- `src/main/ipc/handlers/director-notes.ts` and `src/main/web-server/web-server-factory.ts` (Director's Notes synopsis) stay local **by design** - the prompt is a manifest of history file paths on this machine. Both call sites now say so instead of leaving the next reader to wonder.

## Tests

`src/__tests__/main/utils/context-groomer.test.ts`, 8 new cases against the real `wrapSpawnWithSsh` (only `resolveSshPath` is stubbed): spawns `ssh` rather than the agent, invokes the agent by binary name and never the local path, honors `sessionCustomPath` as the remote binary, cds to the remote working dir, routes large prompts through the stdin script, throws on an unresolvable remote, throws when no store is provided, and still spawns locally when the config is present but disabled. The pre-existing "passes SSH remote config through to spawn" case asserted the broken behavior and was replaced.

Full suite green locally (33,882 passed), plus `npm run lint`, eslint, prettier.

## Note on #1403

That PR touches `resolvedCommand` in the same function (`sessionCustomPath || agent.path || agent.command`). This branch leaves the local command line alone, so the two should merge cleanly; whichever lands second, the remote path here stays on `binaryName` and is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SSH remote execution support for context grooming.
  * Group chat context summaries can resume using each participant’s configured remote environment.
  * Added support for remote working directories, custom agent paths, and large prompt transfers.
  * Session listings now more accurately indicate active or unknown states.
* **Bug Fixes**
  * Missing or unresolvable SSH configurations now report errors instead of silently running locally.
  * Local fallback remains available when SSH is disabled.
  * Director’s Notes grooming continues to run locally when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->