### PR TITLE
feat(git): name the agent in the pull/push modal header

### DIFF
--- a/docs/agent-guides/UI-PATTERNS.md
+++ b/docs/agent-guides/UI-PATTERNS.md
@@ -187,7 +187,7 @@ The expanded Prompt Composer (`src/renderer/components/PromptComposerModal.tsx`)
 
 A modal opened from a **right-click menu** frequently acts on something other than the highlighted agent. `git push` as a header names the operation but not the target, so a user who right-clicked an arbitrary Left Bar row has no way to tell which agent is about to push.
 
-Pass `<Modal subtitle={...}>` for the subject: which agent, which repo, which file. It renders dimmed after the title (`git push - Sonoma-Fix`) and is skipped entirely when empty, so a modal with nothing to name looks exactly as it did before. `GitCommandRunnerModal.tsx` is the reference use.
+Pass `<Modal subtitle={...}>` for the subject: which agent, which repo, which file. It renders dimmed after the title (`git push · Sonoma-Fix`) and is skipped entirely when empty, so a modal with nothing to name looks exactly as it did before. `GitCommandRunnerModal.tsx` is the reference use.
 
 **Do not concatenate the subject into `title`.** `title` is the `aria-label` and the modal-layer label, and it seeds the fallback resize key via `getDefaultResizeKey()` - a per-agent title mints a different persisted window size for every agent, so the modal would forget its size each time you targeted a different one. That is also why any test asserting on the bare title keeps passing after a `subtitle` is added.
 

--- a/docs/agent-guides/UI-PATTERNS.md
+++ b/docs/agent-guides/UI-PATTERNS.md
@@ -183,6 +183,16 @@ Guidance:
 
 The expanded Prompt Composer (`src/renderer/components/PromptComposerModal.tsx`) is the reference implementation of the compact-vs-`90vw x 90vh` toggle.
 
+### Naming the Subject in a Modal Header (`subtitle`)
+
+A modal opened from a **right-click menu** frequently acts on something other than the highlighted agent. `git push` as a header names the operation but not the target, so a user who right-clicked an arbitrary Left Bar row has no way to tell which agent is about to push.
+
+Pass `<Modal subtitle={...}>` for the subject: which agent, which repo, which file. It renders dimmed after the title (`git push - Sonoma-Fix`) and is skipped entirely when empty, so a modal with nothing to name looks exactly as it did before. `GitCommandRunnerModal.tsx` is the reference use.
+
+**Do not concatenate the subject into `title`.** `title` is the `aria-label` and the modal-layer label, and it seeds the fallback resize key via `getDefaultResizeKey()` - a per-agent title mints a different persisted window size for every agent, so the modal would forget its size each time you targeted a different one. That is also why any test asserting on the bare title keeps passing after a `subtitle` is added.
+
+Most openers already carry what they need: `useGitAgentActions.ts` has been putting `sessionId` in the `gitCommandRunner` payload since it was written, the modal just ignored it. Check the payload before plumbing a new prop.
+
 ### Resizable Modals
 
 Dialog-style modals can offer persisted, center-anchored drag-to-resize via `useResizableModal()` (`src/renderer/hooks/ui/useResizableModal.ts`), backed by pure sizing/clamping helpers in `src/renderer/utils/modalSizing.ts` and the handle UI in `src/renderer/components/ui/ResizeHandles.tsx`. Sizes persist in the `modalSizes` setting (`src/renderer/stores/settingsStore.ts`: `setModalSize`/`resetModalSize`/`resetModalSizes`), clamped to a `320x240` minimum and the `90vw x 90vh` app-wide ceiling described above, with per-modal `minSize`/`maxSize` overrides for dense tools or width-capped reading surfaces (e.g. Director's Notes caps `maxSize.width` at `1050`).

--- a/src/__tests__/renderer/components/GitCommandRunnerModal.test.tsx
+++ b/src/__tests__/renderer/components/GitCommandRunnerModal.test.tsx
@@ -10,6 +10,8 @@ import { GitCommandRunnerModal } from '../../../renderer/components/GitCommandRu
 import { LayerStackProvider } from '../../../renderer/contexts/LayerStackContext';
 import { gitService } from '../../../renderer/services/git';
 import { mockTheme } from '../../helpers/mockTheme';
+import { createMockSession } from '../../helpers/mockSession';
+import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import type { GitCommandOutputChunk, GitRunCommandResult } from '../../../shared/gitUtils';
 
 vi.mock('../../../renderer/services/git', () => ({
@@ -73,6 +75,12 @@ describe('GitCommandRunnerModal', () => {
 				finishRun = resolve;
 			});
 		});
+
+		// The modal names the agent it is transferring for, so the store has to
+		// hold the agent the payload points at.
+		useSessionStore.setState({
+			sessions: [createMockSession({ id: 'session-1', name: 'Sonoma-Fix' })],
+		} as never);
 	});
 
 	it('starts the requested operation exactly once', async () => {
@@ -83,6 +91,34 @@ describe('GitCommandRunnerModal', () => {
 			expect.objectContaining({ operation: 'push', cwd: '/test/repo', setUpstream: false })
 		);
 		expect(screen.getByText('git push')).toBeInTheDocument();
+	});
+
+	// Pull/Push are reachable by right-clicking any Left Bar row, so the target
+	// is frequently not the highlighted agent. "git push" alone names nothing.
+	it('names the agent the command targets', async () => {
+		renderModal('push');
+
+		await waitFor(() => expect(gitService.runCommand).toHaveBeenCalled());
+		expect(screen.getByTestId('modal-subtitle')).toHaveTextContent('Sonoma-Fix');
+	});
+
+	it('keeps the command line as the title rather than folding the name into it', async () => {
+		// The title is the aria-label and seeds the fallback resize key, so a
+		// per-agent title would mint a per-agent persisted window size.
+		renderModal('push');
+
+		await waitFor(() => expect(gitService.runCommand).toHaveBeenCalled());
+		expect(screen.getByText('git push')).toBeInTheDocument();
+		expect(screen.queryByText('git push - Sonoma-Fix')).not.toBeInTheDocument();
+	});
+
+	it('renders no subtitle when the agent is gone', async () => {
+		useSessionStore.setState({ sessions: [] } as never);
+		renderModal('pull');
+
+		await waitFor(() => expect(gitService.runCommand).toHaveBeenCalled());
+		expect(screen.queryByTestId('modal-subtitle')).not.toBeInTheDocument();
+		expect(screen.getByText('git pull')).toBeInTheDocument();
 	});
 
 	it('renders streamed output as it arrives', async () => {

--- a/src/__tests__/renderer/components/GitCommandRunnerModal.test.tsx
+++ b/src/__tests__/renderer/components/GitCommandRunnerModal.test.tsx
@@ -109,7 +109,24 @@ describe('GitCommandRunnerModal', () => {
 
 		await waitFor(() => expect(gitService.runCommand).toHaveBeenCalled());
 		expect(screen.getByText('git push')).toBeInTheDocument();
-		expect(screen.queryByText('git push - Sonoma-Fix')).not.toBeInTheDocument();
+		expect(screen.queryByText(/git push . Sonoma-Fix/)).not.toBeInTheDocument();
+		// The concrete consequence of folding the name into the title: the
+		// persisted-size key is title-derived when no explicit key is passed, so
+		// a per-agent title would give every agent its own remembered size.
+		expect(document.querySelector('[data-modal-resize-key]')).toHaveAttribute(
+			'data-modal-resize-key',
+			'modal-git-command-runner'
+		);
+	});
+
+	// `subtitle={agent && agent.name}` yields `false` when the agent is missing,
+	// which must not paint a bare separator with nothing after it.
+	it('renders no separator for a falsy subtitle', async () => {
+		useSessionStore.setState({ sessions: [] } as never);
+		renderModal('pull');
+
+		await waitFor(() => expect(gitService.runCommand).toHaveBeenCalled());
+		expect(screen.queryByText(/·/)).not.toBeInTheDocument();
 	});
 
 	it('renders no subtitle when the agent is gone', async () => {

--- a/src/renderer/components/GitCommandRunnerModal.tsx
+++ b/src/renderer/components/GitCommandRunnerModal.tsx
@@ -18,6 +18,7 @@ import { generateId } from '../utils/ids';
 import { processCarriageReturns } from '../utils/textProcessing';
 import { stripAnsiCodes } from '../../shared/stringUtils';
 import { useGitDetail } from '../contexts/GitStatusContext';
+import { useSessionStore } from '../stores/sessionStore';
 import type { GitCommandRunnerData } from '../stores/modalStore';
 import type { GitStreamingOperation, GitRunCommandResult } from '../../shared/gitUtils';
 import type { Theme } from '../types';
@@ -46,8 +47,16 @@ function needsUpstream(output: string): boolean {
 }
 
 export function GitCommandRunnerModal({ theme, data, onClose }: GitCommandRunnerModalProps) {
-	const { operation, cwd, sshRemoteId, branch } = data;
+	const { sessionId, operation, cwd, sshRemoteId, branch } = data;
 	const { refreshGitStatus } = useGitDetail();
+
+	// Which agent this transfer belongs to. Pull/Push are reachable by
+	// right-clicking any row in the Left Bar, so the target is often NOT the
+	// highlighted agent and the command line alone ("git push") names nothing.
+	// Subscribe to the name only, never the Session: this modal is on screen
+	// while a command streams, and a whole-session subscription would re-render
+	// it on every unrelated token and log update.
+	const agentName = useSessionStore((s) => s.sessions.find((x) => x.id === sessionId)?.name);
 
 	const [output, setOutput] = useState('');
 	const [status, setStatus] = useState<RunStatus>('running');
@@ -143,6 +152,7 @@ export function GitCommandRunnerModal({ theme, data, onClose }: GitCommandRunner
 		<Modal
 			theme={theme}
 			title={commandLine}
+			subtitle={agentName}
 			priority={MODAL_PRIORITIES.GIT_COMMAND_RUNNER}
 			onClose={onClose}
 			width={700}

--- a/src/renderer/components/ui/Modal.tsx
+++ b/src/renderer/components/ui/Modal.tsx
@@ -91,6 +91,10 @@ export interface ModalProps {
 	 * right-click menu can target something other than the highlighted agent,
 	 * and without this the header gives the user no way to tell.
 	 *
+	 * Tested for truthiness rather than against `undefined`/`null`/`''`: the
+	 * idiomatic `subtitle={agent && agent.name}` yields `false`, which would
+	 * otherwise paint the separator with nothing after it.
+	 *
 	 * Deliberately separate from `title` rather than concatenated into it.
 	 * `title` is the `aria-label` and the modal-layer label, and it seeds the
 	 * fallback resize key (`getDefaultResizeKey`) - folding a per-agent string
@@ -387,16 +391,16 @@ export function Modal({
 								<h2 className="text-sm font-bold shrink-0" style={{ color: theme.colors.textMain }}>
 									{title}
 								</h2>
-								{subtitle !== undefined && subtitle !== null && subtitle !== '' && (
+								{subtitle ? (
 									<span
-										className="text-sm truncate"
+										className="text-sm truncate min-w-0"
 										style={{ color: theme.colors.textDim }}
 										data-testid="modal-subtitle"
 									>
 										<span aria-hidden="true">{'\u00b7'} </span>
 										{subtitle}
 									</span>
-								)}
+								) : null}
 							</div>
 							<div className="flex items-center gap-2">
 								{headerActions}

--- a/src/renderer/components/ui/Modal.tsx
+++ b/src/renderer/components/ui/Modal.tsx
@@ -85,6 +85,18 @@ export interface ModalProps {
 	theme: Theme;
 	/** Modal title displayed in the header */
 	title: string;
+	/**
+	 * Optional dimmed text rendered after the title, for the subject the modal
+	 * is acting on: which agent, which repo, which file. A modal opened from a
+	 * right-click menu can target something other than the highlighted agent,
+	 * and without this the header gives the user no way to tell.
+	 *
+	 * Deliberately separate from `title` rather than concatenated into it.
+	 * `title` is the `aria-label` and the modal-layer label, and it seeds the
+	 * fallback resize key (`getDefaultResizeKey`) - folding a per-agent string
+	 * into it would mint a different persisted window size for every agent.
+	 */
+	subtitle?: ReactNode;
 	/** Modal priority from MODAL_PRIORITIES constant */
 	priority: number;
 	/** Callback when modal should close (via X button, Escape, or backdrop click) */
@@ -193,6 +205,7 @@ export interface ModalProps {
 export function Modal({
 	theme,
 	title,
+	subtitle,
 	priority,
 	onClose,
 	children,
@@ -369,11 +382,21 @@ export function Modal({
 							onPointerDown={floating?.onMovePointerDown}
 							data-testid={isFloating ? 'modal-float-handle' : undefined}
 						>
-							<div className="flex items-center gap-2">
+							<div className="flex items-center gap-2 min-w-0">
 								{headerIcon}
-								<h2 className="text-sm font-bold" style={{ color: theme.colors.textMain }}>
+								<h2 className="text-sm font-bold shrink-0" style={{ color: theme.colors.textMain }}>
 									{title}
 								</h2>
+								{subtitle !== undefined && subtitle !== null && subtitle !== '' && (
+									<span
+										className="text-sm truncate"
+										style={{ color: theme.colors.textDim }}
+										data-testid="modal-subtitle"
+									>
+										<span aria-hidden="true">{'\u00b7'} </span>
+										{subtitle}
+									</span>
+								)}
 							</div>
 							<div className="flex items-center gap-2">
 								{headerActions}


### PR DESCRIPTION
## Problem

Pull and Push are reachable by right-clicking **any** row in the Left Bar (`useGitAgentActions` backs all three surfaces: the header branch pill, the Left Bar context menu, and the command palette). So the agent they target is frequently *not* the highlighted one.

The header read `git push` and named nothing:

```
BEFORE                          AFTER
+------------------------+      +--------------------------------+
| ⬆ git push         [x] |      | ⬆ git push · Sonoma-Fix    [x] |
+------------------------+      +--------------------------------+
```

If the target agent isn't already selected, there is no way to tell what you are about to push.

## Fix

New `subtitle` prop on the shared `<Modal>`, for the subject a modal acts on: which agent, which repo, which file. Rendered dimmed after the title, skipped entirely when empty, so every existing `<Modal>` caller looks exactly as it did.

**The name deliberately does not go into `title`.** `title` is the `aria-label` and the modal-layer label, and it seeds the fallback resize key via `getDefaultResizeKey()`. A per-agent title would mint a different persisted window size for each agent, so the modal would forget its size whenever you targeted a different one. (`GitCommandRunnerModal` passes an explicit `resizeKey`, so it dodges that specific consequence - but the trap is real for the follow-up modals listed below, and the aria-label/layer-label reasons apply regardless.)

**No prop plumbing needed.** `useGitAgentActions.ts:152` has been putting `sessionId` in the `gitCommandRunner` payload since it was written; the modal was destructuring around it (`operation, cwd, sshRemoteId, branch`).

**Perf:** the modal subscribes to `?.name` alone, not the `Session`. It stays on screen while a command streams, and a whole-session subscription would re-render the console on every unrelated token and log update.

## Testing

Three tests in `GitCommandRunnerModal.test.tsx`, plus the existing 8:

- the header names the target agent (verified to fail without the change)
- the title stays the bare command line, so both the pre-existing `getByText('git push')` assertion and the resize key survive
- a session that no longer exists renders no subtitle rather than crashing

```
vitest Modal.test.tsx + GitCommandRunnerModal.test.tsx   28 passed
tsc -p tsconfig.json --noEmit                            clean
eslint / prettier                                        clean
```

## Not in this PR

This is systemic - of ~15 modals reachable from the right-click menu, **one** (`EditAgentModal`) names its agent. The `subtitle` prop makes most of the rest one-line fixes (Branch Switcher, Rename, both delete confirms, Duplicate, Create Group), but that is a separate sweep.

Two of them need behaviour fixes rather than a header, and a subtitle would make them *more* misleading:

- **Configure Worktrees** - `useWorktreeHandlers.ts:189` calls `setActiveSessionId(session.id)` before opening, so right-clicking an arbitrary agent silently changes which agent is selected.
- **Configure Maestro Cue** - `useModalHandlers.ts:550` is `async (_session: Session) => {`. The session is discarded and a global dashboard opens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modal dialogs can now display contextual subtitles alongside their titles.
  * Git command dialogs show the targeted agent’s name as a subtitle while keeping the command as the main title.

* **Bug Fixes**
  * Long subtitles now fit more cleanly within the modal title area.
  * Empty subtitles no longer display unnecessary separators.

* **Documentation**
  * Added guidance for using modal subtitles to identify action subjects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->