### PR TITLE
feat(web-desktop): answer window-scoped reads for web clients

### DIFF
--- a/src/__tests__/main/ipc/handlers/windows.test.ts
+++ b/src/__tests__/main/ipc/handlers/windows.test.ts
@@ -86,6 +86,16 @@ function makeEvent(browserWindow: BrowserWindow | null) {
 	return { sender: { id: 1 } } as unknown as Electron.IpcMainInvokeEvent;
 }
 
+/** The synthetic event a web-desktop bridge invoke arrives on (FAKE_EVENT). */
+function makeBridgeEvent() {
+	return {
+		senderFrame: null,
+		frameId: -1,
+		processId: -1,
+		type: 'bridge',
+	} as unknown as Electron.IpcMainInvokeEvent;
+}
+
 describe('Windows IPC Handlers', () => {
 	let registry: WindowRegistry;
 	let handlers: Map<string, Function>;
@@ -358,18 +368,53 @@ describe('Windows IPC Handlers', () => {
 			expect(result).toBeNull();
 		});
 
-		it('returns null (not a throw) for a senderless bridge event', async () => {
+		it('returns null (not a throw) for a senderless bridge event with no primary', async () => {
 			// The web-desktop bridge dispatches invokes with a synthetic event that
-			// has no sender (FAKE_EVENT). getState must resolve to null so the web
-			// client's WindowContext hydrate degrades gracefully instead of the
-			// handler crashing on BrowserWindow.fromWebContents(undefined).
-			const bridgeEvent = {
-				senderFrame: null,
-				frameId: -1,
-				processId: -1,
-				type: 'bridge',
-			} as unknown as Electron.IpcMainInvokeEvent;
-			const result = await handlers.get('windows:getState')!(bridgeEvent);
+			// has no sender (FAKE_EVENT). With nothing registered there is no window
+			// to answer for, and the handler must still resolve rather than crash on
+			// BrowserWindow.fromWebContents(undefined).
+			const result = await handlers.get('windows:getState')!(makeBridgeEvent());
+			expect(result).toBeNull();
+		});
+
+		// A web-desktop client mirrors the primary window, so a READ answers for it.
+		// Before this, every window-scoped read returned "unknown caller" and the
+		// remote page booted with null window state.
+		it('answers a bridge read with the primary window state', async () => {
+			const secondary = makeFakeWindow();
+			const primary = makeFakeWindow({
+				getBounds: vi.fn(() => ({ x: 5, y: 6, width: 1280, height: 720 })),
+			});
+			registry.create({ browserWindow: secondary, sessionIds: ['agent-2'], isMain: false });
+			const primaryId = registry.create({
+				browserWindow: primary,
+				sessionIds: ['agent-1'],
+				isMain: true,
+			});
+
+			const result = (await handlers.get('windows:getState')!(makeBridgeEvent())) as {
+				id: string;
+				width: number;
+				sessionIds: string[];
+			} | null;
+
+			expect(result).not.toBeNull();
+			// Resolved by isMain, NOT by registration order - the secondary was
+			// registered first precisely so an order-based lookup would fail here.
+			expect(result!.id).toBe(primaryId);
+			expect(result!.width).toBe(1280);
+			expect(result!.sessionIds).toEqual(['agent-1']);
+		});
+
+		// The opt-in is per-handler and reads only. A senderless event that is not
+		// a bridge event must stay an unknown caller.
+		it('does not answer a senderless non-bridge event', async () => {
+			const primary = makeFakeWindow();
+			registry.create({ browserWindow: primary, sessionIds: [], isMain: true });
+
+			const result = await handlers.get('windows:getState')!(
+				{} as unknown as Electron.IpcMainInvokeEvent
+			);
 			expect(result).toBeNull();
 		});
 
@@ -446,6 +491,23 @@ describe('Windows IPC Handlers', () => {
 			expect(result.registered).toBe(false);
 			expect(registry.getWindowForSession('agent-new')).toBeNull();
 		});
+
+		// The bridge opt-in is READS ONLY. This handler documents that a window only
+		// ever claims an agent into itself; with two windows open, honoring a web
+		// client here would claim it into a window the remote user never chose.
+		it('does not claim an agent for a bridge caller', async () => {
+			const primary = makeFakeWindow();
+			const id = registry.create({ browserWindow: primary, sessionIds: [], isMain: true });
+
+			const result = (await handlers.get('windows:registerSession')!(
+				makeBridgeEvent(),
+				'agent-new'
+			)) as { registered: boolean };
+
+			expect(result.registered).toBe(false);
+			expect(registry.get(id)?.sessionIds).toEqual([]);
+			expect(registry.getWindowForSession('agent-new')).toBeNull();
+		});
 	});
 
 	describe('windows:setPanelState', () => {
@@ -497,6 +559,24 @@ describe('Windows IPC Handlers', () => {
 				renamed: boolean;
 			};
 			expect(result.renamed).toBe(false);
+		});
+
+		// Same rule as registerSession: a remote panel collapse must not rewrite a
+		// desktop window's persisted state.
+		it('does not write panel state for a bridge caller', async () => {
+			const primary = makeFakeWindow();
+			registry.create({ browserWindow: primary, sessionIds: [], isMain: true });
+
+			await handlers.get('windows:setPanelState')!(makeBridgeEvent(), {
+				leftPanelCollapsed: true,
+			});
+
+			// The read DOES answer for the primary, which is exactly how we can see
+			// that the write above did not land.
+			const state = (await handlers.get('windows:getState')!(makeBridgeEvent())) as {
+				leftPanelCollapsed: boolean;
+			};
+			expect(state.leftPanelCollapsed).toBe(false);
 		});
 	});
 

--- a/src/main/ipc/handlers/windows.ts
+++ b/src/main/ipc/handlers/windows.ts
@@ -72,16 +72,46 @@ function toWindowInfo(entry: RegisteredWindow): WindowInfo {
 	};
 }
 
-/** Resolve the registry entry for the window that sent an IPC message. */
+/**
+ * True for the synthetic event a web-desktop bridge invoke arrives on
+ * (`FAKE_EVENT` in `web-server/handlers/bridgeHandlers.ts`), which carries no
+ * `sender` because a web client has no `WebContents` of its own.
+ */
+function isBridgeEvent(event: Electron.IpcMainInvokeEvent | undefined): boolean {
+	return (event as { type?: string } | undefined)?.type === 'bridge';
+}
+
+/**
+ * Resolve the registry entry for the window that sent an IPC message.
+ *
+ * Pass `allowBridge` ONLY from a read. A web-desktop client mirrors the primary
+ * window, so answering a read for it is right - without this every
+ * window-scoped read returned "unknown caller" and a remote page got `null`
+ * window state during boot.
+ *
+ * A write must not opt in. `registerSession` and `setPanelState` both document
+ * that a window only ever mutates itself, and resolving a web client to some
+ * window would break that: with two windows open, a remote agent-create would
+ * claim the agent into a window the remote user never chose, and a remote panel
+ * collapse would silently rewrite a desktop window's persisted state. Reads
+ * answering for the primary are defensible; writes landing on it are not.
+ */
 function resolveCallingWindow(
 	event: Electron.IpcMainInvokeEvent,
-	registry: WindowRegistry
+	registry: WindowRegistry,
+	{ allowBridge = false }: { allowBridge?: boolean } = {}
 ): RegisteredWindow | undefined {
-	// Web-desktop bridge invokes arrive with a synthetic event that has no
-	// sender (FAKE_EVENT in web-server/handlers/bridgeHandlers.ts). A web
-	// client is not a window; resolve to "no window" instead of letting
-	// BrowserWindow.fromWebContents throw on the missing WebContents.
-	if (!event?.sender) return undefined;
+	if (!event?.sender) {
+		// Resolve the PRIMARY window explicitly rather than "whichever window is
+		// first". BrowserWindow.getAllWindows() has no documented ordering, and a
+		// nondeterministic answer here would be read as the caller's identity.
+		if (allowBridge && isBridgeEvent(event)) {
+			return registry.getAll().find((entry) => entry.isMain);
+		}
+		// No sender and not a bridge read: resolve to "no window" rather than
+		// letting BrowserWindow.fromWebContents throw on the missing WebContents.
+		return undefined;
+	}
 	const browserWindow = BrowserWindow.fromWebContents(event.sender);
 	if (!browserWindow) return undefined;
 	return registry.getAll().find((entry) => entry.browserWindow === browserWindow);
@@ -313,7 +343,7 @@ export function registerWindowsHandlers(deps: WindowsHandlerDependencies): void 
 	// Current window's full WindowState (bounds + owned agents).
 	ipcMain.handle('windows:getState', (event: Electron.IpcMainInvokeEvent): WindowState | null => {
 		const registry = requireDependency(getWindowRegistry, 'Window registry');
-		const entry = resolveCallingWindow(event, registry);
+		const entry = resolveCallingWindow(event, registry, { allowBridge: true });
 		return entry ? registeredWindowToWindowState(entry) : null;
 	});
 
@@ -375,7 +405,9 @@ export function registerWindowsHandlers(deps: WindowsHandlerDependencies): void 
 		'windows:getBounds',
 		(event: Electron.IpcMainInvokeEvent, windowId?: string): WindowBounds | null => {
 			const registry = requireDependency(getWindowRegistry, 'Window registry');
-			const entry = windowId ? registry.get(windowId) : resolveCallingWindow(event, registry);
+			const entry = windowId
+				? registry.get(windowId)
+				: resolveCallingWindow(event, registry, { allowBridge: true });
 			if (!entry || entry.browserWindow.isDestroyed()) return null;
 			return entry.browserWindow.getBounds();
 		}


### PR DESCRIPTION
Narrow implementation of the gap found in #1313 by @user79697, following the shape agreed in that thread.

## The gap

Web-desktop clients invoke `ipcMain` through `FAKE_EVENT`, which carries no `sender` because a web client has no `WebContents`. Every window-scoped handler therefore resolved to "unknown caller", so `windows:getState` returned `null` and the remote page booted without the window state it mirrors. That degradation was never designed - it fell out of the `if (!event?.sender) return undefined` guard added in `4765edae1a` to stop `BrowserWindow.fromWebContents` throwing.

## Why not #1313's approach

#1313 gave `FAKE_EVENT` a lazily-resolved `sender`. That fixes the four `windows:*` handlers but reaches every bridged channel, and two of those are trust guards that currently reject web clients **only** because `sender` is `undefined`:

- `plugins:request-consent` - `if (event.sender !== mainWindow?.webContents) throw new Error('UntrustedConsentRequester')`. In the single-window case the resolved sender *is* `mainWindow.webContents`, so any token-holding web client could force a native consent dialog onto the desktop user.
- `browser:clearSessionData` - `event.sender.getType() !== 'window'`. Currently TypeErrors and is rejected; with a sender it passes, so a web client could clear a tab partition's storage and cache.

## This change

`resolveCallingWindow` takes an `allowBridge` option, and only the two **read** handlers pass it:

| Handler | Bridge caller | Why |
|---|---|---|
| `windows:getState` | answered | read; a web client mirrors the primary |
| `windows:getBounds` | answered | read (already inert) |
| `windows:registerSession` | still no-op | write: "a window only ever claims an agent into itself" |
| `windows:setPanelState` | still no-op | write: "a window only ever writes its own state" |

A bridge event resolves to the registry's `isMain` entry rather than `BrowserWindow.getAllWindows()[0]`. Electron documents no ordering for that array, and the nondeterminism discussed on #1313 is worse inside an identity resolution than anywhere else. Using `isMain` retires the caveat entirely and needs no `getMainWindow` injection.

`FAKE_EVENT` is untouched and still has no `sender`, which is what keeps the blast radius to this one file - both guards above stay closed. Verified directly rather than assumed.

## Tests

Five tests in `windows.test.ts`, pinning the behavior from **both** directions:

- Red against current `rc` (the read returns `null`) - so it catches the bug.
- Red again if `allowBridge` is extended to the write handlers - so it catches the over-permissive version too.

The primary-resolution test registers the secondary window **first**, so an order-based lookup fails it. The existing "returns null for a senderless bridge event" test was rewritten rather than left alone: it still passed by accident, because the registry in it has no primary.

```
windows.test.ts + web-server suites   616 passed
tsc -p tsconfig.main.json             clean
eslint / prettier                     clean
```

Credit to @user79697 for finding and correctly characterizing the gap, including coming back to say the original crash framing was wrong once they found `4765edae1a`. Closes #1313.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved window state and bounds retrieval for supported bridge requests when no direct window sender is available.
  - Prevented unauthorized bridge requests from registering sessions or changing panel state.
  - Added validation to reject unsupported senderless window operations.
- **Tests**
  - Expanded coverage for bridge-based window resolution and access restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->