### PR TITLE
feat(cli): let `gist create` target a provider session

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -984,10 +984,11 @@ Publish session context to GitHub gists
 
 Publish an agent's session transcript as a GitHub gist (requires running Maestro app)
 
-| Option                     | Description                             | Default |
-| -------------------------- | --------------------------------------- | ------- |
-| `-d, --description <text>` | Gist description                        | -       |
-| `-p, --public`             | Create a public gist (default: private) | -       |
+| Option                     | Description                                                                                              | Default |
+| -------------------------- | -------------------------------------------------------------------------------------------------------- | ------- |
+| `-d, --description <text>` | Gist description                                                                                         | -       |
+| `-p, --public`             | Create a public gist (default: private)                                                                  | -       |
+| `-s, --session <id>`       | Publish one provider session's transcript (from `send -s <id>`) instead of the agent's open desktop tabs | -       |
 
 ## `maestro-cli notify`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1571,12 +1571,16 @@ maestro-cli gist create <agent-id> -d "Auth refactor pairing session"
 
 # Make it public
 maestro-cli gist create <agent-id> --public -d "Repro for issue #1234"
+
+# Publish one provider session instead of the agent's open tabs
+maestro-cli gist create <agent-id> --session <session-id>
 ```
 
-| Flag                       | Description                            | Default |
-| -------------------------- | -------------------------------------- | ------- |
-| `-d, --description <text>` | Gist description                       | -       |
-| `-p, --public`             | Create a public gist (default private) | private |
+| Flag                       | Description                                                        | Default        |
+| -------------------------- | ------------------------------------------------------------------ | -------------- |
+| `-d, --description <text>` | Gist description                                                   | -              |
+| `-p, --public`             | Create a public gist (default private)                             | private        |
+| `-s, --session <id>`       | Publish one provider session's transcript instead of the open tabs | the agent tabs |
 
 Output is JSON with the gist URL on success:
 
@@ -1584,7 +1588,21 @@ Output is JSON with the gist URL on success:
 { "success": true, "agentId": "a1b2c3d4-...", "gistUrl": "https://gist.github.com/..." }
 ```
 
-Requires the Maestro desktop app to be running and `gh` to be authenticated (`gh auth login`). Error codes: `AGENT_NOT_FOUND`, `MAESTRO_NOT_RUNNING`, `GIST_CREATE_FAILED`.
+### Publishing a headless session
+
+Without `--session`, `gist create` publishes the transcripts of the agent's **open AI tabs** in the desktop app. Headless callers (chat bridges, playbooks, Cue pipelines, CI) run their conversations with `maestro-cli send -s <session-id>` and have no tab, so for them that publishes an unrelated conversation - and a gist is readable by anyone holding the URL.
+
+Pass the same session id you sent with:
+
+```bash
+SESSION=$(maestro-cli send <agent-id> "..." | jq -r .sessionId)
+maestro-cli send <agent-id> "follow-up" -s "$SESSION"
+maestro-cli gist create <agent-id> --session "$SESSION"
+```
+
+The desktop app publishes that session and nothing else: it uses the open tab holding the session when there is one, otherwise it reads the provider's stored transcript (SSH remotes included). If the session cannot be found it fails with `GIST_CREATE_FAILED` rather than falling back to the open tabs. The response echoes `agentSessionId` so you can confirm what was published.
+
+Requires the Maestro desktop app to be running and `gh` to be authenticated (`gh auth login`). Error codes: `AGENT_NOT_FOUND`, `INVALID_SESSION`, `MAESTRO_NOT_RUNNING`, `GIST_CREATE_FAILED`.
 
 ## Scheduling with Cron
 

--- a/src/__tests__/cli/commands/gist.test.ts
+++ b/src/__tests__/cli/commands/gist.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @file gist.test.ts
+ * @description Tests for the `gist create` CLI command.
+ *
+ * Focus is the `--session` option: which conversation actually gets published.
+ * A gist is readable by anyone holding the URL, so a caller that names a
+ * session and gets a different one published has leaked it.
+ */
+
+import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest';
+
+vi.mock('../../../cli/services/maestro-client', () => ({
+	withMaestroClient: vi.fn(),
+}));
+
+vi.mock('../../../cli/services/storage', () => ({
+	resolveAgentId: vi.fn((id: string) => id),
+}));
+
+import { gistCreate } from '../../../cli/commands/gist';
+import { withMaestroClient } from '../../../cli/services/maestro-client';
+
+describe('gist create command', () => {
+	let consoleSpy: MockInstance;
+	let processExitSpy: MockInstance;
+
+	/** Capture the message sent to the desktop and reply with a successful gist. */
+	function captureMessage(): Record<string, unknown> {
+		const captured: Record<string, unknown> = {};
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = {
+				sendCommand: vi.fn().mockImplementation((msg) => {
+					Object.assign(captured, msg);
+					return Promise.resolve({ success: true, gistUrl: 'https://gist.github.com/abc' });
+				}),
+			};
+			return action(mockClient as never);
+		});
+		return captured;
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+	});
+
+	it('omits agentSessionId when no session is requested', async () => {
+		const msg = captureMessage();
+
+		await gistCreate('agent-1', {});
+
+		expect(msg.sessionId).toBe('agent-1');
+		expect(msg.agentSessionId).toBeUndefined();
+		expect(processExitSpy).not.toHaveBeenCalled();
+	});
+
+	it('sends the requested provider session id', async () => {
+		const msg = captureMessage();
+
+		await gistCreate('agent-1', { session: 'provider-session-9' });
+
+		expect(msg.sessionId).toBe('agent-1');
+		expect(msg.agentSessionId).toBe('provider-session-9');
+
+		const output = JSON.parse(consoleSpy.mock.calls[0][0] as string);
+		expect(output.success).toBe(true);
+		expect(output.agentSessionId).toBe('provider-session-9');
+	});
+
+	// A blank `--session` must not degrade into "publish the open tabs" - that is
+	// the exact substitution this option exists to prevent. `process.exit` really
+	// does end the process here, so the spy throws rather than returning: a spy
+	// that returns lets the function run on and publish the very gist the guard
+	// just refused.
+	it('rejects a blank --session instead of publishing the open tabs', async () => {
+		const msg = captureMessage();
+		processExitSpy.mockImplementation((code?: number) => {
+			throw new Error(`process.exit(${code})`);
+		});
+
+		await expect(gistCreate('agent-1', { session: '   ' })).rejects.toThrow('process.exit(1)');
+
+		expect(msg.sessionId).toBeUndefined();
+		const output = JSON.parse(consoleSpy.mock.calls[0][0] as string);
+		expect(output.success).toBe(false);
+		expect(output.code).toBe('INVALID_SESSION');
+	});
+
+	it('reports the desktop failure rather than claiming success', async () => {
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = {
+				sendCommand: vi
+					.fn()
+					.mockResolvedValue({ success: false, error: 'No transcript found for session x' }),
+			};
+			return action(mockClient as never);
+		});
+
+		await gistCreate('agent-1', { session: 'x' });
+
+		const output = JSON.parse(consoleSpy.mock.calls[0][0] as string);
+		expect(output.success).toBe(false);
+		expect(output.code).toBe('GIST_CREATE_FAILED');
+		expect(output.error).toContain('No transcript found');
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+});

--- a/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
@@ -2624,7 +2624,7 @@ describe('WebSocketMessageHandler', () => {
 			});
 
 			await vi.waitFor(() => {
-				expect(callbacks.createGist).toHaveBeenCalledWith('session-1', 'My gist', false);
+				expect(callbacks.createGist).toHaveBeenCalledWith('session-1', 'My gist', false, undefined);
 			});
 
 			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
@@ -2640,7 +2640,7 @@ describe('WebSocketMessageHandler', () => {
 			});
 
 			await vi.waitFor(() => {
-				expect(callbacks.createGist).toHaveBeenCalledWith('session-1', '', false);
+				expect(callbacks.createGist).toHaveBeenCalledWith('session-1', '', false, undefined);
 			});
 		});
 
@@ -2684,6 +2684,51 @@ describe('WebSocketMessageHandler', () => {
 			expect(response.type).toBe('create_gist_result');
 			expect(response.success).toBe(false);
 			expect(response.error).toContain('boom');
+		});
+
+		it('forwards agentSessionId so a headless session can be published', async () => {
+			handler.handleMessage(client, {
+				type: 'create_gist',
+				sessionId: 'session-1',
+				agentSessionId: 'provider-session-9',
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.createGist).toHaveBeenCalledWith(
+					'session-1',
+					'',
+					false,
+					'provider-session-9'
+				);
+			});
+		});
+
+		it('rejects a blank agentSessionId instead of publishing the open tabs', () => {
+			handler.handleMessage(client, {
+				type: 'create_gist',
+				sessionId: 'session-1',
+				agentSessionId: '',
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('create_gist_result');
+			expect(response.success).toBe(false);
+			expect(response.error).toContain('agentSessionId');
+			expect(callbacks.createGist).not.toHaveBeenCalled();
+		});
+
+		it('rejects a non-string agentSessionId', () => {
+			handler.handleMessage(client, {
+				type: 'create_gist',
+				sessionId: 'session-1',
+				agentSessionId: 42,
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('create_gist_result');
+			expect(response.success).toBe(false);
+			expect(response.error).toContain('agentSessionId');
+			expect(callbacks.createGist).not.toHaveBeenCalled();
 		});
 
 		it('replies with create_gist_result when createGist callback is unconfigured', () => {

--- a/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
@@ -51,6 +51,15 @@ describe('useRemoteIntegration', () => {
 	let onRemoteNewAITabWithPromptHandler:
 		| ((sessionId: string, prompt: string, responseChannel: string) => void)
 		| undefined;
+	let onRemoteCreateGistHandler:
+		| ((
+				sessionId: string,
+				description: string,
+				isPublic: boolean,
+				agentSessionId: string | undefined,
+				responseChannel: string
+		  ) => void)
+		| undefined;
 	let onRemoteNotifyToastHandler:
 		| ((params: {
 				title: string;
@@ -233,7 +242,8 @@ describe('useRemoteIntegration', () => {
 			return () => {};
 		}),
 		sendRemoteGetGitDiffResponse: vi.fn(),
-		onRemoteCreateGist: vi.fn().mockImplementation(() => {
+		onRemoteCreateGist: vi.fn().mockImplementation((handler) => {
+			onRemoteCreateGistHandler = handler;
 			return () => {};
 		}),
 		sendRemoteCreateGistResponse: vi.fn(),
@@ -296,6 +306,13 @@ describe('useRemoteIntegration', () => {
 		updateSessionName: vi.fn().mockResolvedValue(true),
 	};
 
+	const mockGit = {
+		...window.maestro.git,
+		createGist: vi
+			.fn()
+			.mockResolvedValue({ success: true, gistUrl: 'https://gist.github.com/abc' }),
+	};
+
 	const mockCue = {
 		...window.maestro.cue,
 		triggerSubscription: vi.fn().mockResolvedValue(true),
@@ -316,6 +333,7 @@ describe('useRemoteIntegration', () => {
 		onRemoteToggleBookmarkHandler = undefined;
 		onRemoteNewAITabWithPromptHandler = undefined;
 		onRemoteNotifyToastHandler = undefined;
+		onRemoteCreateGistHandler = undefined;
 
 		// Reset zustand stores so cross-test state doesn't leak.
 		useSessionStore.setState({ sessions: [] });
@@ -330,6 +348,7 @@ describe('useRemoteIntegration', () => {
 			agentSessions: mockAgentSessions as typeof window.maestro.agentSessions,
 			history: mockHistory as typeof window.maestro.history,
 			cue: mockCue as typeof window.maestro.cue,
+			git: mockGit as typeof window.maestro.git,
 		};
 	});
 
@@ -871,6 +890,162 @@ describe('useRemoteIntegration', () => {
 
 			expect(mockClaude.updateSessionName).not.toHaveBeenCalled();
 			expect(mockAgentSessions.setSessionName).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('remote create gist', () => {
+		const gistLog = (source: 'user' | 'stdout', text: string) => ({
+			id: `${source}-${text}`,
+			timestamp: 1700000000000,
+			source,
+			text,
+		});
+
+		// `gist create <agent> --session <id>` must publish the named conversation
+		// and nothing else. Headless callers (Relay, playbooks, Cue, CI) hold a
+		// provider session id, and a gist is readable by anyone with the URL, so
+		// publishing the agent's open tabs instead leaks an unrelated chat.
+		it('publishes only the tab holding the requested provider session', async () => {
+			const targetTab = createMockTab({
+				id: 'tab-target',
+				agentSessionId: 'provider-session-9',
+				logs: [gistLog('user', 'question about topic B')],
+			});
+			const otherTab = createMockTab({
+				id: 'tab-other',
+				agentSessionId: 'provider-session-1',
+				logs: [gistLog('user', 'unrelated topic A')],
+			});
+			const session = createMockSession({
+				id: 'session-1',
+				aiTabs: [otherTab, targetTab],
+				activeTabId: 'tab-other',
+			});
+			const deps = createDeps({ sessions: [session] });
+
+			renderHook(() => useRemoteIntegration(deps));
+
+			await act(async () => {
+				await onRemoteCreateGistHandler?.(
+					'session-1',
+					'desc',
+					false,
+					'provider-session-9',
+					'response-channel'
+				);
+			});
+
+			expect(mockGit.createGist).toHaveBeenCalledTimes(1);
+			const [filename, content] = mockGit.createGist.mock.calls[0];
+			expect(content).toContain('question about topic B');
+			expect(content).not.toContain('unrelated topic A');
+			expect(content).toContain('provider-session-9');
+			expect(filename).toContain('provider');
+			expect(mockProcess.sendRemoteCreateGistResponse).toHaveBeenCalledWith('response-channel', {
+				success: true,
+				gistUrl: 'https://gist.github.com/abc',
+			});
+		});
+
+		// The relay case: the conversation was run headlessly with `send -s <id>`,
+		// so no desktop tab holds it and the transcript only exists on disk.
+		it('reads the provider transcript when no open tab holds the session', async () => {
+			mockAgentSessions.read.mockResolvedValueOnce({
+				messages: [
+					{
+						type: 'user',
+						content: 'headless question',
+						timestamp: '2026-08-26T00:00:00.000Z',
+						uuid: 'u1',
+					},
+					{
+						type: 'assistant',
+						content: 'headless answer',
+						timestamp: '2026-08-26T00:00:01.000Z',
+						uuid: 'a1',
+					},
+				],
+				total: 2,
+				hasMore: false,
+			});
+			const session = createMockSession({
+				id: 'session-1',
+				toolType: 'claude-code',
+				projectRoot: '/test/project',
+			});
+			const deps = createDeps({ sessions: [session] });
+
+			renderHook(() => useRemoteIntegration(deps));
+
+			await act(async () => {
+				await onRemoteCreateGistHandler?.(
+					'session-1',
+					'',
+					false,
+					'headless-session-4',
+					'response-channel'
+				);
+			});
+
+			expect(mockAgentSessions.read).toHaveBeenCalledWith(
+				'claude-code',
+				'/test/project',
+				'headless-session-4',
+				expect.objectContaining({ offset: 0 }),
+				undefined
+			);
+			const [, content] = mockGit.createGist.mock.calls[0];
+			expect(content).toContain('headless question');
+			expect(content).toContain('headless answer');
+		});
+
+		// No silent fallback: publishing the open tabs for a session that could not
+		// be found is exactly the leak this option exists to close.
+		it('fails instead of falling back to the open tabs when the session is unknown', async () => {
+			mockAgentSessions.read.mockRejectedValueOnce(new Error('ENOENT'));
+			const tab = createMockTab({
+				id: 'tab-other',
+				agentSessionId: 'provider-session-1',
+				logs: [gistLog('user', 'unrelated topic A')],
+			});
+			const session = createMockSession({ id: 'session-1', aiTabs: [tab] });
+			const deps = createDeps({ sessions: [session] });
+
+			renderHook(() => useRemoteIntegration(deps));
+
+			await act(async () => {
+				await onRemoteCreateGistHandler?.(
+					'session-1',
+					'',
+					false,
+					'missing-session',
+					'response-channel'
+				);
+			});
+
+			expect(mockGit.createGist).not.toHaveBeenCalled();
+			expect(mockProcess.sendRemoteCreateGistResponse).toHaveBeenCalledWith(
+				'response-channel',
+				expect.objectContaining({ success: false })
+			);
+		});
+
+		it('still publishes every open tab when no session is requested', async () => {
+			const tabA = createMockTab({ id: 'tab-a', logs: [gistLog('user', 'topic A')] });
+			const tabB = createMockTab({ id: 'tab-b', logs: [gistLog('user', 'topic B')] });
+			const session = createMockSession({ id: 'session-1', aiTabs: [tabA, tabB] });
+			const deps = createDeps({ sessions: [session] });
+
+			renderHook(() => useRemoteIntegration(deps));
+
+			await act(async () => {
+				await onRemoteCreateGistHandler?.('session-1', '', false, undefined, 'response-channel');
+			});
+
+			const [, content] = mockGit.createGist.mock.calls[0];
+			expect(content).toContain('topic A');
+			expect(content).toContain('topic B');
+			expect(mockAgentSessions.read).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/cli/commands/gist.ts
+++ b/src/cli/commands/gist.ts
@@ -1,6 +1,11 @@
 // Gist create - publish an agent's session transcript to a GitHub gist.
 // Routes through the running Maestro desktop app (which holds live tab
 // transcripts) and reuses the existing `gh gist create` IPC handler.
+//
+// `--session` narrows the publish to one provider session instead of the
+// agent's open AI tabs. Headless callers (Maestro Relay, playbooks, Cue, CI)
+// hold a session id from `send -s <id>` and have no desktop tab, so without it
+// they publish whatever unrelated conversation the agent has open.
 
 import { resolveAgentId } from '../services/storage';
 import { withMaestroClient } from '../services/maestro-client';
@@ -8,11 +13,13 @@ import { withMaestroClient } from '../services/maestro-client';
 interface GistCreateOptions {
 	description?: string;
 	public?: boolean;
+	session?: string;
 }
 
 interface GistCreateResponse {
 	success: boolean;
 	agentId?: string;
+	agentSessionId?: string;
 	gistUrl?: string;
 	error?: string;
 	code?: string;
@@ -36,6 +43,15 @@ export async function gistCreate(agentIdArg: string, options: GistCreateOptions)
 	const description = options.description ?? '';
 	const isPublic = Boolean(options.public);
 
+	// Reject a blank `--session` rather than dropping it: falling through to the
+	// agent's open tabs would publish a different conversation than the one the
+	// caller named, and a gist is readable by anyone with the URL.
+	const agentSessionId = options.session?.trim();
+	if (options.session !== undefined && !agentSessionId) {
+		emitErrorJson('--session requires a non-empty session id', 'INVALID_SESSION');
+		process.exit(1);
+	}
+
 	try {
 		const result = await withMaestroClient((client) =>
 			client.sendCommand<{
@@ -48,6 +64,7 @@ export async function gistCreate(agentIdArg: string, options: GistCreateOptions)
 					sessionId: agentId,
 					description,
 					isPublic,
+					...(agentSessionId ? { agentSessionId } : {}),
 				},
 				'create_gist_result',
 				60000
@@ -62,6 +79,7 @@ export async function gistCreate(agentIdArg: string, options: GistCreateOptions)
 		const response: GistCreateResponse = {
 			success: true,
 			agentId,
+			...(agentSessionId ? { agentSessionId } : {}),
 			gistUrl: result.gistUrl,
 		};
 		console.log(JSON.stringify(response, null, 2));

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1112,6 +1112,10 @@ gist
 	)
 	.option('-d, --description <text>', 'Gist description')
 	.option('-p, --public', 'Create a public gist (default: private)')
+	.option(
+		'-s, --session <id>',
+		"Publish one provider session's transcript (from `send -s <id>`) instead of the agent's open desktop tabs"
+	)
 	.action(gistCreate);
 
 // Notify commands - surface notifications in the Maestro desktop app

--- a/src/main/preload/process.ts
+++ b/src/main/preload/process.ts
@@ -1831,6 +1831,7 @@ export function createProcessApi() {
 				sessionId: string,
 				description: string,
 				isPublic: boolean,
+				agentSessionId: string | undefined,
 				responseChannel: string
 			) => void
 		): (() => void) => {
@@ -1839,10 +1840,11 @@ export function createProcessApi() {
 				sessionId: string,
 				description: string,
 				isPublic: boolean,
+				agentSessionId: string | undefined,
 				responseChannel: string
 			) => {
 				try {
-					callback(sessionId, description, isPublic, responseChannel);
+					callback(sessionId, description, isPublic, agentSessionId, responseChannel);
 				} catch (error) {
 					ipcRenderer.send(responseChannel, {
 						success: false,

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -1009,8 +1009,12 @@ export class WebServer {
 				this.callbackRegistry.transferContext(sourceSessionId, targetSessionId),
 			summarizeContext: async (sessionId: string) =>
 				this.callbackRegistry.summarizeContext(sessionId),
-			createGist: async (sessionId: string, description: string, isPublic: boolean) =>
-				this.callbackRegistry.createGist(sessionId, description, isPublic),
+			createGist: async (
+				sessionId: string,
+				description: string,
+				isPublic: boolean,
+				agentSessionId?: string
+			) => this.callbackRegistry.createGist(sessionId, description, isPublic, agentSessionId),
 			getCueSubscriptions: async (sessionId?: string) =>
 				this.callbackRegistry.getCueSubscriptions(sessionId),
 			toggleCueSubscription: async (subscriptionId: string, enabled: boolean) =>

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -363,7 +363,8 @@ export interface MessageHandlerCallbacks {
 	createGist: (
 		sessionId: string,
 		description: string,
-		isPublic: boolean
+		isPublic: boolean,
+		agentSessionId?: string
 	) => Promise<{ success: boolean; gistUrl?: string; error?: string }>;
 	getCueSubscriptions: (sessionId?: string) => Promise<CueSubscriptionInfo[]>;
 	toggleCueSubscription: (subscriptionId: string, enabled: boolean) => Promise<boolean>;
@@ -4094,6 +4095,22 @@ export class WebSocketMessageHandler {
 			reply({ success: false, error: 'isPublic must be a boolean when provided' });
 			return;
 		}
+		// `agentSessionId` narrows the publish to one provider session (a headless
+		// `send -s <id>` conversation) instead of the agent's open AI tabs. Reject a
+		// blank string rather than treating it as absent: silently falling back to
+		// the tabs is how a caller aiming at one conversation publishes another.
+		const rawAgentSessionId = message.agentSessionId;
+		let agentSessionId: string | undefined;
+		if (rawAgentSessionId !== undefined) {
+			if (typeof rawAgentSessionId !== 'string' || !rawAgentSessionId) {
+				reply({
+					success: false,
+					error: 'agentSessionId must be a non-empty string when provided',
+				});
+				return;
+			}
+			agentSessionId = rawAgentSessionId;
+		}
 		const description = message.description ?? '';
 		const isPublic = message.isPublic ?? false;
 
@@ -4103,7 +4120,7 @@ export class WebSocketMessageHandler {
 		}
 
 		this.callbacks
-			.createGist(sessionId, description, isPublic)
+			.createGist(sessionId, description, isPublic, agentSessionId)
 			.then((result) => {
 				reply(result);
 			})

--- a/src/main/web-server/managers/CallbackRegistry.ts
+++ b/src/main/web-server/managers/CallbackRegistry.ts
@@ -758,12 +758,13 @@ export class CallbackRegistry {
 	async createGist(
 		sessionId: string,
 		description: string,
-		isPublic: boolean
+		isPublic: boolean,
+		agentSessionId?: string
 	): Promise<{ success: boolean; gistUrl?: string; error?: string }> {
 		if (!this.callbacks.createGist) {
 			return { success: false, error: 'Gist creation not configured' };
 		}
-		return this.callbacks.createGist(sessionId, description, isPublic);
+		return this.callbacks.createGist(sessionId, description, isPublic, agentSessionId);
 	}
 
 	async getCueSubscriptions(sessionId?: string): Promise<CueSubscriptionInfo[]> {

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -1028,7 +1028,14 @@ export type SummarizeContextCallback = (sessionId: string) => Promise<boolean>;
 export type CreateGistCallback = (
 	sessionId: string,
 	description: string,
-	isPublic: boolean
+	isPublic: boolean,
+	/**
+	 * Provider session id to publish instead of the agent's open AI tabs.
+	 * Headless callers (Relay, playbooks, Cue, CI) hold a provider session id
+	 * rather than a desktop tab, and publishing the agent's tabs for them
+	 * leaks an unrelated conversation.
+	 */
+	agentSessionId?: string
 ) => Promise<{ success: boolean; gistUrl?: string; error?: string }>;
 
 // =============================================================================

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -2746,7 +2746,12 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 		// the AI-tab transcripts in memory, so we forward to it and let it
 		// build the payload + call the existing `git:createGist` handler.
 		server.setCreateGistCallback(
-			async (sessionId: string, description: string, isPublic: boolean) => {
+			async (
+				sessionId: string,
+				description: string,
+				isPublic: boolean,
+				agentSessionId?: string
+			) => {
 				const mainWindow = getMainWindow();
 				if (!mainWindow) {
 					logger.warn('mainWindow is null for createGist', 'WebServer');
@@ -2779,6 +2784,7 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 						sessionId,
 						description,
 						isPublic,
+						agentSessionId,
 						responseChannel
 					);
 

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -628,6 +628,7 @@ interface MaestroAPI {
 				sessionId: string,
 				description: string,
 				isPublic: boolean,
+				agentSessionId: string | undefined,
 				responseChannel: string
 			) => void
 		) => () => void;

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -7,6 +7,9 @@ import { aiTabFocusFields, createTab, closeTab } from '../../utils/tabHelpers';
 import { logger } from '../../utils/logger';
 import { persistTabStarred } from '../../utils/starredSessions';
 import { formatLogsForClipboard } from '../../utils/contextExtractor';
+import { messagesToLogEntries } from '../../components/AgentSessionsBrowser/utils/messagesToLogEntries';
+import type { SessionMessage } from '../agent/useSessionViewer';
+import { resolveSessionProjectPath } from '../../components/AgentSessionsBrowser/utils/sessionProjectPath';
 import { notifyToast } from '../../stores/notificationStore';
 import { openUiSurface } from '../../utils/openUiSurface';
 import { notifyCenterFlash } from '../../stores/centerFlashStore';
@@ -41,6 +44,67 @@ export interface UseRemoteIntegrationDeps {
  */
 export interface UseRemoteIntegrationReturn {
 	// No return values - all functionality is via side effects
+}
+
+/**
+ * Upper bound on messages pulled from a provider transcript for a gist. The
+ * read is tail-anchored, so this keeps the newest N and reports the cut.
+ */
+const GIST_SESSION_MESSAGE_LIMIT = 10000;
+
+type GistBody = { body: string } | { error: string };
+
+/**
+ * Transcript body for `gist create <agent-id> --session <id>` - ONE provider
+ * session, not the agent's open AI tabs.
+ *
+ * Headless callers (Maestro Relay, playbooks, Cue, CI) address a conversation
+ * by its provider session id and have no desktop tab, so publishing the
+ * agent's tabs for them puts an unrelated conversation in a URL-readable gist.
+ *
+ * Prefers a live tab holding that session (its logs are already in memory and
+ * every provider has them) and falls back to the provider's on-disk transcript,
+ * which is where a purely headless session lives.
+ */
+async function buildSessionGistBody(session: Session, agentSessionId: string): Promise<GistBody> {
+	const liveTab = session.aiTabs.find((tab) => tab.agentSessionId === agentSessionId);
+	if (liveTab) {
+		const body = formatLogsForClipboard(liveTab.logs);
+		return body ? { body } : { error: `Session has no conversation history: ${agentSessionId}` };
+	}
+
+	const { projectPathForSessions, sshRemoteId } = resolveSessionProjectPath(session);
+	if (!projectPathForSessions) {
+		return { error: `Cannot resolve a project path for agent ${session.id}` };
+	}
+
+	let result: { messages: SessionMessage[]; hasMore: boolean };
+	try {
+		result = await window.maestro.agentSessions.read(
+			session.toolType,
+			projectPathForSessions,
+			agentSessionId,
+			{ offset: 0, limit: GIST_SESSION_MESSAGE_LIMIT },
+			sshRemoteId
+		);
+	} catch {
+		// A missing transcript throws out of the provider storage read. That is
+		// an ordinary miss (wrong id, wrong agent, provider without on-disk
+		// sessions), so answer the caller instead of reporting a crash.
+		return { error: `No transcript found for session ${agentSessionId}` };
+	}
+
+	const body = formatLogsForClipboard(messagesToLogEntries(result.messages, agentSessionId));
+	if (!body) {
+		return { error: `No transcript found for session ${agentSessionId}` };
+	}
+	// Say so when the tail was cut - a silently truncated transcript reads as a
+	// complete one to whoever opens the gist.
+	return {
+		body: result.hasMore
+			? `_Older messages truncated - showing the most recent ${GIST_SESSION_MESSAGE_LIMIT}._\n\n${body}`
+			: body,
+	};
 }
 
 /**
@@ -1416,6 +1480,7 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 				sessionId: string,
 				description: string,
 				isPublic: boolean,
+				agentSessionId: string | undefined,
 				responseChannel: string
 			) => {
 				try {
@@ -1428,26 +1493,49 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 						return;
 					}
 
-					const sections: string[] = [];
-					for (const tab of session.aiTabs) {
-						const body = formatLogsForClipboard(tab.logs);
-						if (!body) continue;
-						const header = tab.name || tab.id.slice(0, 8);
-						sections.push(`## Tab: ${header}\n\n${body}`);
+					let content: string;
+					if (agentSessionId) {
+						// Narrowed to one provider session: publish exactly that
+						// conversation, never a fallback to the agent's tabs. A caller
+						// that named a session and got a different one published has
+						// leaked it - gists are readable by anyone with the URL.
+						const result = await buildSessionGistBody(session, agentSessionId);
+						if ('error' in result) {
+							window.maestro.process.sendRemoteCreateGistResponse(responseChannel, {
+								success: false,
+								error: result.error,
+							});
+							return;
+						}
+						content = `# ${session.name}\n\n_Session \`${agentSessionId}\`_\n\n${result.body}\n`;
+					} else {
+						const sections: string[] = [];
+						for (const tab of session.aiTabs) {
+							const body = formatLogsForClipboard(tab.logs);
+							if (!body) continue;
+							const header = tab.name || tab.id.slice(0, 8);
+							sections.push(`## Tab: ${header}\n\n${body}`);
+						}
+
+						if (sections.length === 0) {
+							window.maestro.process.sendRemoteCreateGistResponse(responseChannel, {
+								success: false,
+								error: 'Session has no conversation history to publish',
+							});
+							return;
+						}
+
+						content = `# ${session.name}\n\n${sections.join('\n\n---\n\n')}\n`;
 					}
 
-					if (sections.length === 0) {
-						window.maestro.process.sendRemoteCreateGistResponse(responseChannel, {
-							success: false,
-							error: 'Session has no conversation history to publish',
-						});
-						return;
-					}
-
-					const content = `# ${session.name}\n\n${sections.join('\n\n---\n\n')}\n`;
 					const safeName =
 						(session.name || 'session').replace(/[^a-zA-Z0-9]/g, '_').slice(0, 60) || 'session';
-					const filename = `${safeName}_context.md`;
+					// Session ids are provider-issued, so scrub them the same way as the
+					// agent name before they become a gist filename.
+					const safeSessionId = agentSessionId?.replace(/[^a-zA-Z0-9]/g, '_').slice(0, 8);
+					const filename = safeSessionId
+						? `${safeName}_${safeSessionId}_context.md`
+						: `${safeName}_context.md`;
 
 					const result = await window.maestro.git.createGist(
 						filename,
@@ -1469,6 +1557,7 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 							sessionId,
 							isPublic,
 							descriptionProvided: Boolean(description),
+							agentSessionTargeted: Boolean(agentSessionId),
 						},
 					});
 					window.maestro.process.sendRemoteCreateGistResponse(responseChannel, {


### PR DESCRIPTION
Closes #1440

## The gap

`maestro-cli gist create <agent-id>` took only an agent id, so it published the transcripts of whatever AI tabs that agent had **open in the desktop app**. Headless callers address a conversation by its provider session id (`send -s <id>`) and have no tab at all, so Maestro Relay's `/gist` in a channel discussing topic B published an unrelated desktop conversation about topic A. Gists are readable by anyone holding the URL, so that is a leak rather than a surprise. Playbooks, Cue pipelines, and CI have the same gap: `send` is session-addressable, `gist create` was not.

## The change

```bash
maestro-cli gist create <agent-id> --session <session-id>
```

`--session` is threaded through the WebSocket bridge as `agentSessionId` (CLI -> `create_gist` message -> `CreateGistCallback` -> renderer). The renderer resolves the transcript in two steps:

1. the open AI tab holding that `agentSessionId`, when one exists (logs are already in memory, and every provider has them);
2. otherwise the provider's stored transcript, read through the existing `agentSessions.read` path, so SSH remotes work via `resolveSessionProjectPath`.

Omitting the flag keeps today's behavior byte for byte.

## Deliberate non-fallbacks

- A `--session` that cannot be resolved **fails**. Falling back to the agent's open tabs is precisely the substitution this option exists to prevent, and the caller cannot tell the difference from the returned URL.
- A blank `--session` is rejected at the CLI (`INVALID_SESSION`) and again at the bridge, rather than being treated as absent.
- The read is capped at 10k messages and the body says so when it truncates - a silently cut transcript reads as a complete one to whoever opens the gist.

The success payload echoes `agentSessionId` so a caller can confirm what was published.

## Tests

- `src/__tests__/cli/commands/gist.test.ts` (new): flag is forwarded, absent when unused, blank rejected, desktop failure surfaced.
- `useRemoteIntegration.test.ts`: publishes only the matching tab, reads the provider transcript when no tab holds the session, fails rather than falling back to the tabs, and the unflagged path still publishes every tab.
- `messageHandlers.test.ts`: `agentSessionId` forwarded; blank and non-string rejected.

`npm run lint`, `npx eslint src/`, prettier, and the cli / web-server / preload suites (1910 tests) are green locally. Docs updated in `docs/cli.md` plus the generated `docs/cli-reference.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-s, --session <id>` to `gist create` for publishing a specific provider session transcript.
  * Remote gist creation now supports targeted session transcripts, including headless sessions.
  * Responses identify the published session when applicable.

* **Bug Fixes**
  * Invalid or missing session transcripts now return clear errors without falling back to unrelated open tabs.

* **Documentation**
  * Updated CLI usage, transcript behavior, failure scenarios, and error codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->