### PR TITLE
feat(codex): surface Codex custom slash commands in the composer

### DIFF
--- a/docs/provider-notes.md
+++ b/docs/provider-notes.md
@@ -73,21 +73,24 @@ For [SSH remote agents](/ssh-remote-execution), maestro-p must be installed on t
 
 ## Codex (OpenAI)
 
-| Feature            | Support                                    |
-| ------------------ | ------------------------------------------ |
-| Image attachments  | ⚠️ New sessions only (not on resume)       |
-| Session resume     | ✅ `exec resume <id>`                      |
-| Read-only mode     | ✅ `--sandbox read-only`                   |
-| Slash commands     | ❌ Interactive TUI only (not in exec mode) |
-| Cost tracking      | ❌ Token counts only (no pricing)          |
-| Model selection    | ✅ `-m, --model` flag                      |
-| Context operations | ✅ Merge, export, and transfer             |
-| Thinking display   | ✅ Reasoning tokens (o3/o4-mini)           |
+| Feature            | Support                                               |
+| ------------------ | ----------------------------------------------------- |
+| Image attachments  | ⚠️ New sessions only (not on resume)                  |
+| Session resume     | ✅ `exec resume <id>`                                 |
+| Read-only mode     | ✅ `--sandbox read-only`                              |
+| Slash commands     | ✅ Custom skills and prompts (built-ins are TUI only) |
+| Cost tracking      | ❌ Token counts only (no pricing)                     |
+| Model selection    | ✅ `-m, --model` flag                                 |
+| Context operations | ✅ Merge, export, and transfer                        |
+| Thinking display   | ✅ Reasoning tokens (o3/o4-mini)                      |
 
 **Notes**:
 
 - Codex's `resume` subcommand doesn't accept the `-i/--image` flag. Images can only be attached when starting a new session. Maestro hides the attach image button when resuming Codex sessions.
-- Codex has [slash commands](https://developers.openai.com/codex/cli/slash-commands) (`/compact`, `/diff`, `/model`, etc.) but they only work in interactive TUI mode, not in `exec` mode which Maestro uses.
+- Your **custom** Codex commands appear in Maestro's `/` autocomplete. Maestro reads them straight off disk from `<CODEX_HOME>/skills/<name>/SKILL.md` and `.codex/skills/` (plus `<CODEX_HOME>/prompts/*.md` on older Codex builds), so no extra setup is needed. `CODEX_HOME` is honoured, and a project-local command shadows a global one with the same name. A skill marked `user-invocable: false` is skipped, matching Codex's own picker.
+- Because Maestro drives Codex through `codex exec`, the CLI never expands the slash itself. Maestro substitutes the command's file contents before sending, so the agent receives the fully expanded prompt.
+- Codex's **built-in** [slash commands](https://developers.openai.com/codex/cli/slash-commands) (`/compact`, `/diff`, `/model`, etc.) are still unavailable: they are implemented inside the interactive TUI and have no on-disk prompt to expand.
+- Codex commands on an SSH remote agent are not discovered yet, since the skills live on the remote host.
 
 ## OpenCode
 

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -174,9 +174,30 @@ See [OpenSpec Commands](/openspec-commands) for the complete workflow guide and 
 
 ## Agent Native Commands
 
-When using Claude Code, Maestro automatically discovers and displays the agent's native slash commands in the autocomplete menu. These commands are sent via the `system/init` event when Claude Code starts and appear with a "Claude Code command" label to distinguish them from Maestro's custom commands.
+Maestro automatically discovers the commands your provider already knows about and
+shows them in the `/` autocomplete alongside Maestro's own. How they are discovered
+depends on the provider:
 
-### Supported in Batch Mode
+| Provider    | Discovered from                                                                                    |
+| ----------- | -------------------------------------------------------------------------------------------------- |
+| Claude Code | The `system/init` event when the agent starts                                                      |
+| Codex       | `<CODEX_HOME>/skills/<name>/SKILL.md`, `.codex/skills/`, and `<CODEX_HOME>/prompts/*.md`           |
+| OpenCode    | `.opencode/commands/*.md`, `~/.opencode/commands/*.md`, and the `command` block in `opencode.json` |
+| Copilot CLI | A built-in list                                                                                    |
+
+For Codex and OpenCode, Maestro expands the command itself: the file's contents are
+substituted into your message before it is sent, because both CLIs run headless under
+Maestro and would otherwise receive a literal `/name`. A project-local command shadows
+a global one with the same name, and a Codex skill marked `user-invocable: false` is
+skipped, matching Codex's own picker.
+
+<Note>
+Provider **built-in** commands (`/compact`, `/model`, `/review`, ...) only work where the
+CLI implements them outside its interactive TUI. For Codex and OpenCode they are not
+offered at all, since there is no on-disk prompt for Maestro to expand.
+</Note>
+
+### Claude Code: Supported in Batch Mode
 
 Claude Code runs in batch/print mode within Maestro, which means only certain native commands work. The following commands are **supported**:
 
@@ -192,7 +213,7 @@ Claude Code runs in batch/print mode within Maestro, which means only certain na
 
 Additionally, any **custom commands from Claude Code plugins/skills** (e.g., `/commit`, `/pdf`, `/docx`) are fully supported and will appear in the autocomplete menu.
 
-### Not Supported in Batch Mode
+### Claude Code: Not Supported in Batch Mode
 
 The following Claude Code commands are **interactive-only** and don't work through Maestro:
 

--- a/src/__tests__/main/agents/capabilities.test.ts
+++ b/src/__tests__/main/agents/capabilities.test.ts
@@ -101,7 +101,8 @@ describe('agent-capabilities', () => {
 			expect(capabilities.supportsUsageStats).toBe(true);
 			expect(capabilities.supportsBatchMode).toBe(true);
 			expect(capabilities.supportsStreaming).toBe(true);
-			expect(capabilities.supportsSlashCommands).toBe(false);
+			// Custom skills/prompts read off disk and expanded renderer-side.
+			expect(capabilities.supportsSlashCommands).toBe(true);
 			expect(capabilities.supportsResultMessages).toBe(false);
 			expect(capabilities.imageResumeMode).toBe('prompt-embed');
 		});

--- a/src/__tests__/main/agents/codex-config.test.ts
+++ b/src/__tests__/main/agents/codex-config.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for Codex config utilities
+ *
+ * Covers CODEX_HOME resolution, skill/prompt directory ordering, and the
+ * frontmatter scanner that decides whether a file is offered as a `/command`.
+ *
+ * Path assertions are built with path.join so they hold on both CI legs -
+ * POSIX literals pass locally and fail only on windows-latest.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as os from 'os';
+import * as path from 'path';
+import {
+	getCodexHome,
+	getCodexSkillDirs,
+	getCodexPromptDirs,
+	parseCodexMarkdownDoc,
+} from '../../../main/agents/codex-config';
+
+describe('codex-config', () => {
+	describe('getCodexHome', () => {
+		it('defaults to ~/.codex', () => {
+			expect(getCodexHome({})).toBe(path.join(os.homedir(), '.codex'));
+		});
+
+		it('honours CODEX_HOME so an alternate profile is probed', () => {
+			expect(getCodexHome({ CODEX_HOME: path.join('/custom', 'codex') })).toBe(
+				path.join('/custom', 'codex')
+			);
+		});
+	});
+
+	describe('getCodexSkillDirs', () => {
+		it('puts the project-local dir ahead of the global one', () => {
+			expect(getCodexSkillDirs(path.join('/project'), {})).toEqual([
+				path.join('/project', '.codex', 'skills'),
+				path.join(os.homedir(), '.codex', 'skills'),
+			]);
+		});
+
+		it('omits the project dir when there is no cwd', () => {
+			expect(getCodexSkillDirs(undefined, {})).toEqual([
+				path.join(os.homedir(), '.codex', 'skills'),
+			]);
+		});
+	});
+
+	describe('getCodexPromptDirs', () => {
+		it('probes both the project and global prompt dirs', () => {
+			expect(getCodexPromptDirs(path.join('/project'), { CODEX_HOME: path.join('/ch') })).toEqual([
+				path.join('/project', '.codex', 'prompts'),
+				path.join('/ch', 'prompts'),
+			]);
+		});
+	});
+
+	describe('parseCodexMarkdownDoc', () => {
+		it('extracts name and description and strips the frontmatter', () => {
+			const doc = parseCodexMarkdownDoc(
+				[
+					'---',
+					'name: ship-it',
+					'description: Cut a release',
+					'---',
+					'',
+					'# Ship It',
+					'Do the thing.',
+				].join('\n')
+			);
+			expect(doc.name).toBe('ship-it');
+			expect(doc.description).toBe('Cut a release');
+			expect(doc.userInvocable).toBe(true);
+			expect(doc.body).toBe('# Ship It\nDo the thing.');
+		});
+
+		it('strips surrounding quotes from frontmatter values', () => {
+			const doc = parseCodexMarkdownDoc(
+				['---', 'description: "Quoted: value"', '---', 'body'].join('\n')
+			);
+			expect(doc.description).toBe('Quoted: value');
+		});
+
+		it('treats user-invocable: false as not offerable', () => {
+			const doc = parseCodexMarkdownDoc(
+				['---', 'name: internal', 'user-invocable: false', '---', 'body'].join('\n')
+			);
+			expect(doc.userInvocable).toBe(false);
+		});
+
+		it('defaults userInvocable to true when the key is absent', () => {
+			expect(
+				parseCodexMarkdownDoc(['---', 'name: x', '---', 'body'].join('\n')).userInvocable
+			).toBe(true);
+		});
+
+		it('ignores an indented description nested under metadata', () => {
+			const doc = parseCodexMarkdownDoc(
+				[
+					'---',
+					'name: nested',
+					'metadata:',
+					'  description: not the skill description',
+					'---',
+					'body',
+				].join('\n')
+			);
+			expect(doc.description).toBeUndefined();
+		});
+
+		it('treats a file without frontmatter as an all-body prompt', () => {
+			const doc = parseCodexMarkdownDoc('Just a prompt body.\n');
+			expect(doc.name).toBeUndefined();
+			expect(doc.userInvocable).toBe(true);
+			expect(doc.body).toBe('Just a prompt body.');
+		});
+
+		it('keeps the whole file when the frontmatter block is never closed', () => {
+			const raw = '---\nname: broken\nstill going';
+			expect(parseCodexMarkdownDoc(raw).body).toBe(raw);
+		});
+
+		it('parses CRLF files, so a Windows-authored skill is not skipped', () => {
+			const doc = parseCodexMarkdownDoc(
+				'---\r\nname: crlf\r\ndescription: Works\r\n---\r\nbody\r\n'
+			);
+			expect(doc.name).toBe('crlf');
+			expect(doc.description).toBe('Works');
+			expect(doc.body).toBe('body');
+		});
+	});
+});

--- a/src/__tests__/main/ipc/handlers/agents.test.ts
+++ b/src/__tests__/main/ipc/handlers/agents.test.ts
@@ -23,6 +23,7 @@ vi.mock('electron', () => ({
 // Mock agents module (capabilities exports)
 vi.mock('../../../../main/agents', async () => {
 	const opencodeConfig = await import('../../../../main/agents/opencode-config');
+	const codexConfig = await import('../../../../main/agents/codex-config');
 	return {
 		getAgentCapabilities: vi.fn(),
 		AGENT_DEFINITIONS: [
@@ -53,6 +54,9 @@ vi.mock('../../../../main/agents', async () => {
 		extractModelsFromConfig: opencodeConfig.extractModelsFromConfig,
 		getOpenCodeConfigPaths: opencodeConfig.getOpenCodeConfigPaths,
 		getOpenCodeCommandDirs: opencodeConfig.getOpenCodeCommandDirs,
+		getCodexSkillDirs: codexConfig.getCodexSkillDirs,
+		getCodexPromptDirs: codexConfig.getCodexPromptDirs,
+		parseCodexMarkdownDoc: codexConfig.parseCodexMarkdownDoc,
 	};
 });
 
@@ -97,6 +101,8 @@ vi.mock('../../../../main/utils/stripAnsi', () => ({
 import { execFileNoThrow } from '../../../../main/utils/execFile';
 import { buildSshCommand } from '../../../../main/utils/ssh-command-builder';
 import * as fs from 'fs';
+import * as path from 'path';
+import { getCodexSkillDirs, getCodexPromptDirs } from '../../../../main/agents/codex-config';
 
 describe('agents IPC handlers', () => {
 	let handlers: Map<string, Function>;
@@ -1354,15 +1360,15 @@ describe('agents IPC handlers', () => {
 
 		it('should return null for unsupported agents', async () => {
 			const mockAgent = {
-				id: 'codex',
+				id: 'terminal',
 				available: true,
-				path: '/usr/bin/codex',
+				path: '/bin/bash',
 			};
 
 			mockAgentDetector.getAgent.mockResolvedValue(mockAgent);
 
 			const handler = handlers.get('agents:discoverSlashCommands');
-			const result = await handler!({} as any, 'codex', '/test');
+			const result = await handler!({} as any, 'terminal', '/test');
 
 			expect(result).toBeNull();
 			expect(execFileNoThrow).not.toHaveBeenCalled();
@@ -1621,6 +1627,178 @@ describe('agents IPC handlers', () => {
 
 			const handler = handlers.get('agents:discoverSlashCommands');
 			await expect(handler!({} as any, 'opencode', '/test')).rejects.toThrow('EACCES');
+		});
+
+		// ---- Codex (issue #1434) -------------------------------------------
+		// Codex custom commands live on disk as skills / prompts. Maestro drives
+		// Codex through headless `codex exec`, which does NOT expand a slash, so
+		// every discovered command must carry its body as `prompt` for the
+		// renderer to substitute before sending.
+
+		const codexAgent = { id: 'codex', available: true, path: '/usr/bin/codex' };
+		const enoentError = () => Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+
+		/** Build a readdir/readFile pair backed by a virtual path -> content map. */
+		const mockCodexDisk = (
+			dirs: Record<string, { name: string; isDirectory: () => boolean }[]>,
+			files: Record<string, string>
+		) => {
+			vi.mocked(fs.promises.readdir).mockImplementation(async (dir: any) => {
+				const entries = dirs[String(dir)];
+				if (!entries) throw enoentError();
+				return entries as any;
+			});
+			vi.mocked(fs.promises.readFile).mockImplementation(async (filePath: any) => {
+				const content = files[String(filePath)];
+				if (content === undefined) throw enoentError();
+				return content;
+			});
+		};
+
+		it('discovers Codex skills and carries SKILL.md body as the prompt', async () => {
+			mockAgentDetector.getAgent.mockResolvedValue(codexAgent);
+
+			const [projectSkills] = getCodexSkillDirs('/test');
+			mockCodexDisk(
+				{ [projectSkills]: [{ name: 'ship-it', isDirectory: () => true }] },
+				{
+					[path.join(projectSkills, 'ship-it', 'SKILL.md')]:
+						'---\nname: ship-it\ndescription: Cut a release\n---\n\nRun the release checklist.',
+				}
+			);
+
+			const handler = handlers.get('agents:discoverSlashCommands');
+			const result = await handler!({} as any, 'codex', '/test');
+
+			expect(result).toEqual([
+				{
+					name: 'ship-it',
+					description: 'Cut a release',
+					prompt: 'Run the release checklist.',
+				},
+			]);
+			// Discovery is pure disk reads - it must never spawn the CLI.
+			expect(execFileNoThrow).not.toHaveBeenCalled();
+		});
+
+		it('discovers legacy Codex prompts from <CODEX_HOME>/prompts/*.md', async () => {
+			mockAgentDetector.getAgent.mockResolvedValue(codexAgent);
+
+			const globalPrompts = getCodexPromptDirs('/test')[1];
+			// A prompts dir is read without withFileTypes, so it yields filenames.
+			vi.mocked(fs.promises.readdir).mockImplementation(async (dir: any) => {
+				if (String(dir) === globalPrompts) return ['triage.md', 'notes.txt'] as any;
+				throw enoentError();
+			});
+			vi.mocked(fs.promises.readFile).mockImplementation(async (filePath: any) => {
+				if (String(filePath) === path.join(globalPrompts, 'triage.md')) {
+					return 'Triage the open bugs.';
+				}
+				throw enoentError();
+			});
+
+			const handler = handlers.get('agents:discoverSlashCommands');
+			const result = await handler!({} as any, 'codex', '/test');
+
+			expect(result).toEqual([
+				{ name: 'triage', description: undefined, prompt: 'Triage the open bugs.' },
+			]);
+		});
+
+		it('skips Codex skills marked user-invocable: false', async () => {
+			mockAgentDetector.getAgent.mockResolvedValue(codexAgent);
+
+			const [projectSkills] = getCodexSkillDirs('/test');
+			mockCodexDisk(
+				{
+					[projectSkills]: [
+						{ name: 'background', isDirectory: () => true },
+						{ name: 'usable', isDirectory: () => true },
+					],
+				},
+				{
+					[path.join(projectSkills, 'background', 'SKILL.md')]:
+						'---\nname: background\nuser-invocable: false\n---\nReference only.',
+					[path.join(projectSkills, 'usable', 'SKILL.md')]: '---\nname: usable\n---\nDo it.',
+				}
+			);
+
+			const handler = handlers.get('agents:discoverSlashCommands');
+			const result = await handler!({} as any, 'codex', '/test');
+
+			expect(result.map((c: any) => c.name)).toEqual(['usable']);
+		});
+
+		it("skips Codex's internal .system skills directory", async () => {
+			mockAgentDetector.getAgent.mockResolvedValue(codexAgent);
+
+			const [projectSkills] = getCodexSkillDirs('/test');
+			mockCodexDisk(
+				{ [projectSkills]: [{ name: '.system', isDirectory: () => true }] },
+				{
+					[path.join(projectSkills, '.system', 'SKILL.md')]:
+						'---\nname: review-agent\n---\nInternal.',
+				}
+			);
+
+			const handler = handlers.get('agents:discoverSlashCommands');
+			expect(await handler!({} as any, 'codex', '/test')).toEqual([]);
+		});
+
+		it('lets a project-local Codex skill win over a same-named global one', async () => {
+			mockAgentDetector.getAgent.mockResolvedValue(codexAgent);
+
+			const [projectSkills, globalSkills] = getCodexSkillDirs('/test');
+			mockCodexDisk(
+				{
+					[projectSkills]: [{ name: 'dup', isDirectory: () => true }],
+					[globalSkills]: [{ name: 'dup', isDirectory: () => true }],
+				},
+				{
+					[path.join(projectSkills, 'dup', 'SKILL.md')]: 'project body',
+					[path.join(globalSkills, 'dup', 'SKILL.md')]: 'global body',
+				}
+			);
+
+			const handler = handlers.get('agents:discoverSlashCommands');
+			const result = await handler!({} as any, 'codex', '/test');
+
+			expect(result).toEqual([{ name: 'dup', description: undefined, prompt: 'project body' }]);
+		});
+
+		it('returns an empty list when Codex has no custom commands on disk', async () => {
+			mockAgentDetector.getAgent.mockResolvedValue(codexAgent);
+			vi.mocked(fs.promises.readdir).mockRejectedValue(enoentError());
+			vi.mocked(fs.promises.readFile).mockRejectedValue(enoentError());
+
+			const handler = handlers.get('agents:discoverSlashCommands');
+			expect(await handler!({} as any, 'codex', '/test')).toEqual([]);
+		});
+
+		it("returns null for an SSH-remote Codex agent rather than this machine's commands", async () => {
+			mockAgentDetector.getAgent.mockResolvedValue(codexAgent);
+
+			const [projectSkills] = getCodexSkillDirs('/test');
+			mockCodexDisk(
+				{ [projectSkills]: [{ name: 'local-only', isDirectory: () => true }] },
+				{ [path.join(projectSkills, 'local-only', 'SKILL.md')]: 'local body' }
+			);
+
+			const handler = handlers.get('agents:discoverSlashCommands');
+			const result = await handler!({} as any, 'codex', '/test', undefined, 'remote-1');
+
+			expect(result).toBeNull();
+			expect(fs.promises.readdir).not.toHaveBeenCalled();
+		});
+
+		it('rethrows non-ENOENT errors from Codex discovery so Sentry sees them', async () => {
+			mockAgentDetector.getAgent.mockResolvedValue(codexAgent);
+			vi.mocked(fs.promises.readdir).mockRejectedValue(
+				Object.assign(new Error('EACCES'), { code: 'EACCES' })
+			);
+
+			const handler = handlers.get('agents:discoverSlashCommands');
+			await expect(handler!({} as any, 'codex', '/test')).rejects.toThrow('EACCES');
 		});
 
 		it('should return null when agent is not available', async () => {

--- a/src/main/agents/capabilities.ts
+++ b/src/main/agents/capabilities.ts
@@ -109,7 +109,12 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 		supportsSessionId: true, // thread_id in thread.started event - Verified
 		supportsImageInput: true, // -i, --image flag - Documented
 		supportsImageInputOnResume: true, // Images are written to disk and paths embedded in prompt text (codex exec resume doesn't support -i flag)
-		supportsSlashCommands: false, // None - Verified
+		// Custom `/name` entries only: skills (<CODEX_HOME>/skills/<name>/SKILL.md,
+		// .codex/skills/) and legacy prompts (<CODEX_HOME>/prompts/*.md). Read off
+		// disk by discoverCodexSlashCommands and expanded renderer-side, since
+		// `codex exec` does not expand a slash itself. Codex's BUILT-IN commands
+		// stay unsupported - they are TUI-internal with no prompt to inline.
+		supportsSlashCommands: true,
 		supportsSessionStorage: true, // ~/.codex/sessions/YYYY/MM/DD/*.jsonl - Verified
 		supportsCostTracking: false, // Token counts only - Codex doesn't provide cost, pricing varies by model
 		supportsUsageStats: true, // usage in turn.completed events - Verified

--- a/src/main/agents/codex-config.ts
+++ b/src/main/agents/codex-config.ts
@@ -1,0 +1,109 @@
+/**
+ * Codex Configuration Utilities
+ *
+ * Shared helpers for resolving Codex's on-disk slash-command sources. Codex
+ * exposes two kinds of user-invocable `/name` entries in its TUI:
+ *
+ *   1. Skills   - `<CODEX_HOME>/skills/<name>/SKILL.md` and `<cwd>/.codex/skills/...`
+ *                 (the current surface, verified against codex-cli 0.144.1)
+ *   2. Prompts  - `<CODEX_HOME>/prompts/<name>.md` and `<cwd>/.codex/prompts/...`
+ *                 (the older custom-prompt surface, still probed so users on
+ *                 earlier Codex builds keep their commands)
+ *
+ * Both are plain markdown with optional YAML frontmatter, so they can be read
+ * without spawning the CLI. Maestro drives Codex in headless `codex exec` mode,
+ * where the CLI does NOT expand `/name` itself - so Maestro carries the file
+ * body as the command's `prompt` and expands it renderer-side, the same way
+ * OpenCode custom commands already work (see `opencode-config.ts`).
+ */
+
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * Resolve Codex's config home.
+ *
+ * Codex honours `CODEX_HOME` for every on-disk lookup (it is how `codex exec`
+ * is pointed at an alternate profile), so respect it here too rather than
+ * hard-coding `~/.codex` - otherwise a user running a non-default profile is
+ * offered commands that their Codex will never see.
+ */
+export function getCodexHome(env?: Record<string, string | undefined>): string {
+	const effectiveEnv = env ?? process.env;
+	return effectiveEnv.CODEX_HOME || path.join(os.homedir(), '.codex');
+}
+
+/**
+ * Ordered list of Codex skill directories to probe. Project-local first so a
+ * repo-scoped skill wins over a same-named global one.
+ */
+export function getCodexSkillDirs(
+	cwd?: string,
+	env?: Record<string, string | undefined>
+): string[] {
+	const dirs: string[] = [];
+	if (cwd) dirs.push(path.join(cwd, '.codex', 'skills'));
+	dirs.push(path.join(getCodexHome(env), 'skills'));
+	return dirs;
+}
+
+/**
+ * Ordered list of Codex custom-prompt directories to probe (pre-skills builds).
+ */
+export function getCodexPromptDirs(
+	cwd?: string,
+	env?: Record<string, string | undefined>
+): string[] {
+	const dirs: string[] = [];
+	if (cwd) dirs.push(path.join(cwd, '.codex', 'prompts'));
+	dirs.push(path.join(getCodexHome(env), 'prompts'));
+	return dirs;
+}
+
+export interface CodexMarkdownDoc {
+	/** `name:` from frontmatter, when present. */
+	name?: string;
+	/** `description:` from frontmatter, when present. */
+	description?: string;
+	/**
+	 * `user-invocable:` from frontmatter. Codex defaults this to true; `false`
+	 * marks a background/reference-only skill that has no `/name` entry.
+	 */
+	userInvocable: boolean;
+	/** Everything after the frontmatter block. */
+	body: string;
+}
+
+/**
+ * Parse the leading YAML frontmatter of a Codex skill/prompt file.
+ *
+ * Deliberately a line scanner rather than a YAML parse: these files are read
+ * on every agent focus, only three scalar keys are needed, and a malformed
+ * document must degrade to "no metadata, body is the whole file" instead of
+ * throwing away a command the user can see in their own Codex TUI.
+ */
+export function parseCodexMarkdownDoc(content: string): CodexMarkdownDoc {
+	const normalized = content.replace(/\r\n/g, '\n');
+	const doc: CodexMarkdownDoc = { userInvocable: true, body: normalized.trim() };
+
+	if (!normalized.startsWith('---\n')) return doc;
+	const endIndex = normalized.indexOf('\n---', 3);
+	if (endIndex === -1) return doc;
+
+	const frontmatter = normalized.slice(4, endIndex);
+	doc.body = normalized.slice(endIndex + 4).trim();
+
+	// Top-level keys only: `metadata:` nests its own indented block, and an
+	// indented `description:` under it is not the skill's description.
+	for (const line of frontmatter.split('\n')) {
+		const match = /^([A-Za-z][\w-]*):\s*(.*)$/.exec(line);
+		if (!match) continue;
+		const key = match[1];
+		const value = match[2].trim().replace(/^["']|["']$/g, '');
+		if (key === 'name' && value) doc.name = value;
+		else if (key === 'description' && value) doc.description = value;
+		else if (key === 'user-invocable') doc.userInvocable = value !== 'false';
+	}
+
+	return doc;
+}

--- a/src/main/agents/index.ts
+++ b/src/main/agents/index.ts
@@ -62,6 +62,15 @@ export {
 	discoverModelsFromLocalConfigs,
 } from './opencode-config';
 
+// ============ Codex Config ============
+export {
+	type CodexMarkdownDoc,
+	getCodexHome,
+	getCodexSkillDirs,
+	getCodexPromptDirs,
+	parseCodexMarkdownDoc,
+} from './codex-config';
+
 // ============ Session Storage ============
 export {
 	type AgentSessionOrigin,

--- a/src/main/ipc/handlers/agents.ts
+++ b/src/main/ipc/handlers/agents.ts
@@ -12,6 +12,9 @@ import {
 	extractModelsFromConfig,
 	getOpenCodeConfigPaths,
 	getOpenCodeCommandDirs,
+	getCodexSkillDirs,
+	getCodexPromptDirs,
+	parseCodexMarkdownDoc,
 } from '../../agents';
 import { capabilitySnapshots } from '../../agents/capability-snapshot';
 import type { AgentCapabilitiesSnapshotMap } from '../../../shared/agentCapabilities';
@@ -262,6 +265,101 @@ async function discoverOpenCodeSlashCommands(cwd: string): Promise<DiscoveredCom
 
 	const commandList = Array.from(commands.values());
 	logger.info(`Discovered ${commandList.length} OpenCode slash commands`, LOG_CONTEXT);
+	return commandList;
+}
+
+/**
+ * Discover Codex slash commands by reading from disk.
+ *
+ * Codex commands come from these sources (checked in priority order):
+ * 1. Project-local skills:  <cwd>/.codex/skills/<name>/SKILL.md
+ * 2. User-global skills:    <CODEX_HOME>/skills/<name>/SKILL.md
+ * 3. Project-local prompts: <cwd>/.codex/prompts/<name>.md
+ * 4. User-global prompts:   <CODEX_HOME>/prompts/<name>.md
+ *
+ * Every discovered command carries the file body as its `prompt`, because
+ * Maestro drives Codex through headless `codex exec`, where the CLI does not
+ * expand `/name` itself - the renderer substitutes the body before sending
+ * (see `useInputProcessing`), exactly as it already does for OpenCode.
+ *
+ * Codex's own built-in commands (/init, /compact, /review, ...) are excluded:
+ * they are implemented inside the TUI and have no on-disk prompt to inline, so
+ * offering them would send a literal "/compact" to the model.
+ */
+async function discoverCodexSlashCommands(cwd: string): Promise<DiscoveredCommand[]> {
+	const commands = new Map<string, DiscoveredCommand>();
+
+	const addCommand = (name: string, content: string) => {
+		if (commands.has(name)) return; // project-local wins over global
+		const doc = parseCodexMarkdownDoc(content);
+		// `user-invocable: false` marks a background/reference skill that Codex
+		// itself never offers as a `/name`, so Maestro must not either.
+		if (!doc.userInvocable) return;
+		if (!doc.body) return;
+		commands.set(name, { name, prompt: doc.body, description: doc.description });
+	};
+
+	// Skills: one directory per command, holding a SKILL.md.
+	const addSkillsFromDir = async (dir: string) => {
+		let entries: fs.Dirent[];
+		try {
+			entries = await fs.promises.readdir(dir, { withFileTypes: true });
+		} catch (error) {
+			if (isMissingEntryError(error)) {
+				logger.debug(`Codex skills directory not found: ${dir}`, LOG_CONTEXT);
+				return;
+			}
+			throw error;
+		}
+		for (const entry of entries) {
+			if (!entry.isDirectory()) continue;
+			// `.system/` holds Codex's own internal skills, and dotted names are
+			// hidden from its picker.
+			if (entry.name.startsWith('.')) continue;
+			if (commands.has(entry.name)) continue;
+			try {
+				const raw = await fs.promises.readFile(path.join(dir, entry.name, 'SKILL.md'), 'utf-8');
+				addCommand(entry.name, raw);
+			} catch (error) {
+				// A directory without a SKILL.md is not a skill.
+				if (!isMissingEntryError(error)) throw error;
+			}
+		}
+	};
+
+	// Prompts: one .md file per command.
+	const addPromptsFromDir = async (dir: string) => {
+		let files: string[];
+		try {
+			files = await fs.promises.readdir(dir);
+		} catch (error) {
+			if (isMissingEntryError(error)) {
+				logger.debug(`Codex prompts directory not found: ${dir}`, LOG_CONTEXT);
+				return;
+			}
+			throw error;
+		}
+		for (const file of files) {
+			if (!file.endsWith('.md')) continue;
+			const name = file.replace(/\.md$/, '');
+			if (commands.has(name)) continue;
+			try {
+				addCommand(name, await fs.promises.readFile(path.join(dir, file), 'utf-8'));
+			} catch (error) {
+				if (!isMissingEntryError(error)) throw error;
+			}
+		}
+	};
+
+	for (const dir of getCodexSkillDirs(cwd)) {
+		await addSkillsFromDir(dir);
+	}
+	for (const dir of getCodexPromptDirs(cwd)) {
+		await addPromptsFromDir(dir);
+	}
+
+	const commandList = Array.from(commands.values());
+	logger.info(`Discovered ${commandList.length} Codex slash commands`, LOG_CONTEXT);
 	return commandList;
 }
 
@@ -1431,6 +1529,21 @@ export function registerAgentsHandlers(deps: AgentsHandlerDependencies): void {
 				// Agent-specific discovery paths
 				if (agentId === 'opencode') {
 					return discoverOpenCodeSlashCommands(cwd);
+				}
+
+				if (agentId === 'codex') {
+					// Codex skills/prompts live on the machine that runs the CLI.
+					// For an SSH-remote agent that is the remote host, so return
+					// nothing rather than offering this machine's commands - a
+					// command the remote Codex has never heard of is worse than none.
+					if (sshRemoteId) {
+						logger.debug(
+							'Skipping Codex slash command discovery for SSH remote agent',
+							LOG_CONTEXT
+						);
+						return null;
+					}
+					return discoverCodexSlashCommands(cwd);
 				}
 
 				if (agentId === 'copilot-cli') {

--- a/src/renderer/hooks/wizard/useWizardHandlers.ts
+++ b/src/renderer/hooks/wizard/useWizardHandlers.ts
@@ -205,7 +205,8 @@ export function useWizardHandlers(deps: UseWizardHandlersDeps): UseWizardHandler
 		if (
 			currentSession.toolType !== 'claude-code' &&
 			currentSession.toolType !== 'opencode' &&
-			currentSession.toolType !== 'copilot-cli'
+			currentSession.toolType !== 'copilot-cli' &&
+			currentSession.toolType !== 'codex'
 		)
 			return;
 		if (currentSession.agentCommands && currentSession.agentCommands.length > 0) return;


### PR DESCRIPTION
Closes #1434

## What was wrong

Typing `/` in a **Codex** agent offered only Maestro's own commands (built-ins, custom AI commands, Spec-Kit / OpenSpec / BMAD). None of the user's Codex commands showed up, for two independent reasons:

1. The renderer's discovery effect (`useWizardHandlers`) only ran for `claude-code`, `opencode`, and `copilot-cli`.
2. `supportsSlashCommands` was `false` for `codex`, so `App.tsx` filtered `session.agentCommands` out even if something had populated it.

## What this does

Codex keeps its user-invocable commands on disk, so they can be read without spawning the CLI:

| Source | Path |
| --- | --- |
| Project skills | `<cwd>/.codex/skills/<name>/SKILL.md` |
| Global skills | `<CODEX_HOME>/skills/<name>/SKILL.md` |
| Project prompts | `<cwd>/.codex/prompts/<name>.md` |
| Global prompts | `<CODEX_HOME>/prompts/<name>.md` |

Skills are the current surface (verified against `codex-cli` 0.144.1, which ships `~/.codex/skills/` and no `prompts/`); the prompt directories are still probed so anyone on an earlier Codex build keeps their commands. A directory that does not exist simply yields nothing.

Maestro drives Codex through headless `codex exec`, which does **not** expand a slash itself, so each discovered command carries its file body as `prompt` and the renderer substitutes it before sending. That is the exact path OpenCode custom commands already take (`discoverOpenCodeSlashCommands` -> `useInputProcessing`), so no new execution machinery is introduced.

Codex **built-ins** (`/compact`, `/model`, `/diff`, ...) stay unsupported on purpose: they are implemented inside the TUI and have no on-disk prompt to inline, so offering them would send a literal `/compact` to the model.

Behavioural details worth reviewing:

- `CODEX_HOME` is honoured rather than hard-coding `~/.codex`, so a user on a non-default profile is not offered commands their Codex will never see.
- Project-local commands shadow same-named global ones.
- Skills marked `user-invocable: false` are skipped, matching Codex's own picker, as is Codex's internal `.system/` directory.
- **SSH-remote Codex agents return `null`** rather than this machine's commands. The skills live on the remote host, and a command the remote Codex has never heard of is worse than no command at all. Remote discovery (the `discoverOpenCodeSlashCommandsRemote` equivalent) is a deliberate follow-up.
- Frontmatter is read with a small line scanner rather than a YAML parse: only three scalar keys are needed, it runs on every agent focus, and a malformed document degrades to "body is the whole file" instead of dropping a command the user can see in their own Codex TUI. Nested `metadata: description:` is correctly ignored, and CRLF files parse.

## Scope: Grok and Antigravity are NOT included

The issue asks for three providers. This PR covers Codex only, and that is a deliberate stop rather than an oversight.

Neither `grok` nor `agy` is installed on the machine this was written on, and I could not verify either one's custom-command location or file format. Maestro's own capability table already records the uncertainty (`antigravity`: "Slash commands are TUI-only, not exposed to headless runs"; `grok`: "Conservative default: not investigated in headless mode"). Shipping a guessed directory path and frontmatter shape would either silently find nothing or, worse, offer commands that expand to the wrong text.

What is needed to finish them is small and mechanical once the facts are known: a `getXSkillDirs()`-style path resolver plus a `discoverXSlashCommands()` following the same shape as `discoverCodexSlashCommands`. See the issue thread for the specific questions.

## Testing

- New `src/__tests__/main/agents/codex-config.test.ts` (13 tests): `CODEX_HOME` resolution, directory ordering, frontmatter scanning, `user-invocable: false`, nested `metadata:`, unclosed frontmatter, CRLF.
- New Codex cases in `src/__tests__/main/ipc/handlers/agents.test.ts` (8 tests): skill discovery with prompt body, legacy prompt discovery, `user-invocable: false` filtering, `.system/` exclusion, project-over-global precedence, empty disk, SSH-remote returning `null` without touching the disk, and non-ENOENT errors rethrowing so Sentry sees them.
- Path assertions are built with `path.join`, not POSIX literals, so they hold on the `windows-latest` CI leg too.
- Updated the existing "unsupported agents" case (it used `codex`, which is now supported) to use `terminal`, and the `codex` capability assertion in `capabilities.test.ts`.
- Full suite: **34,730 passed / 108 skipped**. `npm run lint` and `eslint` clean.
- Docs updated: `docs/provider-notes.md` and `docs/slash-commands.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering and using custom Codex slash commands and prompts.
  * Supports project and global command locations, precedence rules, metadata filtering, and `CODEX_HOME` configuration.
  * Commands are expanded automatically before execution.
  * Non-user-invocable and built-in TUI-only commands remain unavailable.
  * Remote SSH Codex command discovery is not supported.

* **Documentation**
  * Updated provider and slash-command documentation with discovery behavior, limitations, and provider-specific support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->