### PR TITLE
fix(codex): tag item.completed reasoning with isReasoning

### DIFF
--- a/src/__tests__/main/parsers/codex-output-parser.test.ts
+++ b/src/__tests__/main/parsers/codex-output-parser.test.ts
@@ -61,6 +61,43 @@ describe('CodexOutputParser', () => {
 				expect(event?.text).toBe('\n\n**Thinking about the task**\n\nI need to analyze...');
 				expect(event?.isPartial).toBe(true);
 			});
+
+			// StdoutHandler gates Codex thinking-chunk events on isReasoning, and
+			// untagged partial text is appended to streamedText (the buffer
+			// ExitHandler emits as the final answer). An item.completed reasoning
+			// item that forgets the flag is therefore both invisible in the
+			// thinking panel and liable to be shown as the agent's response.
+			it('tags reasoning items with isReasoning', () => {
+				const line = JSON.stringify({
+					type: 'item.completed',
+					item: { id: 'item_0', type: 'reasoning', text: 'weighing the options' },
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event?.isReasoning).toBe(true);
+			});
+
+			it('tags reasoning items with isReasoning regardless of section markers', () => {
+				const line = JSON.stringify({
+					type: 'item.completed',
+					item: { type: 'reasoning', text: 'Plain thinking text' },
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event?.text).toBe('Plain thinking text');
+				expect(event?.isReasoning).toBe(true);
+			});
+
+			it('does not tag agent_message as reasoning', () => {
+				const line = JSON.stringify({
+					type: 'item.completed',
+					item: { type: 'agent_message', text: 'Here is the answer.' },
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event?.type).toBe('result');
+				expect(event?.isReasoning).toBeUndefined();
+			});
 		});
 
 		describe('item.completed events - agent_message', () => {

--- a/src/main/parsers/codex-output-parser.ts
+++ b/src/main/parsers/codex-output-parser.ts
@@ -711,14 +711,25 @@ export class CodexOutputParser implements AgentOutputParser {
 	private transformItemCompleted(item: CodexItem, msg: CodexRawMessage): ParsedEvent {
 		switch (item.type) {
 			case 'reasoning':
-				// Reasoning shows model's thinking process
-				// Emit as text but mark it as partial/streaming
+				// Reasoning shows model's thinking process.
 				// Format reasoning text: add line breaks before ** SECTION ** markers
-				// Codex uses this pattern to separate thinking stages
+				// Codex uses this pattern to separate thinking stages.
+				//
+				// `isReasoning` matters twice, exactly as it does on the
+				// `response_item` reasoning path in transformResponseItem():
+				//   1. StdoutHandler gates Codex thinking-chunk events on it, so
+				//      without the flag this reasoning never reaches the thinking
+				//      panel and never becomes a `source: 'thinking'` log entry -
+				//      which is what "Context: Copy with Reasoning" keys off.
+				//   2. Untagged partial text is appended to `streamedText`, the
+				//      buffer ExitHandler emits as the final answer when a turn
+				//      ends without a result message. Reasoning must never be
+				//      handed to the user as the agent's response.
 				return {
 					type: 'text',
 					text: this.formatReasoningText(item.text || ''),
 					isPartial: true,
+					isReasoning: true,
 					raw: msg,
 				};
 


### PR DESCRIPTION
closes #1438

## What this fixes

Codex emits reasoning in two shapes. `transformResponseItem()` (the `response_item` path) correctly returns `isReasoning: true`. `transformItemCompleted()` (the `item.completed` path) did not.

That flag is load-bearing twice:

1. **The thinking pipeline is gated on it.** `StdoutHandler` only forwards `thinking-chunk` events for grok/codex/opencode when `event.isReasoning` is set. Without the tag, Codex reasoning from `item.completed` never becomes a `source: 'thinking'` log entry - and `AITabOverlayMenu` gates **Context: Copy with Reasoning** on `hasThinkingEntries(tab.logs)`. So the option never appeared for Codex tabs, which is exactly what the issue reports.

2. **Untagged partial text lands in `streamedText`.** That buffer is what `ExitHandler` emits as the final answer when a turn ends without a result message, so Codex reasoning could be handed to the user as the agent's response. Same class of bug the `stream_error` case already guards against on the `event_msg` path.

One-line behavioral change plus the comment explaining why the flag matters, so the next person doesn't drop it again.

## Tests

Three cases added to `src/__tests__/main/parsers/codex-output-parser.test.ts`: reasoning items are tagged with and without section markers, and `agent_message` is confirmed to stay untagged (so the fix can't leak into the answer path). Existing 125 codex parser tests and all 317 process-manager tests pass; `tsc --noEmit` clean.

## Scope notes

The issue asks for three providers. Verified against the current tree:

- **Codex** - fixed here.
- **Grok** - already works. `GrokOutputParser.deltaEvent()` tags `thought` events with `isReasoning: true`, so Grok tabs do produce thinking entries. The issue's claim that "only the Claude pipeline creates those" doesn't hold for Grok on the live path.
- **Antigravity** - not addressed. The CLI's stream-json has no reasoning step type (`supportsThinkingDisplay: false` in `capabilities.ts`), so recovering it means a new SQLite session-storage reader plus a protobuf wire walker, as the issue describes. That is a separate feature, not a flag fix, and it would populate the session browser rather than `tab.logs` - which is what copy-context actually reads. Worth its own issue.

One general note for the reporter: **Context: Copy with Reasoning** only appears while thinking entries are present in the tab, so with the Thinking chip on `on` they are cleared when the answer arrives and again on exit. Set the chip to **sticky** to keep reasoning around after a turn finishes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of legacy reasoning events so they are consistently identified as reasoning content.
  * Preserved partial status and formatting for reasoning messages.
  * Ensured regular agent messages are not incorrectly classified as reasoning.

* **Tests**
  * Added regression coverage for formatted and unformatted reasoning events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->