### PR TITLE
fix(sentry): stop quit-time stats flush and expected gh failures from crashing

### DIFF
--- a/src/__tests__/main/cue/cue-github-poller.test.ts
+++ b/src/__tests__/main/cue/cue-github-poller.test.ts
@@ -1141,6 +1141,16 @@ describe('cue-github-poller', () => {
 			);
 			expect(sentryCalls).toHaveLength(0);
 
+			// Auto-detection fails before doPoll ever has a repo, so the actionable
+			// guidance has to come from resolveRepo itself. Without it the only
+			// message the user sees is "could not auto-detect repo", which points
+			// at the project instead of at the login.
+			const authLog = (config.onLog as ReturnType<typeof vi.fn>).mock.calls.find(
+				(c) => typeof c[1] === 'string' && (c[1] as string).includes('gh auth login')
+			);
+			expect(authLog).toBeDefined();
+			expect(authLog?.[0]).toBe('warn');
+
 			cleanup();
 		});
 

--- a/src/__tests__/main/cue/cue-github-poller.test.ts
+++ b/src/__tests__/main/cue/cue-github-poller.test.ts
@@ -83,6 +83,7 @@ vi.mock('../../../main/cue/cue-db', () => ({
 import {
 	createCueGitHubPoller,
 	isGitHubConnectivityError,
+	isGitHubAuthError,
 	isGitHubRateLimitError,
 	GITHUB_RATE_LIMIT_MAX_BACKOFF_MS,
 	type CueGitHubPollerConfig,
@@ -925,8 +926,73 @@ describe('cue-github-poller', () => {
 			expect(isGitHubConnectivityError(new Error('ENOTFOUND api.github.com'))).toBe(true);
 		});
 
+		it('matches Go transport failures (gh is a Go binary, not libuv)', () => {
+			// `Post "https://api.github.com/graphql": net/http: TLS handshake timeout`
+			// is the same unreachable-right-now condition as ETIMEDOUT, spelled the
+			// way Go's http client spells it.
+			expect(
+				isGitHubConnectivityError(
+					new Error('Post "https://api.github.com/graphql": net/http: TLS handshake timeout')
+				)
+			).toBe(true);
+			expect(isGitHubConnectivityError(new Error('dial tcp 140.82.121.6:443: i/o timeout'))).toBe(
+				true
+			);
+			expect(
+				isGitHubConnectivityError(new Error('dial tcp: lookup api.github.com: no such host'))
+			).toBe(true);
+		});
+
 		it('does not match auth/configuration failures', () => {
+			// Auth stays outside this predicate on purpose - it is a different
+			// condition with different user guidance. isGitHubAuthError owns it.
 			expect(isGitHubConnectivityError(new Error('gh auth login required'))).toBe(false);
+			expect(isGitHubConnectivityError(new Error('HTTP 401: Bad credentials'))).toBe(false);
+		});
+	});
+
+	// MAESTRO-KE: a single install whose `gh` token had gone stale filed 924
+	// events - one per poll tick - because no predicate claimed HTTP 401.
+	describe('auth detection (isGitHubAuthError)', () => {
+		it('matches the field message verbatim', () => {
+			expect(
+				isGitHubAuthError(
+					new Error(
+						'Command failed: /usr/bin/gh issue list --repo acme/widgets --json number\n' +
+							'HTTP 401: Bad credentials (https://api.github.com/graphql)\n' +
+							'Try authenticating with:  gh auth login\n'
+					)
+				)
+			).toBe(true);
+		});
+
+		it('matches an unauthenticated gh CLI', () => {
+			expect(
+				isGitHubAuthError(
+					new Error('You are not logged into any GitHub hosts. Run gh auth login to authenticate.')
+				)
+			).toBe(true);
+			expect(isGitHubAuthError(new Error('HTTP 401: Requires authentication'))).toBe(true);
+		});
+
+		it('reads stderr as well as message', () => {
+			const err = Object.assign(new Error('Command failed: gh pr list'), {
+				stderr: 'HTTP 401: Bad credentials (https://api.github.com/graphql)',
+			});
+			expect(isGitHubAuthError(err)).toBe(true);
+		});
+
+		it('does not match rate limits, connectivity failures, or real faults', () => {
+			// 403/429 belong to isGitHubRateLimitError and get exponential backoff;
+			// misrouting them here would drop that behaviour on the floor.
+			expect(isGitHubAuthError(new Error('HTTP 403: API rate limit exceeded'))).toBe(false);
+			expect(isGitHubAuthError(new Error('ENOTFOUND api.github.com'))).toBe(false);
+			expect(isGitHubAuthError(new Error('HTTP 422: Validation Failed'))).toBe(false);
+		});
+
+		it('handles null/undefined safely', () => {
+			expect(isGitHubAuthError(null)).toBe(false);
+			expect(isGitHubAuthError(undefined)).toBe(false);
 		});
 	});
 
@@ -1016,9 +1082,78 @@ describe('cue-github-poller', () => {
 			cleanup();
 		});
 
-		it('reports non-rate-limit/non-connectivity errors to Sentry with cue:github:doPoll tag', async () => {
+		it('does not report an unauthenticated gh CLI to Sentry (MAESTRO-KE)', async () => {
+			// A stale/revoked `gh` token is only fixable by the user, and the poller
+			// keeps ticking - so without a carve-out one install files an event
+			// every poll interval, indefinitely.
 			const config = makeConfig();
-			setupExecFileReject('pr list', 'gh auth login required');
+			setupExecFileReject(
+				'pr list',
+				'HTTP 401: Bad credentials (https://api.github.com/graphql)\nTry authenticating with:  gh auth login'
+			);
+			mockExecFile.mockImplementationOnce((_c, _a, _o, cb) => cb(null, '2.0.0', ''));
+
+			const cleanup = createCueGitHubPoller(config);
+			await vi.advanceTimersByTimeAsync(2100);
+
+			// Prove the injected failure actually ran - a zero-Sentry assertion
+			// also passes if polling never reached `pr list`.
+			expect(
+				mockExecFile.mock.calls.some((c) => (c[1] as string[]).join(' ').includes('pr list'))
+			).toBe(true);
+			const sentryCalls = mockCaptureException.mock.calls.filter(
+				(c) => (c[1] as { operation: string }).operation === 'cue:github:doPoll'
+			);
+			expect(sentryCalls).toHaveLength(0);
+
+			cleanup();
+		});
+
+		it('tells the user to run gh auth login instead of failing silently', async () => {
+			const config = makeConfig();
+			setupExecFileReject('pr list', 'HTTP 401: Bad credentials (https://api.github.com/graphql)');
+			mockExecFile.mockImplementationOnce((_c, _a, _o, cb) => cb(null, '2.0.0', ''));
+
+			const cleanup = createCueGitHubPoller(config);
+			await vi.advanceTimersByTimeAsync(2100);
+
+			const authLog = (config.onLog as ReturnType<typeof vi.fn>).mock.calls.find(
+				(c) => typeof c[1] === 'string' && (c[1] as string).includes('gh auth login')
+			);
+			expect(authLog).toBeDefined();
+			expect(authLog?.[0]).toBe('warn');
+
+			cleanup();
+		});
+
+		it('does not report an unauthenticated gh CLI during repo auto-detection (MAESTRO-KE)', async () => {
+			const config = makeConfig({ repo: undefined });
+			mockExecFile.mockImplementation((_c, args, _o, cb) => {
+				if ((args as string[]).includes('--version')) return cb(null, '2.0.0', '');
+				return cb(new Error('HTTP 401: Bad credentials (https://api.github.com)'), '', '');
+			});
+
+			const cleanup = createCueGitHubPoller(config);
+			await vi.advanceTimersByTimeAsync(2100);
+
+			const sentryCalls = mockCaptureException.mock.calls.filter(
+				(c) => (c[1] as { operation: string }).operation === 'cue:github:resolveRepo'
+			);
+			expect(sentryCalls).toHaveLength(0);
+
+			cleanup();
+		});
+
+		it('reports non-rate-limit/non-connectivity/non-auth errors to Sentry with cue:github:doPoll tag', async () => {
+			// Fixture is a 422: GitHub rejected a query *we* built, which is a real
+			// bug on our side and must keep paging. (This case used to use
+			// `gh auth login required`, which is now classified as an expected auth
+			// failure - see isGitHubAuthError / MAESTRO-KE.)
+			const config = makeConfig();
+			setupExecFileReject(
+				'pr list',
+				'HTTP 422: Validation Failed (https://api.github.com/graphql)'
+			);
 			mockExecFile.mockImplementationOnce((_c, _a, _o, cb) => cb(null, '2.0.0', ''));
 
 			const cleanup = createCueGitHubPoller(config);

--- a/src/__tests__/main/stats/query-events-buffer.test.ts
+++ b/src/__tests__/main/stats/query-events-buffer.test.ts
@@ -12,6 +12,8 @@ import {
 	QUERY_EVENT_FLUSH_INTERVAL_MS,
 } from '../../../main/stats/query-events-buffer';
 import type { QueryEvent } from '../../../shared/stats-types';
+import { logger } from '../../../main/utils/logger';
+import { captureException } from '../../../main/utils/sentry';
 
 vi.mock('../../../main/utils/logger', () => ({
 	logger: {
@@ -22,6 +24,10 @@ vi.mock('../../../main/utils/logger', () => ({
 	},
 }));
 
+vi.mock('../../../main/utils/sentry', () => ({
+	captureException: vi.fn(),
+}));
+
 interface MockStatement {
 	run: ReturnType<typeof vi.fn>;
 }
@@ -29,20 +35,37 @@ interface MockTransactionFactory {
 	(fn: () => void): () => void;
 }
 interface MockDb {
+	open: boolean;
 	prepare: ReturnType<typeof vi.fn>;
 	transaction: MockTransactionFactory;
 }
 
+/**
+ * Fake that reproduces the two better-sqlite3 rules this module depends on:
+ * a `Database` exposes a boolean `open`, and once it is closed every operation
+ * throws `TypeError: The database connection is not open`. A mock that ignored
+ * `open` and happily ran statements against a closed handle would stay green
+ * through exactly the shutdown race MAESTRO-ZC reported from the field.
+ */
 function makeMockDb(): { db: MockDb; stmt: MockStatement; runs: unknown[][] } {
 	const runs: unknown[][] = [];
+	const assertOpen = () => {
+		if (!db.open) throw new TypeError('The database connection is not open');
+	};
 	const stmt: MockStatement = {
 		run: vi.fn((...args: unknown[]) => {
+			assertOpen();
 			runs.push(args);
 		}),
 	};
 	const db: MockDb = {
-		prepare: vi.fn(() => stmt),
+		open: true,
+		prepare: vi.fn(() => {
+			assertOpen();
+			return stmt;
+		}),
 		transaction: ((fn: () => void) => () => {
+			assertOpen();
 			fn();
 		}) as MockTransactionFactory,
 	};
@@ -64,6 +87,8 @@ describe('query-events-buffer', () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
 		resetQueryEventBufferForTests();
+		vi.mocked(captureException).mockClear();
+		vi.mocked(logger.warn).mockClear();
 	});
 
 	afterEach(() => {
@@ -249,5 +274,63 @@ describe('query-events-buffer', () => {
 	it('does not flush before any enqueue establishes a DB reference', () => {
 		// No enqueue has happened, so flush has no DB to write to.
 		expect(() => flushQueryEventsSync()).not.toThrow();
+	});
+
+	// MAESTRO-ZC: `closeStatsDB()` runs inside the quit handler's `before-quit`
+	// listener, which re-enters `app.quit()`; the re-emitted `before-quit` then
+	// ran this module's flush listener against an already-closed connection.
+	// better-sqlite3 threw, and the catch reported it to Sentry as a crash.
+	describe('flushing after the stats DB was closed (MAESTRO-ZC)', () => {
+		it('does not report the closed connection to Sentry', () => {
+			const { db } = makeMockDb();
+			enqueueQueryEvent(db as never, sampleEvent);
+
+			db.open = false;
+			flushQueryEventsSync();
+
+			expect(captureException).not.toHaveBeenCalled();
+		});
+
+		it('drops the batch without throwing, and empties the buffer', () => {
+			const { db, stmt } = makeMockDb();
+			enqueueQueryEvent(db as never, sampleEvent);
+			enqueueQueryEvent(db as never, sampleEvent);
+
+			db.open = false;
+
+			expect(() => flushQueryEventsSync()).not.toThrow();
+			expect(stmt.run).not.toHaveBeenCalled();
+			expect(getQueryEventBufferSize()).toBe(0);
+		});
+
+		it('logs the dropped count so the loss is not silent', () => {
+			const { db } = makeMockDb();
+			enqueueQueryEvent(db as never, sampleEvent);
+			enqueueQueryEvent(db as never, sampleEvent);
+			enqueueQueryEvent(db as never, sampleEvent);
+
+			db.open = false;
+			flushQueryEventsSync();
+
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('already closed'),
+				expect.anything(),
+				expect.objectContaining({ count: 3 })
+			);
+		});
+
+		it('still reports genuinely unexpected write failures to Sentry', () => {
+			// The carve-out is for a closed handle only - a real write fault on an
+			// open connection (disk full, corruption) must keep paging.
+			const { db, stmt } = makeMockDb();
+			stmt.run.mockImplementationOnce(() => {
+				throw new Error('database disk image is malformed');
+			});
+			enqueueQueryEvent(db as never, sampleEvent);
+
+			flushQueryEventsSync();
+
+			expect(captureException).toHaveBeenCalledTimes(1);
+		});
 	});
 });

--- a/src/__tests__/main/stats/query-events-buffer.test.ts
+++ b/src/__tests__/main/stats/query-events-buffer.test.ts
@@ -332,5 +332,22 @@ describe('query-events-buffer', () => {
 
 			expect(captureException).toHaveBeenCalledTimes(1);
 		});
+
+		it('swallows a statement-preparation failure instead of aborting the caller', () => {
+			// `StatsDB.close()` calls this during quit cleanup, so an exception that
+			// escapes the flush skips the `db.close()` and the `initialized = false`
+			// that follow it. A prepare can still fail on a handle that reports
+			// `open` (damaged schema, disk fault), so it has to sit inside the same
+			// error boundary as the transaction.
+			const { db } = makeMockDb();
+			enqueueQueryEvent(db as never, sampleEvent);
+			db.prepare.mockImplementationOnce(() => {
+				throw new Error('no such table: query_events');
+			});
+
+			expect(() => flushQueryEventsSync()).not.toThrow();
+			expect(getQueryEventBufferSize()).toBe(0);
+			expect(captureException).toHaveBeenCalledTimes(1);
+		});
 	});
 });

--- a/src/__tests__/main/stats/stats-db.test.ts
+++ b/src/__tests__/main/stats/stats-db.test.ts
@@ -94,6 +94,15 @@ vi.mock('../../../main/utils/logger', () => ({
 	},
 }));
 
+// Spy on the query-event write buffer so `close()`'s flush is observable.
+// Everything else in the module stays real - only the flush entry point is
+// swapped, so the rest of the stats module keeps working through `index.ts`.
+const mockFlushQueryEventsSync = vi.fn();
+vi.mock('../../../main/stats/query-events-buffer', async (importOriginal) => ({
+	...(await importOriginal<typeof import('../../../main/stats/query-events-buffer')>()),
+	flushQueryEventsSync: () => mockFlushQueryEventsSync(),
+}));
+
 // Import types only - we'll test the type definitions
 import type {
 	QueryEvent,
@@ -480,6 +489,44 @@ describe('StatsDB class (mocked)', () => {
 
 			expect(mockDb.close).toHaveBeenCalled();
 			expect(db.isReady()).toBe(false);
+		});
+
+		// MAESTRO-ZC: the buffer has its own `before-quit` flush listener, but
+		// listener order across modules is not guaranteed and the quit handler
+		// re-emits `before-quit`, so that flush could land after this close and
+		// write against a dead connection. Flushing here is what makes the last
+		// events of a session survive.
+		it('flushes buffered query events BEFORE closing the connection', async () => {
+			const { StatsDB } = await import('../../../main/stats');
+			const db = new StatsDB();
+			db.initialize();
+			// initialize() closes probe connections of its own, so start the
+			// ordering window at the point we actually care about.
+			mockDb.close.mockClear();
+			mockFlushQueryEventsSync.mockClear();
+
+			db.close();
+
+			expect(mockFlushQueryEventsSync).toHaveBeenCalledTimes(1);
+			expect(mockDb.close).toHaveBeenCalledTimes(1);
+			expect(mockFlushQueryEventsSync.mock.invocationCallOrder[0]).toBeLessThan(
+				mockDb.close.mock.invocationCallOrder[0]
+			);
+		});
+
+		it('does not flush into a database it already believes is corrupt', async () => {
+			// The corruption-recovery paths close `this.db` directly rather than
+			// going through close(), so recovery must not trigger a write.
+			const { StatsDB } = await import('../../../main/stats');
+			const db = new StatsDB();
+			db.initialize();
+			mockDb.close.mockClear();
+			mockFlushQueryEventsSync.mockClear();
+
+			db.restoreFromBackup('/path/to/backup');
+
+			expect(mockDb.close).toHaveBeenCalledTimes(1);
+			expect(mockFlushQueryEventsSync).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/__tests__/shared/sentryFilters.test.ts
+++ b/src/__tests__/shared/sentryFilters.test.ts
@@ -111,6 +111,45 @@ describe('shouldDropSentryEvent', () => {
 			).toBe(true);
 		});
 
+		// MAESTRO-9V: Electron's catch-all when the OS refuses to trash a path
+		// (file open elsewhere, no recycle bin on the volume, permissions). The
+		// delete is user-initiated and the caller already toasts this exact
+		// message, so the crash report on top of it is noise.
+		it('drops the generic trash failure through shell:trashItem', () => {
+			expect(
+				shouldDropSentryEvent(
+					exceptionEvent(
+						'Error',
+						"Error invoking remote method 'shell:trashItem': Error: Failed to perform delete operation"
+					)
+				)
+			).toBe(true);
+		});
+
+		it('keeps a generic delete failure that did NOT come from shell:trashItem', () => {
+			// The rule is scoped to the one IPC channel we know shows a toast -
+			// the same words arriving from anywhere else are still signal.
+			expect(
+				shouldDropSentryEvent(
+					exceptionEvent(
+						'Error',
+						"Error invoking remote method 'fs:deleteFile': Error: Failed to perform delete operation"
+					)
+				)
+			).toBe(false);
+		});
+
+		it('keeps unrelated shell:trashItem failures', () => {
+			expect(
+				shouldDropSentryEvent(
+					exceptionEvent(
+						'Error',
+						"Error invoking remote method 'shell:trashItem': Error: EBUSY: resource busy or locked"
+					)
+				)
+			).toBe(false);
+		});
+
 		it('drops EACCES on the sessions file bubbling up through sessions:setMany', () => {
 			expect(
 				shouldDropSentryEvent(

--- a/src/main/cue/cue-github-poller.ts
+++ b/src/main/cue/cue-github-poller.ts
@@ -68,11 +68,13 @@ export function formatNewCommentsForTemplate(comments: GitHubComment[]): string 
 export const GITHUB_RATE_LIMIT_MAX_BACKOFF_MS = 60 * 60 * 1000;
 
 /**
- * Heuristic rate-limit detector for `gh` CLI failures. GitHub surfaces rate
- * limits in stderr text rather than a structured error code, so we pattern
- * match the user-visible strings. Exported for tests.
+ * Lowercased `message` + `stderr` of a `gh` CLI failure, joined for pattern
+ * matching. `gh` reports the interesting detail (rate limits, HTTP status,
+ * auth hints) in stderr text rather than in a structured error code, and
+ * `execFile` rejections carry it on a separate property from the message, so
+ * every classifier below has to look at both.
  */
-export function isGitHubRateLimitError(err: unknown): boolean {
+function ghErrorHaystack(err: unknown): string {
 	const msg = (
 		err && typeof err === 'object' && 'message' in err && typeof err.message === 'string'
 			? err.message
@@ -85,7 +87,16 @@ export function isGitHubRateLimitError(err: unknown): boolean {
 		typeof (err as { stderr: unknown }).stderr === 'string'
 			? (err as { stderr: string }).stderr.toLowerCase()
 			: '';
-	const haystack = `${msg}\n${stderr}`;
+	return `${msg}\n${stderr}`;
+}
+
+/**
+ * Heuristic rate-limit detector for `gh` CLI failures. GitHub surfaces rate
+ * limits in stderr text rather than a structured error code, so we pattern
+ * match the user-visible strings. Exported for tests.
+ */
+export function isGitHubRateLimitError(err: unknown): boolean {
+	const haystack = ghErrorHaystack(err);
 	return (
 		haystack.includes('api rate limit exceeded') ||
 		haystack.includes('secondary rate limit') ||
@@ -104,19 +115,7 @@ export function isGitHubRateLimitError(err: unknown): boolean {
  * paging Sentry on every tick of a GitHub outage is pure noise (MAESTRO-KE).
  */
 export function isGitHubConnectivityError(err: unknown): boolean {
-	const msg = (
-		err && typeof err === 'object' && 'message' in err && typeof err.message === 'string'
-			? err.message
-			: String(err ?? '')
-	).toLowerCase();
-	const stderr =
-		err &&
-		typeof err === 'object' &&
-		'stderr' in err &&
-		typeof (err as { stderr: unknown }).stderr === 'string'
-			? (err as { stderr: string }).stderr.toLowerCase()
-			: '';
-	const haystack = `${msg}\n${stderr}`;
+	const haystack = ghErrorHaystack(err);
 	return (
 		haystack.includes('error connecting to api.github.com') ||
 		haystack.includes('check your internet connection') ||
@@ -125,7 +124,38 @@ export function isGitHubConnectivityError(err: unknown): boolean {
 		haystack.includes('etimedout') ||
 		haystack.includes('network is unreachable') ||
 		haystack.includes('could not resolve host: api.github.com') ||
+		// `gh` is a Go binary, so a transport-level failure surfaces with Go's
+		// wording rather than a libuv errno: `Post "https://api.github.com/graphql":
+		// net/http: TLS handshake timeout`. Same unreachable-right-now condition as
+		// the ECONNRESET/ETIMEDOUT spellings above, different vocabulary.
+		haystack.includes('tls handshake timeout') ||
+		haystack.includes('i/o timeout') ||
+		haystack.includes('no such host') ||
 		/\bhttp\s+5\d{2}\b/.test(haystack)
+	);
+}
+
+/**
+ * Detect GitHub CLI authentication failures - an expired, revoked, or missing
+ * `gh` token.
+ *
+ * Deliberately NOT folded into `isGitHubConnectivityError`: that predicate is
+ * documented and unit-tested as *not* matching auth/configuration failures, and
+ * the two want different user-facing guidance ("GitHub is unreachable, we'll
+ * retry" vs "re-authenticate `gh`"). What they share is that neither is a
+ * Maestro bug, so neither should page Sentry. Without this, one install whose
+ * token went stale files an event on every poll tick indefinitely - MAESTRO-KE
+ * collected 924 of them from a single trigger.
+ */
+export function isGitHubAuthError(err: unknown): boolean {
+	const haystack = ghErrorHaystack(err);
+	return (
+		/\bhttp\s+401\b/.test(haystack) ||
+		haystack.includes('bad credentials') ||
+		haystack.includes('gh auth login') ||
+		haystack.includes('requires authentication') ||
+		haystack.includes('authentication required') ||
+		haystack.includes('not logged into any github hosts')
 	);
 }
 
@@ -276,7 +306,8 @@ export function createCueGitHubPoller(config: CueGitHubPollerConfig): () => void
 			// first, so without this a `gh repo view` 5xx during an outage would
 			// still page Sentry once per tick for every auto-detect trigger
 			// (MAESTRO-KE). Skipping the poll and returning null is unchanged.
-			if (!isGitHubConnectivityError(err)) {
+			// A stale `gh` token is the same story with a different cause.
+			if (!isGitHubConnectivityError(err) && !isGitHubAuthError(err)) {
 				void captureException(err, { operation: 'cue:github:resolveRepo', triggerName });
 			}
 			return null;
@@ -589,6 +620,13 @@ export function createCueGitHubPoller(config: CueGitHubPollerConfig): () => void
 				onLog(
 					'warn',
 					`[CUE] GitHub poll skipped for "${triggerName}" because GitHub is unreachable: ${message}`
+				);
+			} else if (isGitHubAuthError(err)) {
+				// Actionable by the user and only by the user, so say what to do
+				// instead of filing a crash report on every tick (MAESTRO-KE).
+				onLog(
+					'warn',
+					`[CUE] GitHub poll skipped for "${triggerName}" - the GitHub CLI is not authenticated. Run \`gh auth login\` to reconnect: ${message}`
 				);
 			} else {
 				// Emit typed payload so the metric interceptor bumps the

--- a/src/main/cue/cue-github-poller.ts
+++ b/src/main/cue/cue-github-poller.ts
@@ -300,14 +300,25 @@ export function createCueGitHubPoller(config: CueGitHubPollerConfig): () => void
 			if (isGitHubRateLimitError(err)) {
 				throw err;
 			}
+			// A stale token fails here first, before `doPoll` ever gets a repo to
+			// poll, so the auth guidance has to be repeated at this call site -
+			// otherwise an auto-detect trigger only ever says "could not auto-detect
+			// repo", which reads like a project problem rather than a login one.
+			if (isGitHubAuthError(err)) {
+				const message = err instanceof Error ? err.message : String(err);
+				onLog(
+					'warn',
+					`[CUE] GitHub poll skipped for "${triggerName}" - the GitHub CLI is not authenticated. Run \`gh auth login\` to reconnect: ${message}`
+				);
+				return null;
+			}
 			onLog('warn', `[CUE] Could not auto-detect repo for "${triggerName}" - skipping poll`);
 			// GitHub being unreachable or degraded is the same expected operational
 			// condition the doPoll catch below suppresses. Repo auto-detection runs
 			// first, so without this a `gh repo view` 5xx during an outage would
 			// still page Sentry once per tick for every auto-detect trigger
 			// (MAESTRO-KE). Skipping the poll and returning null is unchanged.
-			// A stale `gh` token is the same story with a different cause.
-			if (!isGitHubConnectivityError(err) && !isGitHubAuthError(err)) {
+			if (!isGitHubConnectivityError(err)) {
 				void captureException(err, { operation: 'cue:github:resolveRepo', triggerName });
 			}
 			return null;

--- a/src/main/stats/query-events-buffer.ts
+++ b/src/main/stats/query-events-buffer.ts
@@ -125,11 +125,17 @@ export function flushQueryEventsSync(): void {
 
 	const events = buffer;
 	buffer = [];
-
-	const stmt = stmtCache.get(lastDb, INSERT_SQL);
+	const db = lastDb;
 
 	try {
-		const tx = lastDb.transaction(() => {
+		// Statement preparation is inside the try on purpose. This runs from
+		// `StatsDB.close()` during quit cleanup, and a prepare can still fail on a
+		// handle that reports `open` (a damaged schema, a disk fault). Outside the
+		// try that exception escapes the flush, aborts the close, and leaves the
+		// connection and the singleton's `initialized` flag alive for the rest of
+		// shutdown.
+		const stmt = stmtCache.get(db, INSERT_SQL);
+		const tx = db.transaction(() => {
 			for (const { id, event } of events) {
 				stmt.run(
 					id,

--- a/src/main/stats/query-events-buffer.ts
+++ b/src/main/stats/query-events-buffer.ts
@@ -101,6 +101,28 @@ export function flushQueryEventsSync(): void {
 		return;
 	}
 
+	// The stats DB can already be closed by the time we get here. `closeStatsDB()`
+	// runs from the quit handler's cleanup, which itself executes inside a
+	// `before-quit` listener that re-enters `app.quit()`; the re-emitted
+	// `before-quit` then runs the stats module's flush listener *after* the close.
+	// better-sqlite3 answers that with `TypeError: The database connection is not
+	// open`, thrown from inside the transaction, which the catch below used to
+	// report to Sentry as a crash (MAESTRO-ZC).
+	//
+	// A closed handle during shutdown is an expected boundary, not a bug: drop the
+	// batch with a warning and let go of the dead handle so a late `enqueueQueryEvent`
+	// can't keep feeding it. `StatsDB.close()` now flushes while the connection is
+	// still open, so in practice there is nothing left to drop here.
+	if (!lastDb.open) {
+		logger.warn('Stats DB already closed - dropping buffered query events', LOG_CONTEXT, {
+			count: buffer.length,
+		});
+		buffer = [];
+		stmtCache.clear();
+		lastDb = null;
+		return;
+	}
+
 	const events = buffer;
 	buffer = [];
 

--- a/src/main/stats/stats-db.ts
+++ b/src/main/stats/stats-db.ts
@@ -38,6 +38,7 @@ import {
 	hasPendingMigrations,
 } from './migrations';
 import { insertQueryEvent, getQueryEvents, clearQueryEventCache } from './query-events';
+import { flushQueryEventsSync } from './query-events-buffer';
 import {
 	insertAutoRunSession,
 	updateAutoRunSession,
@@ -152,10 +153,24 @@ export class StatsDB {
 	}
 
 	/**
-	 * Close the database connection
+	 * Close the database connection.
+	 *
+	 * Flushes the query-event write buffer first. Buffered events are persisted
+	 * by a `before-quit` listener of their own, but listener order across modules
+	 * is not guaranteed and the quit handler re-emits `before-quit`, so that flush
+	 * could land *after* this close - writing against a dead connection, throwing,
+	 * and losing the batch (MAESTRO-ZC). Flushing here means the last events of a
+	 * session are written while the handle is unambiguously open, and the later
+	 * listener finds an empty buffer and no-ops.
+	 *
+	 * Only the lifecycle close does this. The corruption-recovery paths close
+	 * `this.db` directly, on purpose: flushing into a database we already believe
+	 * is corrupt would just turn one fault into two.
 	 */
 	close(): void {
 		if (this.db) {
+			flushQueryEventsSync();
+
 			this.db.close();
 			this.db = null;
 			this.initialized = false;

--- a/src/shared/sentryFilters.ts
+++ b/src/shared/sentryFilters.ts
@@ -84,6 +84,15 @@ export function shouldDropSentryEvent(event: MinimalSentryEvent): boolean {
 	if (ipcMethod === 'shell:trashItem' || ipcMethod === 'shell:showItemInFolder') {
 		if (/Path does not exist:/i.test(haystack)) return true;
 	}
+	// Electron's catch-all when the platform refuses to move a path to the trash:
+	// the file is open in another process, the volume has no recycle bin (network
+	// share, removable media), or the user lacks permission. Nothing we can do in
+	// code, and the delete is user-initiated - the caller already shows a
+	// "Failed to Erase Directory" toast carrying this message, so the user knows
+	// and can retry. The crash report on top of that is pure noise (MAESTRO-9V).
+	if (ipcMethod === 'shell:trashItem' && /Failed to perform delete operation/i.test(haystack)) {
+		return true;
+	}
 
 	// ENOSPC / EPERM / EACCES bubbling up through settings / sessions writes (same as
 	// rule 1 but the IPC wrapper changes the message prefix). EACCES means the userData


### PR DESCRIPTION
Twelfth Sentry triage, targeting the `main` line. Shipped stable is **0.17.3** (761 events in 14d); HEAD's `package.json` says `0.17.4` but that release has no field population, so `release:0.17.3` is the correct pin. Three issues had an obvious bug and an obvious fix.

## MAESTRO-ZC - stats flush runs after the DB is closed

`TypeError: The database connection is not open`, culprit `flushQueryEventsSync` (`stats/query-events-buffer.ts:104`), `channel:stable`, `release:0.17.3`.

The stack tells the whole story: `app.quit()` emits `before-quit`, the quit handler's listener runs `performCleanup()` which calls `closeStatsDB()`, and that same listener re-enters `app.quit()` - the re-emitted `before-quit` then runs the stats module's *own* flush listener, after the close. better-sqlite3 throws from inside the transaction, the catch reports it to Sentry as a crash, and the buffered events are dropped.

So this was quiet data loss with a crash report stapled to it. Fixed at both layers:

- `StatsDB.close()` flushes the query-event buffer **before** `this.db.close()`. Listener order across modules is not something we control, so the flush has to happen where the handle is unambiguously open. The later listener then finds an empty buffer and no-ops.
- `flushQueryEventsSync()` treats `!lastDb.open` as an expected shutdown boundary: warn with the dropped count, clear the statement cache, release the dead handle, return. No Sentry.

A genuine write fault on an *open* connection (disk full, corruption) still pages - there's a test pinning that.

Deliberately **not** applied to the corruption-recovery paths (`restoreFromBackup`, `recoverFromCorruption`), which close `this.db` directly rather than going through `close()`. Flushing into a database we already believe is corrupt would just turn one fault into two. Also covered by a test.

## MAESTRO-KE - unauthenticated `gh` pages Sentry on every poll tick

1,016 occurrences all-time. The per-message breakdown:

| message | channel | count (14d) |
|---|---|---|
| `HTTP 401: Bad credentials` | rc | 924 |
| `HTTP 503: No server is currently available` | stable | 16 |
| `HTTP 503` | rc | 5 |
| `net/http: TLS handshake timeout` | rc | 1 |

The 5xx rows are already handled - the `/\bhttp\s+5\d{2}\b/` rule landed in #1311 (`85468f1f4`, 2026-08-06) and `git merge-base --is-ancestor 85468f1f4 v0.17.3` is false, so those stable events are pre-fix, just unshipped.

The **401 row is a real gap and it is present in `main`'s code** (and `rc`'s - I checked `origin/rc`, same file, same missing case). No predicate claimed auth failures, so one install whose `gh` token went stale files an event every poll interval, forever. The 924 events came from a single trigger.

Added `isGitHubAuthError`, wired into the `doPoll` catch and the repo auto-detection catch. It is deliberately **separate** from `isGitHubConnectivityError` rather than folded in: that predicate is documented and unit-tested as *not* matching auth/configuration failures, and the two want different guidance ("GitHub is unreachable, we'll retry" vs "re-authenticate"). Ordering is safe because rate-limit detection (403/429) runs first at both call sites.

The poll now logs a warning that names `gh auth login`, so a stale token is actionable instead of a silently dead trigger.

Also taught the connectivity predicate Go's vocabulary while I was in there - `gh` is a Go binary, so a transport failure reads `Post "https://api.github.com/graphql": net/http: TLS handshake timeout` rather than an ETIMEDOUT. Same unreachable-right-now condition, different spelling.

## MAESTRO-9V - generic trash refusal reported as a crash

`shell:trashItem` failing with Electron's catch-all `Failed to perform delete operation` - the file is open in another process, the volume has no recycle bin (network share, removable media), or permissions. `channel:stable`, `release:0.17.3`.

Nothing we can do in code, the delete is user-initiated, and `useSessionLifecycle.ts:559` **already toasts this exact message** ("Failed to Erase Directory"), so the user knows and can retry. The crash report on top is noise. Dropped via the existing `shell:trashItem` rule in `sentryFilters.ts`, scoped to that one channel and that one message - two negative tests pin that the same words from a different channel, and a different failure from the same channel, both still report.

## Drive-by

`isGitHubRateLimitError` and `isGitHubConnectivityError` had the message+stderr haystack builder copy-pasted verbatim. Extracted `ghErrorHaystack`; the third predicate reuses it.

## Testing

13 new/changed tests, **every one confirmed red against the unfixed source** (3 in the buffer, 1 in stats-db, 7 in the poller, 1 in sentryFilters, plus the reclassified fixture below). Negative controls held green throughout, which is what proves the reporting paths that *should* still fire are unchanged.

Two things worth calling out:

**The query-event buffer's fake DB now honours `open`.** It used to accept statements against any handle, so it would have stayed green through exactly this bug. It now reproduces both better-sqlite3 rules: a `Database` exposes a boolean `open`, and every operation throws `TypeError: The database connection is not open` once closed. Third time this family of lesson has bitten a triage (after the Map-based `ipcMain` mock in #1341 and the permissive `IPty` fake in #1360) - a permissive mock hides the bug you are chasing.

**One existing test's fixture changed on purpose.** `reports non-rate-limit/non-connectivity errors to Sentry` used `'gh auth login required'` as its stand-in for an unexpected error. That string is now classified as an expected auth failure, so the fixture moved to `HTTP 422: Validation Failed` - GitHub rejecting a query *we* built, which is a real bug on our side and must keep paging. The test's intent is unchanged and it is still red without the reporting branch. Noted inline so it does not read as an accidental weakening.

Suites run: `main/stats`, `main/cue`, `main/ipc/handlers/stats`, `shared/sentryFilters`, `main/app-lifecycle` - 1,984 passed. The 3 failing files under `main/cue` (`cue-executor`, `cue-cli-executor`, `cue-shell-executor`) are pre-existing collection errors (`promisify(execFile)` mock gap), verified identical on a clean tree via `git stash push -u`.

`npx tsc --noEmit` is at the 112-error baseline with none in the changed files. ESLint clean. Pre-commit lint-staged (prettier + eslint) ran and passed.

## Triaged and skipped, with reasons

- **MAESTRO-RS** (GLIBC 2.38 / better-sqlite3, 392 events, now the noisiest on stable) - still needs a human call on the Linux build toolchain. Fifth triage running.
- **MAESTRO-Q2** (`maestro-p --status` `exit: 1`, 68) - deferred an eighth time; `exit: 1` is generic and needs a decision on maestro-p's exit semantics.
- **Already fixed on `main`, just unshipped in 0.17.3** (verified with `merge-base --is-ancestor` against `v0.17.3`): 1G (`write EPIPE`, #1213), 2S/2Z (`Database not initialized`, #1213), SC (`EMFILE` history watch, #1390), TN (UNC playbooks path, #1390), YP/YQ/YR (`reading 'command'`, #1390), and KE's 5xx rows (#1311).
- **MAESTRO-ZB** (`sessions:setMany` EMFILE, 2) - not filtered, on purpose and consistently with the prior calls on Y5 (EBADF) and the `isExpectedSessionReadError` carve-out: EMFILE can mean a real fd leak in our own process, and a filter would mask exactly that.
- **MAESTRO-ST** (`removeChild`, 3) - pure minified `vendor-react` frames, no app frames. Same dead-end as XV/XX/QZ/QX; needs a real sourcemap.
- **Native / GPU / OOM** (SG, 23, 38, 4V, 2C, 1J, 1F, T2, V2, TZ, Z9, ZA, ZH, 5W, 63, RD, 8C, Y, YM, Y1, 5A, 62) and **genuine spawn signal** (R0, Q8) - unchanged from prior rounds.

I also re-verified the prior guards are intact at HEAD (`write EPIPE` rule, `isExpectedGroomingFailure`, the three `db.isReady()` checks, M9's `RangeError` carve-out, `isExpectedQuotaStatus`, `EXPECTED_WATCH_ERROR_CODES`, `killPty`). No regressions like the force-reset reverts from triage 8.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub authentication-error handling, including clearer re-authentication guidance.
  * Reduced unnecessary error reporting for expected authentication, shutdown, and file-deletion failures.
  * Ensured pending usage events are saved before closing the local statistics database.
  * Prevented errors when pending events are flushed after the database has already closed.
  * Preserved reporting for unexpected failures, including validation and database write errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->