### PR TITLE
perf(files): delete a multi-selection in one batched call

### DIFF
--- a/src/__tests__/main/ipc/handlers/filesystem.test.ts
+++ b/src/__tests__/main/ipc/handlers/filesystem.test.ts
@@ -88,6 +88,7 @@ vi.mock('../../../../main/utils/remote-fs', () => ({
 	renameRemote: vi.fn(),
 	mkdirRemote: vi.fn(),
 	deleteRemote: vi.fn(),
+	deleteManyRemote: vi.fn(),
 	countItemsRemote: vi.fn(),
 	compressFolderRemote: vi.fn(),
 	writeFileRemote: vi.fn(),
@@ -111,6 +112,7 @@ import {
 	renameRemote,
 	mkdirRemote,
 	deleteRemote,
+	deleteManyRemote,
 	writeFileRemote,
 	existsRemote,
 	compressFolderRemote,
@@ -142,6 +144,7 @@ describe('filesystem handlers', () => {
 			expect(ipcMain.handle).toHaveBeenCalledWith('fs:copyPath', expect.any(Function));
 			expect(ipcMain.handle).toHaveBeenCalledWith('fs:mkdir', expect.any(Function));
 			expect(ipcMain.handle).toHaveBeenCalledWith('fs:delete', expect.any(Function));
+			expect(ipcMain.handle).toHaveBeenCalledWith('fs:deleteMany', expect.any(Function));
 			expect(ipcMain.handle).toHaveBeenCalledWith('fs:countItems', expect.any(Function));
 			expect(ipcMain.handle).toHaveBeenCalledWith('fs:fetchImageAsBase64', expect.any(Function));
 		});
@@ -919,6 +922,109 @@ describe('filesystem handlers', () => {
 
 			expect(deleteRemote).toHaveBeenCalledWith('/remote/file.txt', mockSshConfig, true);
 			expect(result).toEqual({ success: true });
+		});
+	});
+
+	describe('fs:deleteMany', () => {
+		it('deletes every local path in one call and reports each outcome', async () => {
+			vi.mocked(fs.stat).mockResolvedValue({ isDirectory: () => false } as any);
+			vi.mocked(fs.unlink).mockResolvedValue(undefined);
+
+			const handler = registeredHandlers.get('fs:deleteMany');
+			const result = await handler!({}, ['/test/a.txt', '/test/b.txt', '/test/c.txt']);
+
+			expect(fs.unlink).toHaveBeenCalledTimes(3);
+			expect(result).toEqual({
+				results: [
+					{ path: '/test/a.txt', success: true },
+					{ path: '/test/b.txt', success: true },
+					{ path: '/test/c.txt', success: true },
+				],
+			});
+		});
+
+		it('keeps deleting past a failure and attributes it to the right path', async () => {
+			vi.mocked(fs.stat).mockResolvedValue({ isDirectory: () => false } as any);
+			vi.mocked(fs.unlink).mockImplementation(async (target) => {
+				if (target === '/test/b.txt') throw new Error('EACCES: permission denied');
+			});
+
+			const handler = registeredHandlers.get('fs:deleteMany');
+			const result = await handler!({}, ['/test/a.txt', '/test/b.txt', '/test/c.txt']);
+
+			// One bad file must not sink the rest of the batch, and the caller
+			// needs to know WHICH path failed to report it.
+			expect(result.results).toEqual([
+				{ path: '/test/a.txt', success: true },
+				{ path: '/test/b.txt', success: false, error: 'EACCES: permission denied' },
+				{ path: '/test/c.txt', success: true },
+			]);
+		});
+
+		it('routes directories through rm and files through unlink', async () => {
+			vi.mocked(fs.stat).mockImplementation(
+				async (target) => ({ isDirectory: () => target === '/test/folder' }) as any
+			);
+			vi.mocked(fs.rm).mockResolvedValue(undefined);
+			vi.mocked(fs.unlink).mockResolvedValue(undefined);
+
+			const handler = registeredHandlers.get('fs:deleteMany');
+			await handler!({}, ['/test/folder', '/test/file.txt']);
+
+			expect(fs.rm).toHaveBeenCalledWith('/test/folder', { recursive: true, force: true });
+			expect(fs.unlink).toHaveBeenCalledWith('/test/file.txt');
+		});
+
+		it('sends the whole remote batch to deleteManyRemote in one go', async () => {
+			const mockSshConfig = { id: 'remote-1', host: 'server.com', username: 'user' };
+			vi.mocked(getSshRemoteById).mockReturnValue(mockSshConfig as any);
+			vi.mocked(deleteManyRemote).mockResolvedValue([
+				{ success: true },
+				{ success: false, error: 'Permission denied: /remote/b.txt' },
+			]);
+
+			const handler = registeredHandlers.get('fs:deleteMany');
+			const result = await handler!({}, ['/remote/a.txt', '/remote/b.txt'], {
+				sshRemoteId: 'remote-1',
+			});
+
+			// One SSH round trip for the batch, not one handshake per file.
+			expect(deleteManyRemote).toHaveBeenCalledTimes(1);
+			expect(deleteManyRemote).toHaveBeenCalledWith(
+				['/remote/a.txt', '/remote/b.txt'],
+				mockSshConfig,
+				true
+			);
+			expect(deleteRemote).not.toHaveBeenCalled();
+			expect(result).toEqual({
+				results: [
+					{ path: '/remote/a.txt', success: true },
+					{ path: '/remote/b.txt', success: false, error: 'Permission denied: /remote/b.txt' },
+				],
+			});
+		});
+
+		it('throws when the SSH remote cannot be resolved', async () => {
+			vi.mocked(getSshRemoteById).mockReturnValue(undefined as any);
+
+			const handler = registeredHandlers.get('fs:deleteMany');
+
+			// A missing remote is a config failure for the whole call, not N
+			// identical per-path errors - and it must never fall through to a
+			// LOCAL delete of paths the user meant to remove on the remote host.
+			await expect(handler!({}, ['/remote/a.txt'], { sshRemoteId: 'gone' })).rejects.toThrow(
+				'SSH remote not found: gone'
+			);
+			expect(fs.unlink).not.toHaveBeenCalled();
+		});
+
+		it('short-circuits an empty batch without touching the filesystem', async () => {
+			const handler = registeredHandlers.get('fs:deleteMany');
+			const result = await handler!({}, []);
+
+			expect(result).toEqual({ results: [] });
+			expect(fs.unlink).not.toHaveBeenCalled();
+			expect(deleteManyRemote).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/__tests__/main/utils/remote-fs.test.ts
+++ b/src/__tests__/main/utils/remote-fs.test.ts
@@ -13,6 +13,7 @@ import {
 	listDirWithStatsRemote,
 	bulkStatFileInSubdirsRemote,
 	listTreeRemote,
+	deleteManyRemote,
 	__resetHostLimitersForTest,
 	type RemoteFsDeps,
 } from '../../../main/utils/remote-fs';
@@ -1431,6 +1432,105 @@ describe('remote-fs', () => {
 			);
 
 			expect(results.every((r) => r.status === 'rejected')).toBe(true);
+		});
+	});
+
+	describe('deleteManyRemote', () => {
+		const ok: ExecResult = { stdout: '', stderr: '', exitCode: 0 };
+
+		it('deletes a whole batch in a single SSH round trip', async () => {
+			const deps = createMockDeps(ok);
+
+			const results = await deleteManyRemote(
+				['/remote/a.txt', '/remote/b.txt', '/remote/c.txt'],
+				baseConfig,
+				true,
+				deps
+			);
+
+			// This is the whole point: one handshake for N paths, not N.
+			expect(deps.execSsh).toHaveBeenCalledTimes(1);
+			const cmd = (deps.execSsh as any).mock.calls[0][1].at(-1);
+			expect(cmd).toBe("rm -rf '/remote/a.txt' '/remote/b.txt' '/remote/c.txt'");
+			expect(results).toEqual([{ success: true }, { success: true }, { success: true }]);
+		});
+
+		it('uses rm -f when recursive is off', async () => {
+			const deps = createMockDeps(ok);
+
+			await deleteManyRemote(['/remote/a.txt'], baseConfig, false, deps);
+
+			expect((deps.execSsh as any).mock.calls[0][1].at(-1)).toBe("rm -f '/remote/a.txt'");
+		});
+
+		it('escapes paths so a hostile filename cannot break out of the command', async () => {
+			const deps = createMockDeps(ok);
+
+			await deleteManyRemote(["/remote/a'; rm -rf ~; echo '.txt"], baseConfig, true, deps);
+
+			const cmd = (deps.execSsh as any).mock.calls[0][1].at(-1);
+			// The whole filename stays one single-quoted argument - the embedded
+			// quote is closed and re-opened as '\'' rather than ending it, so the
+			// injected `rm -rf ~` is data the outer rm receives, not a command the
+			// shell runs. Batching several paths into one command line makes this
+			// the load-bearing property of the whole function.
+			expect(cmd).toBe(`rm -rf '/remote/a'\\''; rm -rf ~; echo '\\''.txt'`);
+		});
+
+		it('chunks a batch too large for one command line', async () => {
+			const deps = createMockDeps(ok);
+			// Each path is ~1 KB escaped, so 64 of them blow past the 32 KB cap.
+			const paths = Array.from({ length: 64 }, (_, i) => `/remote/${'x'.repeat(1000)}-${i}.txt`);
+
+			const results = await deleteManyRemote(paths, baseConfig, true, deps);
+
+			expect((deps.execSsh as any).mock.calls.length).toBeGreaterThan(1);
+			for (const call of (deps.execSsh as any).mock.calls) {
+				expect(Buffer.byteLength(call[1].at(-1), 'utf8')).toBeLessThanOrEqual(32 * 1024);
+			}
+			// Chunking must not drop or reorder anything.
+			expect(results).toHaveLength(paths.length);
+			expect(results.every((r) => r.success)).toBe(true);
+		});
+
+		it('retries a failed chunk per path to attribute the failure', async () => {
+			// `rm` exits non-zero without naming the offending argument, so the
+			// batch is replayed one path at a time to find out which one failed.
+			const execSsh = vi
+				.fn()
+				// Batch attempt fails as a whole.
+				.mockResolvedValueOnce({ stdout: '', stderr: 'rm: permission denied', exitCode: 1 })
+				// Per-path replay: a.txt fine, b.txt is the culprit, c.txt fine.
+				.mockResolvedValueOnce(ok)
+				.mockResolvedValueOnce({
+					stdout: '',
+					stderr: 'rm: /remote/b.txt: Permission denied',
+					exitCode: 1,
+				})
+				.mockResolvedValueOnce(ok);
+			const deps: RemoteFsDeps = {
+				execSsh,
+				buildSshArgs: vi.fn().mockReturnValue(['testuser@dev.example.com']),
+			};
+
+			const results = await deleteManyRemote(
+				['/remote/a.txt', '/remote/b.txt', '/remote/c.txt'],
+				baseConfig,
+				true,
+				deps
+			);
+
+			expect(results[0]).toEqual({ success: true });
+			expect(results[1].success).toBe(false);
+			expect(results[1].error).toContain('Permission denied');
+			expect(results[2]).toEqual({ success: true });
+		});
+
+		it('returns nothing and opens no connection for an empty batch', async () => {
+			const deps = createMockDeps(ok);
+
+			expect(await deleteManyRemote([], baseConfig, true, deps)).toEqual([]);
+			expect(deps.execSsh).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/__tests__/renderer/components/FileExplorerPanel/hooks/useFileContextMenu.test.ts
+++ b/src/__tests__/renderer/components/FileExplorerPanel/hooks/useFileContextMenu.test.ts
@@ -99,6 +99,9 @@ const mockMaestro = {
 	shell: { openPath: vi.fn(), showItemInFolder: vi.fn() },
 	fs: {
 		delete: vi.fn().mockResolvedValue({ success: true }),
+		deleteMany: vi.fn(async (paths: string[]) => ({
+			results: paths.map((path) => ({ path, success: true })),
+		})),
 		downloadRemoteFile: vi.fn().mockResolvedValue({ success: true, path: '/local/App.tsx' }),
 		compressFolder: vi
 			.fn()
@@ -660,14 +663,46 @@ describe('useFileContextMenu', () => {
 			await result.current.handleDeleteMulti();
 		});
 
-		expect(mockMaestro.fs.delete).toHaveBeenCalledWith('/project/README.md', {
-			sshRemoteId: undefined,
-		});
-		expect(mockMaestro.fs.delete).toHaveBeenCalledWith('/project/docs/a.md', {
-			sshRemoteId: undefined,
-		});
+		// One batched call for the whole selection, not one call per file - the
+		// per-file loop put a round trip in front of every path (issue #1423).
+		expect(mockMaestro.fs.deleteMany).toHaveBeenCalledTimes(1);
+		expect(mockMaestro.fs.deleteMany).toHaveBeenCalledWith(
+			['/project/README.md', '/project/docs/a.md'],
+			{ sshRemoteId: undefined }
+		);
+		expect(mockMaestro.fs.delete).not.toHaveBeenCalled();
 		expect(refreshFileTree).toHaveBeenCalledWith('sess-1');
 		expect(setSelectedPaths).toHaveBeenCalledWith(expect.any(Set));
+		expect(result.current.multiDeleteModal).toBeNull();
+	});
+
+	it('handleDeleteMulti reports partial failures without losing the successes', async () => {
+		const refreshFileTree = vi.fn().mockResolvedValue(undefined);
+		const onShowFlash = vi.fn();
+		const selectedPathsRef = { current: new Set(['README.md', 'docs/a.md']) };
+		// A bulk delete is partially successful all the time (one locked or
+		// permission-denied file among many), so the batch resolves with a
+		// per-path outcome rather than rejecting on the first failure.
+		mockMaestro.fs.deleteMany.mockResolvedValueOnce({
+			results: [
+				{ path: '/project/README.md', success: true },
+				{ path: '/project/docs/a.md', success: false, error: 'Permission denied' },
+			],
+		});
+
+		const { result } = renderHook(() =>
+			useFileContextMenu({ ...defaultArgs, selectedPathsRef, refreshFileTree, onShowFlash })
+		);
+
+		act(() => {
+			result.current.handleOpenDeleteMulti();
+		});
+		await act(async () => {
+			await result.current.handleDeleteMulti();
+		});
+
+		expect(onShowFlash).toHaveBeenCalledWith('Deleted 1, 1 failed');
+		expect(refreshFileTree).toHaveBeenCalledWith('sess-1');
 		expect(result.current.multiDeleteModal).toBeNull();
 	});
 	it('handleCompressFolder zips the folder, toasts the archive name, and refreshes', async () => {

--- a/src/main/ipc/handlers/filesystem.ts
+++ b/src/main/ipc/handlers/filesystem.ts
@@ -11,6 +11,7 @@
  * - rename: Rename file/directory (local & SSH remote)
  * - copyPath: Copy a file/directory into a destination (local only; drag-import)
  * - delete: Delete file/directory (local & SSH remote)
+ * - deleteMany: Delete a batch of files/directories in one call (local & SSH remote)
  * - countItems: Count files and folders recursively (local & SSH remote)
  * - compressFolder: Zip a folder into its parent dir (local & SSH remote)
  * - fetchImageAsBase64: Fetch image from URL and return as base64
@@ -45,6 +46,7 @@ import {
 	directorySizeRemote,
 	renameRemote,
 	deleteRemote,
+	deleteManyRemote,
 	existsRemote,
 	countItemsRemote,
 	compressFolderRemote,
@@ -56,6 +58,7 @@ import { resolveDirentType } from '../../utils/dirent-utils';
 import { getDragOutIcon } from '../../utils/drag-out-icon';
 import { getSshRemoteById } from '../../stores';
 import { captureException } from '../../utils/sentry';
+import { mapWithConcurrency, LOCAL_FILE_DELETE_CONCURRENCY } from '../../utils/concurrency';
 
 /**
  * Recursively upload a local directory to a remote host over SSH.
@@ -206,6 +209,31 @@ async function resolveUniqueZipPath(
 		candidate = `${basePath}-${suffix}.zip`;
 	}
 	return candidate;
+}
+
+/** Outcome of one path in a `fs:deleteMany` batch. */
+interface BulkDeleteResult {
+	path: string;
+	success: boolean;
+	error?: string;
+}
+
+/**
+ * Delete one local file or directory.
+ *
+ * Shared by `fs:delete` and `fs:deleteMany` so the two cannot drift on what
+ * "delete" means. The `stat` is what decides between `rm` and `unlink`, and it
+ * stays here rather than being folded into an unconditional `fs.rm(..., {
+ * recursive })`: with `recursive: false` an explicit stat is what lets a
+ * directory fail as a directory instead of surfacing as a bare `ERR_FS_EISDIR`.
+ */
+async function deleteLocalPath(targetPath: string, recursive: boolean): Promise<void> {
+	const stat = await fs.stat(targetPath);
+	if (stat.isDirectory()) {
+		await fs.rm(targetPath, { recursive, force: true });
+	} else {
+		await fs.unlink(targetPath);
+	}
 }
 
 export function registerFilesystemHandlers(): void {
@@ -786,17 +814,78 @@ export function registerFilesystemHandlers(): void {
 					return { success: true };
 				}
 
-				// Local: standard fs delete
-				const stat = await fs.stat(targetPath);
-				if (stat.isDirectory()) {
-					await fs.rm(targetPath, { recursive: options?.recursive ?? true, force: true });
-				} else {
-					await fs.unlink(targetPath);
-				}
+				await deleteLocalPath(targetPath, options?.recursive ?? true);
 				return { success: true };
 			} catch (error) {
 				throw new Error(`Failed to delete: ${error}`);
 			}
+		}
+	);
+
+	// Delete a batch of files/folders in ONE IPC call (supports SSH remote).
+	//
+	// The renderer used to loop `fs:delete` per path, which serialized a full
+	// round trip - plus a `stat` and the SSH handshake - behind every single
+	// file. On a slow volume or a remote host that per-file latency is the whole
+	// cost, and a 125-file multi-select took over 30 seconds (issue #1423).
+	//
+	// Unlike `fs:delete` this RESOLVES with a per-path outcome instead of
+	// throwing on the first failure: a partial delete is the normal case for a
+	// bulk operation (one locked or permission-denied file among many), and the
+	// caller needs to know which paths survived so it can report and attribute
+	// them rather than losing the whole batch to one bad entry.
+	ipcMain.handle(
+		'fs:deleteMany',
+		async (
+			_,
+			targetPaths: string[],
+			options?: { recursive?: boolean; sshRemoteId?: string }
+		): Promise<{ results: BulkDeleteResult[] }> => {
+			if (!Array.isArray(targetPaths) || targetPaths.length === 0) {
+				return { results: [] };
+			}
+
+			const recursive = options?.recursive ?? true;
+			const sshRemoteId = options?.sshRemoteId;
+
+			// SSH remote: one `rm` for the whole batch rather than one per path.
+			if (sshRemoteId) {
+				const sshConfig = getSshRemoteById(sshRemoteId);
+				if (!sshConfig) {
+					// An unresolvable remote is a configuration failure, not a
+					// per-path one - fail the call rather than reporting 125
+					// identical path errors.
+					throw new Error(`SSH remote not found: ${sshRemoteId}`);
+				}
+				const remoteResults = await deleteManyRemote(targetPaths, sshConfig, recursive);
+				return {
+					results: remoteResults.map((result, index) => ({
+						path: targetPaths[index],
+						success: result.success,
+						...(result.success ? {} : { error: result.error || 'Failed to delete remote file' }),
+					})),
+				};
+			}
+
+			// Local: overlap the deletes so per-file latency stops being additive.
+			const results = await mapWithConcurrency(
+				targetPaths,
+				LOCAL_FILE_DELETE_CONCURRENCY,
+				async (targetPath): Promise<BulkDeleteResult> => {
+					try {
+						await deleteLocalPath(targetPath, recursive);
+						return { path: targetPath, success: true };
+					} catch (error) {
+						return {
+							path: targetPath,
+							success: false,
+							error: error instanceof Error ? error.message : String(error),
+						};
+					}
+				}
+			);
+
+			return { results };
 		}
 	);
 

--- a/src/main/preload/fs.ts
+++ b/src/main/preload/fs.ts
@@ -191,6 +191,23 @@ export function createFsApi() {
 		): Promise<{ success: boolean }> => ipcRenderer.invoke('fs:delete', targetPath, options),
 
 		/**
+		 * Delete a batch of files/directories in a single IPC call.
+		 *
+		 * Prefer this over looping `delete` for a multi-selection: one round
+		 * trip instead of N, deletes overlapped locally, and collapsed into a
+		 * single remote `rm` over SSH.
+		 *
+		 * Resolves with one entry per input path (in input order) rather than
+		 * rejecting on the first failure, so a partially-successful batch still
+		 * reports exactly which paths survived.
+		 */
+		deleteMany: (
+			targetPaths: string[],
+			options?: { recursive?: boolean; sshRemoteId?: string }
+		): Promise<{ results: Array<{ path: string; success: boolean; error?: string }> }> =>
+			ipcRenderer.invoke('fs:deleteMany', targetPaths, options),
+
+		/**
 		 * Zip a folder into a `.zip` written beside it in its parent directory.
 		 * The archive is named after the folder, falling back to `name-1.zip`,
 		 * `name-2.zip`, ... when that name is taken. Resolves with the absolute

--- a/src/main/utils/concurrency.ts
+++ b/src/main/utils/concurrency.ts
@@ -18,6 +18,18 @@
 export const REMOTE_SESSION_READ_CONCURRENCY = 6;
 
 /**
+ * Cap on parallel local filesystem deletes when removing a multi-selection.
+ *
+ * Deleting sequentially costs one full renderer->main round trip plus one
+ * `stat` per file; on a slow volume (a network share or an external disk) that
+ * per-file latency dominates, and 125 files took over 30 seconds (issue #1423).
+ * Overlapping the deletes hides that latency. The cap keeps a large selection
+ * from flooding libuv's threadpool and starving unrelated filesystem work in
+ * the main process, and past ~16 the threadpool serializes anyway.
+ */
+export const LOCAL_FILE_DELETE_CONCURRENCY = 16;
+
+/**
  * Map `items` with a bounded concurrency.
  *
  * Spawns up to `limit` workers that pull from a shared cursor; results are

--- a/src/main/utils/remote-fs.ts
+++ b/src/main/utils/remote-fs.ts
@@ -1160,6 +1160,111 @@ export async function deleteRemote(
 }
 
 /**
+ * Conservative cap on the byte length of a single batched `rm` command line.
+ *
+ * The command is executed by the remote login shell, so what actually bounds it
+ * is the remote host's `ARG_MAX` (256 KB on macOS, typically 2 MB on Linux),
+ * minus the environment. 32 KB sits far below the smallest of those on any host
+ * we might land on, and still fits well over a thousand ordinary paths per
+ * round trip, so the chunking never becomes the bottleneck.
+ */
+const REMOTE_DELETE_COMMAND_MAX_BYTES = 32 * 1024;
+
+/**
+ * Split escaped paths into chunks whose joined command line stays under
+ * `REMOTE_DELETE_COMMAND_MAX_BYTES`. A single path longer than the cap still
+ * gets its own chunk rather than being dropped: the remote shell is then the
+ * one to reject it, with a real error, instead of us silently skipping it.
+ */
+function chunkEscapedPaths(escapedPaths: string[], prefixBytes: number): string[][] {
+	const chunks: string[][] = [];
+	let current: string[] = [];
+	let currentBytes = prefixBytes;
+
+	for (const escaped of escapedPaths) {
+		// +1 for the space separating this argument from the previous one.
+		const cost = Buffer.byteLength(escaped, 'utf8') + 1;
+		if (current.length > 0 && currentBytes + cost > REMOTE_DELETE_COMMAND_MAX_BYTES) {
+			chunks.push(current);
+			current = [];
+			currentBytes = prefixBytes;
+		}
+		current.push(escaped);
+		currentBytes += cost;
+	}
+
+	if (current.length > 0) {
+		chunks.push(current);
+	}
+	return chunks;
+}
+
+/**
+ * Delete many files or directories on a remote host via SSH in as few round
+ * trips as possible.
+ *
+ * `deleteRemote` opens one SSH connection per path. Deleting a multi-select of
+ * 125 files that way means 125 handshakes, which is what made bulk delete take
+ * over 30 seconds (issue #1423). This passes the whole set to a single `rm` per
+ * chunk instead, so the usual case is one round trip regardless of count.
+ *
+ * `rm` reports failures on stderr but exits non-zero without saying WHICH
+ * argument failed, so a failed chunk is retried one path at a time to recover
+ * per-path attribution. That fallback only runs on the error path, so the happy
+ * path stays at one connection.
+ *
+ * @param targetPaths Paths to delete
+ * @param sshRemote SSH remote configuration
+ * @param recursive Whether to recursively delete directories (default: true)
+ * @param deps Optional dependencies for testing
+ * @returns One result per input path, in input order
+ */
+export async function deleteManyRemote(
+	targetPaths: string[],
+	sshRemote: SshRemoteConfig,
+	recursive: boolean = true,
+	deps: RemoteFsDeps = defaultDeps
+): Promise<RemoteFsResult<void>[]> {
+	if (targetPaths.length === 0) return [];
+
+	// Use rm -rf for recursive delete (directories), rm -f for files.
+	// The -f flag prevents errors if a path doesn't exist.
+	const rmFlags = recursive ? '-rf' : '-f';
+	const commandPrefix = `rm ${rmFlags} `;
+
+	// Escape once, then chunk on the escaped length - that is what the remote
+	// shell actually has to fit, and escaping can grow a path substantially.
+	const escapedPaths = targetPaths.map((p) => shellEscapeRemotePath(p));
+	const indices = targetPaths.map((_, i) => i);
+	const results: RemoteFsResult<void>[] = new Array(targetPaths.length);
+
+	let cursor = 0;
+	for (const chunk of chunkEscapedPaths(escapedPaths, Buffer.byteLength(commandPrefix, 'utf8'))) {
+		const chunkIndices = indices.slice(cursor, cursor + chunk.length);
+		cursor += chunk.length;
+
+		const result = await execRemoteCommand(sshRemote, commandPrefix + chunk.join(' '), deps);
+
+		if (result.exitCode === 0) {
+			for (const index of chunkIndices) {
+				results[index] = { success: true };
+			}
+			continue;
+		}
+
+		// The chunk failed as a whole and `rm` won't tell us which path was at
+		// fault, so fall back to per-path deletes to attribute the failure. Some
+		// of these will succeed - `rm` keeps going past a bad argument, so a
+		// non-zero exit does not mean nothing in the chunk was removed.
+		for (const index of chunkIndices) {
+			results[index] = await deleteRemote(targetPaths[index], sshRemote, recursive, deps);
+		}
+	}
+
+	return results;
+}
+
+/**
  * Zip a directory on a remote host via SSH.
  *
  * Runs `zip -r` from the folder's parent so the archive contains the folder

--- a/src/renderer/components/FileExplorerPanel/hooks/useFileContextMenu.ts
+++ b/src/renderer/components/FileExplorerPanel/hooks/useFileContextMenu.ts
@@ -405,29 +405,48 @@ export function useFileContextMenu({
 		setIsMultiDeleting(true);
 		let succeeded = 0;
 		let failed = 0;
-		let lastError: unknown = null;
+		let lastError: string | null = null;
+		// The batch reports per-path failures in its result, so a THROW out of it
+		// means the whole call failed (an unresolvable SSH remote, a dead IPC
+		// bridge) and nothing was deleted. That is a different message from the
+		// refresh failing after the files are already gone.
+		let batchCompleted = false;
 
 		try {
-			for (const item of multiDeleteModal.nodes) {
-				const absolutePath = `${session.fullPath}/${item.path}`;
-				try {
-					await window.maestro.fs.delete(absolutePath, { sshRemoteId });
+			// ONE IPC call for the whole selection. Deleting these one at a time
+			// put a full round trip (and an SSH handshake, when remote) in front
+			// of every file, so the cost scaled with the slowest volume rather
+			// than with the work: 125 files took over 30 seconds (issue #1423).
+			const nodesByAbsolutePath = new Map(
+				multiDeleteModal.nodes.map((item) => [`${session.fullPath}/${item.path}`, item])
+			);
+			const { results } = await window.maestro.fs.deleteMany([...nodesByAbsolutePath.keys()], {
+				sshRemoteId,
+			});
+			batchCompleted = true;
+
+			for (const result of results) {
+				if (result.success) {
 					succeeded++;
-				} catch (error) {
-					failed++;
-					lastError = error;
-					captureException(error, {
-						extra: {
-							action: 'delete-multi',
-							path: item.path,
-							absolutePath,
-							nodeName: item.node.name,
-							nodeType: item.node.type,
-							sessionId: session.id,
-							sshRemoteId,
-						},
-					});
+					continue;
 				}
+				failed++;
+				lastError = result.error ?? 'Unknown error';
+				// The batch resolves with per-path outcomes instead of throwing,
+				// so report each failure here to keep the Sentry breadcrumb the
+				// per-file loop used to produce.
+				const item = nodesByAbsolutePath.get(result.path);
+				captureException(new Error(lastError), {
+					extra: {
+						action: 'delete-multi',
+						path: item?.path,
+						absolutePath: result.path,
+						nodeName: item?.node.name,
+						nodeType: item?.node.type,
+						sessionId: session.id,
+						sshRemoteId,
+					},
+				});
 			}
 
 			await refreshFileTree(session.id);
@@ -436,19 +455,18 @@ export function useFileContextMenu({
 			} else if (succeeded > 0 && failed > 0) {
 				onShowFlash?.(`Deleted ${succeeded}, ${failed} failed`);
 			} else if (failed > 0) {
-				const msg = lastError instanceof Error ? lastError.message : 'Unknown error';
-				onShowFlash?.(`Delete failed: ${msg}`);
+				onShowFlash?.(`Delete failed: ${lastError ?? 'Unknown error'}`);
 			}
 		} catch (error) {
 			captureException(error, {
 				extra: {
-					action: 'delete-multi-refresh',
+					action: batchCompleted ? 'delete-multi-refresh' : 'delete-multi-batch',
 					sessionId: session.id,
+					sshRemoteId,
 				},
 			});
-			onShowFlash?.(
-				`Delete refresh failed: ${error instanceof Error ? error.message : 'Unknown error'}`
-			);
+			const msg = error instanceof Error ? error.message : 'Unknown error';
+			onShowFlash?.(batchCompleted ? `Delete refresh failed: ${msg}` : `Delete failed: ${msg}`);
 			throw error;
 		} finally {
 			setSelectedPaths(new Set());

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -1089,6 +1089,14 @@ interface MaestroAPI {
 			targetPath: string,
 			options?: { recursive?: boolean; sshRemoteId?: string }
 		) => Promise<{ success: boolean }>;
+		/**
+		 * Delete many paths in one IPC call. Resolves with a per-path outcome in
+		 * input order instead of rejecting on the first failure.
+		 */
+		deleteMany: (
+			targetPaths: string[],
+			options?: { recursive?: boolean; sshRemoteId?: string }
+		) => Promise<{ results: Array<{ path: string; success: boolean; error?: string }> }>;
 		countItems: (
 			dirPath: string,
 			sshRemoteId?: string


### PR DESCRIPTION
closes #1423

## The problem

Bulk-deleting a multi-selection in the Files panel looped `fs:delete` once per path:

```ts
for (const item of multiDeleteModal.nodes) {
    await window.maestro.fs.delete(absolutePath, { sshRemoteId });
}
```

Every single file paid a full renderer -> main IPC round trip plus a `stat`, and over SSH a fresh handshake on top. Nothing here is parallel, so the total cost scaled with the latency of the slowest volume rather than with the actual work. The reporter's agent working directories live on an external volume, which is exactly the case where that per-file latency dominates: 125 files took over 30 seconds.

The single-file cost is not the bug. The bug is that it is paid 125 times in series.

## The fix

A new `fs:deleteMany` IPC handler that takes the whole selection at once.

**Local** deletes are overlapped at `LOCAL_FILE_DELETE_CONCURRENCY` (16) via the existing `mapWithConcurrency`, which hides the per-file latency instead of summing it. The cap keeps a large selection from flooding libuv's threadpool and starving unrelated filesystem work in the main process; past ~16 the threadpool serializes anyway.

**Remote** deletes collapse into a single `rm` per chunk via a new `deleteManyRemote`, so the usual case is one SSH connection regardless of file count. Chunking keeps each command line under 32 KB, far below the smallest remote `ARG_MAX` (256 KB on macOS), while still fitting well over a thousand ordinary paths per round trip. `rm` exits non-zero without naming the offending argument, so a failed chunk is replayed one path at a time to recover per-path attribution - that fallback only runs on the error path, so the happy path stays at one connection.

## Partial failure is a first-class result, not an exception

Unlike `fs:delete`, the batch **resolves** with a per-path outcome rather than throwing on the first failure:

```ts
{ results: Array<{ path: string; success: boolean; error?: string }> }
```

A partial delete is the normal case for a bulk operation - one locked or permission-denied file among many - and the caller needs to know *which* paths survived so it can report them and keep the per-file Sentry attribution the old loop produced. Throwing would lose the whole batch to one bad entry. The existing `Deleted N, M failed` flash still works, now driven off the result array.

The one case that still throws is an unresolvable SSH remote: that is a configuration failure for the whole call, not N identical per-path errors, and it must never fall through to a *local* delete of paths the user meant to remove on a remote host.

## Other notes

- `fs:delete` and `fs:deleteMany` now share a `deleteLocalPath` helper, so the two cannot drift on what "delete" means. `fs:delete`'s observable behavior is unchanged.
- The renderer's outer catch previously reported any throw as `Delete refresh failed`. Now that a whole-batch failure can also land there, it distinguishes the two - saying "refresh failed" when nothing was deleted was misleading.

## Testing

- New `fs:deleteMany` handler tests: batching, partial failure attribution, dir-vs-file routing, the SSH batch path, unresolvable remote, empty batch.
- New `deleteManyRemote` tests: single round trip for N paths, `-rf` vs `-f`, shell-escaping a hostile filename (asserts the exact escaped command, since batching several paths onto one command line makes escaping load-bearing), chunking a batch too large for one command line, and per-path replay after a chunk failure.
- Updated the existing multi-delete hook test to assert one batched call instead of N, plus a new partial-failure case.
- Full suite: 34,387 passed, 0 failed. `npm run lint`, ESLint, and Prettier clean.

Not verified: an end-to-end timing measurement on a real external volume - I don't have the reporter's setup. The change removes the serialization that accounts for the reported behavior, but confirming the actual wall-clock improvement needs @ronaldeddings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch deletion for multiple files and folders.
  * Deletions now run efficiently in batches, including remote locations.
  * Results identify successful and failed paths individually.

* **Bug Fixes**
  * Partial deletion failures are reported accurately while successful deletions continue.
  * Improved handling and safety for remote paths, including large batches and special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->