### PR TITLE
fix(concerto): make HTML Movements reachable from web-desktop

### DIFF
--- a/src/__tests__/main/web-server/callbacks/cadenzaMovementCallbacks.test.ts
+++ b/src/__tests__/main/web-server/callbacks/cadenzaMovementCallbacks.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Movement payloads reach the Electron renderer through a direct
+ * `webContents.send`, which bypasses `safeSend` and therefore the web-desktop
+ * bridge fanout. Without an explicit broadcast a browser client's Movement
+ * store stays empty forever, and every `maestro://concerto/movement/<id>` chip
+ * reports the panel as unavailable (#1442).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('electron', () => ({
+	ipcMain: { once: vi.fn(), removeListener: vi.fn() },
+}));
+
+vi.mock('../../../../main/utils/logger', () => ({
+	logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../../../main/utils/safe-send', () => ({
+	isWebContentsAvailable: vi.fn(() => true),
+}));
+
+vi.mock('../../../../main/web-server/handlers/bridgeHandlers', () => ({
+	broadcastBridgeEvent: vi.fn(),
+}));
+
+import { registerCadenzaMovementCallbacks } from '../../../../main/web-server/callbacks/cadenzaMovementCallbacks';
+import { broadcastBridgeEvent } from '../../../../main/web-server/handlers/bridgeHandlers';
+import { clearConcertoHtmlDocumentsForTests } from '../../../../main/concerto-html';
+import type { MovementPayload } from '../../../../shared/movement-types';
+
+const mockedBroadcast = vi.mocked(broadcastBridgeEvent);
+
+type MovementCallback = (params: MovementPayload) => Promise<boolean>;
+
+function setup(options: { concerto?: boolean; mainWindow?: unknown } = {}) {
+	const { concerto = true, mainWindow = { webContents: { send: vi.fn() } } } = options;
+	let movementCallback: MovementCallback | undefined;
+	// Auto-stub every setter the registrar reaches for, so adding an unrelated
+	// Concerto callback upstream doesn't fail this suite.
+	const server = new Proxy(
+		{},
+		{
+			get: (_target, prop: string) =>
+				prop === 'setMovementViewCallback'
+					? (cb: MovementCallback) => {
+							movementCallback = cb;
+						}
+					: () => {},
+		}
+	);
+	registerCadenzaMovementCallbacks(
+		server as never,
+		{
+			settingsStore: { get: () => ({ concerto }) } as never,
+			getMainWindow: () => mainWindow as never,
+			deliverCadenza: undefined,
+		} as never
+	);
+	return { movementCallback: movementCallback! };
+}
+
+describe('movement view callback', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		clearConcertoHtmlDocumentsForTests();
+	});
+
+	it('fans an HTML movement out to web-desktop bridge clients', async () => {
+		const { movementCallback } = setup();
+		void movementCallback({
+			op: 'add',
+			id: 'mockup',
+			viewType: 'html',
+			body: '<button>Buy</button>',
+		});
+		// The renderer ack is awaited on a timeout; the fanout is synchronous.
+		await Promise.resolve();
+
+		expect(mockedBroadcast).toHaveBeenCalledTimes(1);
+		const [channel, args] = mockedBroadcast.mock.calls[0];
+		expect(channel).toBe('remote:movement');
+		expect(args).toHaveLength(1);
+		// The broadcast carries the HTML-routed payload, so a browser client sees
+		// the same revision the desktop renderer does.
+		expect((args[0] as MovementPayload).id).toBe('mockup');
+		expect((args[0] as MovementPayload & { revision?: number }).revision).toBe(1);
+	});
+
+	it('sends no response channel, which a bridge client could not answer', async () => {
+		const { movementCallback } = setup();
+		void movementCallback({ op: 'move', id: 'mockup', x: 10, y: 20 });
+		await Promise.resolve();
+
+		expect(mockedBroadcast.mock.calls[0][1]).toHaveLength(1);
+	});
+
+	it('stays inert while the Concerto Encore Feature is off', async () => {
+		const { movementCallback } = setup({ concerto: false });
+		await movementCallback({ op: 'add', id: 'mockup', viewType: 'view', body: '{}' });
+
+		expect(mockedBroadcast).not.toHaveBeenCalled();
+	});
+});

--- a/src/__tests__/main/web-server/routes/concertoRoutes.test.ts
+++ b/src/__tests__/main/web-server/routes/concertoRoutes.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for ConcertoRoutes
+ *
+ * The web-desktop browser bundle cannot resolve the `maestro-concerto://`
+ * scheme the Electron app serves HTML Movements from, so the web server exposes
+ * the same documents over HTTP (#1442). The document body and, crucially, the
+ * sandboxing headers must match the custom-scheme handler exactly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ConcertoRoutes } from '../../../../main/web-server/routes/concertoRoutes';
+import {
+	applyMovementHtmlPayload,
+	clearConcertoHtmlDocumentsForTests,
+	CONCERTO_HTML_CSP,
+} from '../../../../main/concerto-html';
+
+vi.mock('../../../../main/utils/logger', () => ({
+	logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const CONCERTO_TOKEN = 'concerto-token-abc';
+const ROUTE = `/${CONCERTO_TOKEN}/concerto/render`;
+
+function createMockFastify() {
+	const routes = new Map<string, Function>();
+	return {
+		get: vi.fn((path: string, handler: Function) => {
+			routes.set(`GET:${path}`, handler);
+		}),
+		getHandler: (path: string) => routes.get(`GET:${path}`),
+		routes,
+	};
+}
+
+function createMockReply() {
+	const state: { code?: number; headers?: Record<string, string>; body?: unknown } = {};
+	const reply: any = {
+		code: vi.fn((value: number) => {
+			state.code = value;
+			return reply;
+		}),
+		type: vi.fn().mockReturnThis(),
+		headers: vi.fn((value: Record<string, string>) => {
+			state.headers = value;
+			return reply;
+		}),
+		send: vi.fn((value: unknown) => {
+			state.body = value;
+			return reply;
+		}),
+		state,
+	};
+	return reply;
+}
+
+describe('ConcertoRoutes', () => {
+	let concertoRoutes: ConcertoRoutes;
+	let mockFastify: ReturnType<typeof createMockFastify>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		clearConcertoHtmlDocumentsForTests();
+		concertoRoutes = new ConcertoRoutes(CONCERTO_TOKEN);
+		mockFastify = createMockFastify();
+		concertoRoutes.registerRoutes(mockFastify as any);
+	});
+
+	it('registers the render route behind the concerto token', () => {
+		expect(mockFastify.getHandler(ROUTE)).toBeDefined();
+	});
+
+	it('serves a registered document with the same policy headers as the protocol handler', async () => {
+		const html = '<style>b{color:red}</style><button>Buy</button><script>window.ok=1</script>';
+		applyMovementHtmlPayload({ op: 'add', id: 'mockup', viewType: 'html', body: html });
+
+		const reply = createMockReply();
+		await mockFastify.getHandler(ROUTE)!(
+			{ query: { surface: 'movement', id: 'mockup', revision: '1' } },
+			reply
+		);
+
+		expect(reply.state.code).toBeUndefined();
+		expect(reply.state.body).toContain(html);
+		expect(reply.state.headers?.['content-security-policy']).toBe(CONCERTO_HTML_CSP);
+		expect(reply.state.headers?.['content-type']).toBe('text/html; charset=utf-8');
+		expect(reply.state.headers?.['cache-control']).toBe('no-store');
+		expect(reply.state.headers?.['x-content-type-options']).toBe('nosniff');
+	});
+
+	it('rejects an unknown surface', async () => {
+		const reply = createMockReply();
+		await mockFastify.getHandler(ROUTE)!({ query: { surface: 'stage', id: 'mockup' } }, reply);
+		expect(reply.state.code).toBe(400);
+	});
+
+	it('rejects a missing id', async () => {
+		const reply = createMockReply();
+		await mockFastify.getHandler(ROUTE)!({ query: { surface: 'movement' } }, reply);
+		expect(reply.state.code).toBe(400);
+	});
+
+	it('404s a document that is not registered', async () => {
+		const reply = createMockReply();
+		await mockFastify.getHandler(ROUTE)!({ query: { surface: 'movement', id: 'gone' } }, reply);
+		expect(reply.state.code).toBe(404);
+	});
+});

--- a/src/__tests__/main/web-server/routes/staticRoutes.test.ts
+++ b/src/__tests__/main/web-server/routes/staticRoutes.test.ts
@@ -60,13 +60,14 @@ describe('StaticRoutes', () => {
 	const securityToken = 'test-token-123';
 	const webAssetsPath = '/path/to/web/assets';
 	const webDesktopPath = '/path/to/web-desktop';
+	const concertoToken = 'test-concerto-token';
 
 	let staticRoutes: StaticRoutes;
 	let mockFastify: ReturnType<typeof createMockFastify>;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		staticRoutes = new StaticRoutes(securityToken, webAssetsPath, webDesktopPath);
+		staticRoutes = new StaticRoutes(securityToken, webAssetsPath, webDesktopPath, concertoToken);
 		mockFastify = createMockFastify();
 		staticRoutes.registerRoutes(mockFastify as any);
 	});
@@ -114,7 +115,7 @@ describe('StaticRoutes', () => {
 
 	describe('Null path handling', () => {
 		it('should return 404 for manifest.json when webAssetsPath is null', async () => {
-			const noAssetsRoutes = new StaticRoutes(securityToken, null, webDesktopPath);
+			const noAssetsRoutes = new StaticRoutes(securityToken, null, webDesktopPath, concertoToken);
 			const noAssetsFastify = createMockFastify();
 			noAssetsRoutes.registerRoutes(noAssetsFastify as any);
 
@@ -126,7 +127,7 @@ describe('StaticRoutes', () => {
 		});
 
 		it('should return 404 for sw.js when webAssetsPath is null', async () => {
-			const noAssetsRoutes = new StaticRoutes(securityToken, null, webDesktopPath);
+			const noAssetsRoutes = new StaticRoutes(securityToken, null, webDesktopPath, concertoToken);
 			const noAssetsFastify = createMockFastify();
 			noAssetsRoutes.registerRoutes(noAssetsFastify as any);
 
@@ -138,7 +139,7 @@ describe('StaticRoutes', () => {
 		});
 
 		it('should return 503 for the token root when the web-desktop bundle is missing', async () => {
-			const noDesktopRoutes = new StaticRoutes(securityToken, webAssetsPath, null);
+			const noDesktopRoutes = new StaticRoutes(securityToken, webAssetsPath, null, concertoToken);
 			const noDesktopFastify = createMockFastify();
 			noDesktopRoutes.registerRoutes(noDesktopFastify as any);
 
@@ -166,7 +167,12 @@ describe('StaticRoutes', () => {
 	describe('Security Token Validation', () => {
 		it('should use provided security token in routes', () => {
 			const customToken = 'custom-secure-token-456';
-			const customRoutes = new StaticRoutes(customToken, webAssetsPath, webDesktopPath);
+			const customRoutes = new StaticRoutes(
+				customToken,
+				webAssetsPath,
+				webDesktopPath,
+				concertoToken
+			);
 			const customFastify = createMockFastify();
 			customRoutes.registerRoutes(customFastify as any);
 
@@ -193,7 +199,12 @@ describe('StaticRoutes', () => {
 					'utf8'
 				);
 
-				const freshRoutes = new StaticRoutes(securityToken, webAssetsPath, tempDesktopPath);
+				const freshRoutes = new StaticRoutes(
+					securityToken,
+					webAssetsPath,
+					tempDesktopPath,
+					concertoToken
+				);
 				const freshFastify = createMockFastify();
 				freshRoutes.registerRoutes(freshFastify as any);
 
@@ -207,6 +218,11 @@ describe('StaticRoutes', () => {
 				);
 				// Config is injected so the electron-shim can open the WS bridge.
 				expect(firstReply.send).toHaveBeenCalledWith(expect.stringContaining('__MAESTRO_CONFIG__'));
+				// ...including the Concerto document token, which the renderer needs
+				// to point an HTML Movement's iframe at a URL a browser can load.
+				expect(firstReply.send).toHaveBeenCalledWith(
+					expect.stringContaining(`concertoToken: "${concertoToken}"`)
+				);
 				// PWA manifest and iOS home-screen icon are wired into the page,
 				// token-prefixed to match their HTTP-served routes.
 				expect(firstReply.send).toHaveBeenCalledWith(
@@ -250,7 +266,12 @@ describe('StaticRoutes', () => {
 					'utf8'
 				);
 
-				const freshRoutes = new StaticRoutes(securityToken, webAssetsPath, tempDesktopPath);
+				const freshRoutes = new StaticRoutes(
+					securityToken,
+					webAssetsPath,
+					tempDesktopPath,
+					concertoToken
+				);
 				const freshFastify = createMockFastify();
 				freshRoutes.registerRoutes(freshFastify as any);
 

--- a/src/__tests__/renderer/utils/concertoHtmlSrc.test.ts
+++ b/src/__tests__/renderer/utils/concertoHtmlSrc.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolveConcertoHtmlSrc } from '../../../renderer/utils/concertoHtmlSrc';
+import { isWebDesktop } from '../../../renderer/utils/runtimeContext';
+
+vi.mock('../../../renderer/utils/runtimeContext', () => ({
+	isWebDesktop: vi.fn(() => false),
+}));
+
+const mockedIsWebDesktop = vi.mocked(isWebDesktop);
+
+function setConfig(config: unknown): void {
+	(window as unknown as Record<string, unknown>).__MAESTRO_CONFIG__ = config;
+}
+
+afterEach(() => {
+	delete (window as unknown as Record<string, unknown>).__MAESTRO_CONFIG__;
+	mockedIsWebDesktop.mockReturnValue(false);
+});
+
+describe('resolveConcertoHtmlSrc', () => {
+	it('uses the custom scheme in the Electron desktop app', () => {
+		mockedIsWebDesktop.mockReturnValue(false);
+		expect(resolveConcertoHtmlSrc('movement', 'mockup', 7)).toBe(
+			'maestro-concerto://render/?surface=movement&id=mockup&revision=7'
+		);
+	});
+
+	it('uses the token-scoped HTTP route in web-desktop', () => {
+		mockedIsWebDesktop.mockReturnValue(true);
+		setConfig({ concertoToken: 'abc123' });
+		expect(resolveConcertoHtmlSrc('movement', 'mockup', 7)).toBe(
+			'/abc123/concerto/render?surface=movement&id=mockup&revision=7'
+		);
+	});
+
+	it('percent-encodes ids so a slash cannot escape the route', () => {
+		mockedIsWebDesktop.mockReturnValue(true);
+		setConfig({ concertoToken: 'abc123' });
+		expect(resolveConcertoHtmlSrc('cadenza', 'a/b c', 1)).toBe(
+			'/abc123/concerto/render?surface=cadenza&id=a%2Fb+c&revision=1'
+		);
+	});
+
+	it('falls back to the custom scheme when the server served no concerto token', () => {
+		mockedIsWebDesktop.mockReturnValue(true);
+		setConfig({ securityToken: 'only-the-master-token' });
+		expect(resolveConcertoHtmlSrc('movement', 'mockup', 2)).toBe(
+			'maestro-concerto://render/?surface=movement&id=mockup&revision=2'
+		);
+	});
+
+	it('never puts the web server security token in a document URL', () => {
+		mockedIsWebDesktop.mockReturnValue(true);
+		setConfig({ securityToken: 'master-secret', concertoToken: 'scoped-token' });
+		expect(resolveConcertoHtmlSrc('movement', 'mockup', 3)).not.toContain('master-secret');
+	});
+});

--- a/src/main/concerto-html.ts
+++ b/src/main/concerto-html.ts
@@ -273,22 +273,45 @@ export function applyCadenzaHtmlPayload(payload: CadenzaPayload): void {
 	if (isHtml && payload.body !== undefined) setDocument('cadenza', payload.id, payload.body);
 }
 
+/**
+ * Response headers every served Concerto document carries. The CSP (including
+ * its `sandbox` directive) is what keeps an agent-authored document from
+ * reaching the network or the embedding page, so the custom-scheme handler and
+ * the web server's HTTP route MUST send the identical set - a browser client
+ * served without these would run the same document unsandboxed.
+ */
+export const CONCERTO_HTML_RESPONSE_HEADERS: Readonly<Record<string, string>> = {
+	'content-type': 'text/html; charset=utf-8',
+	'cache-control': 'no-store',
+	'content-security-policy': CONCERTO_HTML_CSP,
+	'permissions-policy':
+		'camera=(), microphone=(), geolocation=(), clipboard-read=(), clipboard-write=(), fullscreen=(), payment=(), usb=()',
+	'x-dns-prefetch-control': 'off',
+	'x-content-type-options': 'nosniff',
+};
+
+/**
+ * The registered document for a surface/id, with the designer harness injected,
+ * or null when nothing is registered under that key. Shared by the Electron
+ * protocol handler and the web server's HTTP route so both serve one body.
+ */
+export function getConcertoHtmlDocumentBody(
+	surface: ConcertoHtmlSurface,
+	id: string
+): string | null {
+	const document = documents.get(documentKey(surface, id));
+	if (document === undefined) return null;
+	return injectConcertoDesignerBootstrap(document.html);
+}
+
 export function createConcertoHtmlResponse(requestUrl: string): Response {
 	const target = parseConcertoHtmlUrl(requestUrl);
 	if (!target) return new Response('bad request', { status: 400 });
-	const document = documents.get(documentKey(target.surface, target.id));
-	if (document === undefined) return new Response('not found', { status: 404 });
-	return new Response(injectConcertoDesignerBootstrap(document.html), {
+	const body = getConcertoHtmlDocumentBody(target.surface, target.id);
+	if (body === null) return new Response('not found', { status: 404 });
+	return new Response(body, {
 		status: 200,
-		headers: {
-			'content-type': 'text/html; charset=utf-8',
-			'cache-control': 'no-store',
-			'content-security-policy': CONCERTO_HTML_CSP,
-			'permissions-policy':
-				'camera=(), microphone=(), geolocation=(), clipboard-read=(), clipboard-write=(), fullscreen=(), payment=(), usb=()',
-			'x-dns-prefetch-control': 'off',
-			'x-content-type-options': 'nosniff',
-		},
+		headers: { ...CONCERTO_HTML_RESPONSE_HEADERS },
 	});
 }
 

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -34,7 +34,7 @@ import { getLocalIpAddress } from '../utils/networkUtils';
 import { captureException } from '../utils/sentry';
 import { WebSocketMessageHandler } from './handlers';
 import { BroadcastService } from './services';
-import { ApiRoutes, StaticRoutes, WsRoute } from './routes';
+import { ApiRoutes, ConcertoRoutes, StaticRoutes, WsRoute } from './routes';
 import { LiveSessionManager, CallbackRegistry } from './managers';
 
 // Import shared types from canonical location
@@ -188,6 +188,12 @@ export class WebServer {
 	// Security token - persistent or regenerated per startup
 	private securityToken: string;
 
+	// Read-only token for the Concerto HTML document route. Deliberately NOT the
+	// security token above: a Concerto document is sandboxed but can still
+	// navigate its own frame, so anything in its URL can leave the machine.
+	// Regenerated every startup - documents are in-memory and never outlive it.
+	private concertoToken: string = randomUUID().replace(/-/g, '');
+
 	// Local IP address for generating URLs (detected at startup)
 	private localIpAddress: string = 'localhost';
 
@@ -203,6 +209,7 @@ export class WebServer {
 
 	// Route instances
 	private apiRoutes: ApiRoutes;
+	private concertoRoutes: ConcertoRoutes;
 	private staticRoutes: StaticRoutes;
 	private wsRoute: WsRoute;
 
@@ -254,10 +261,12 @@ export class WebServer {
 
 		// Initialize route handlers
 		this.apiRoutes = new ApiRoutes(this.securityToken, this.rateLimitConfig);
+		this.concertoRoutes = new ConcertoRoutes(this.concertoToken);
 		this.staticRoutes = new StaticRoutes(
 			this.securityToken,
 			this.webAssetsPath,
-			this.webDesktopPath
+			this.webDesktopPath,
+			this.concertoToken
 		);
 		this.wsRoute = new WsRoute(this.securityToken);
 
@@ -888,6 +897,9 @@ export class WebServer {
 			isSessionLive: (sessionId) => this.liveSessionManager.isSessionLive(sessionId),
 		});
 		this.apiRoutes.registerRoutes(this.server);
+
+		// Concerto HTML documents for browser clients (no custom-scheme handler).
+		this.concertoRoutes.registerRoutes(this.server);
 
 		// Setup WebSocket route callbacks and register route
 		this.wsRoute.setCallbacks({

--- a/src/main/web-server/callbacks/cadenzaMovementCallbacks.ts
+++ b/src/main/web-server/callbacks/cadenzaMovementCallbacks.ts
@@ -3,6 +3,7 @@ import type { WebServerFactoryDependencies } from '../web-server-factory';
 import { logger } from '../../utils/logger';
 import { isWebContentsAvailable } from '../../utils/safe-send';
 import { requestFromRenderer } from './remoteRequest';
+import { broadcastBridgeEvent } from '../handlers/bridgeHandlers';
 import type { MovementStateSnapshot } from '../../../shared/movement-types';
 import type {
 	ConcertoDesignerAction,
@@ -102,6 +103,16 @@ export function registerCadenzaMovementCallbacks(
 				return false;
 			}
 			const routedParams = applyMovementHtmlPayload(params);
+			// Fan out to web-desktop browser clients as well. `requestFromRenderer`
+			// below talks to the Electron window directly rather than through
+			// `safeSend`, so it never reaches the bridge - without this line a
+			// browser client's Movement store stays empty and every chat chip
+			// pointing at a Movement reports it as unavailable (#1442). Sent with
+			// no response channel: a web client cannot answer the ad-hoc
+			// `remote:movement:response:<uuid>` channel (the bridge only routes
+			// `ipcMain.handle` channels), and the CLI's ack stays the desktop
+			// renderer's to give.
+			broadcastBridgeEvent('remote:movement', [routedParams]);
 			return requestFromRenderer<boolean>(mainWindow, 'remote:movement', {
 				fallback: false,
 				parse: (raw) => raw === true,

--- a/src/main/web-server/routes/concertoRoutes.ts
+++ b/src/main/web-server/routes/concertoRoutes.ts
@@ -1,0 +1,56 @@
+/**
+ * Concerto Routes for Web Server
+ *
+ * Serves agent-authored Concerto HTML documents (Movement panels and Cadenza
+ * cards) over HTTP so the web-desktop browser bundle can render them.
+ *
+ * The Electron app reaches the same documents through the `maestro-concerto://`
+ * protocol handler registered in `src/main/index.ts`. A browser has no such
+ * handler, so without this route every HTML Movement renders as a blank iframe
+ * in web-desktop (see issue #1442).
+ *
+ * Routes:
+ * - GET /$CONCERTO_TOKEN/concerto/render?surface=&id=&revision= - one document
+ *
+ * The path carries a dedicated per-server token rather than the web server's
+ * master security token. Documents are sandboxed, but a sandboxed frame can
+ * still navigate itself, so an agent-authored mockup can exfiltrate anything in
+ * its own URL. See `buildConcertoHtmlHttpPath` in shared/concerto-html.ts.
+ */
+
+import { FastifyInstance } from 'fastify';
+import { logger } from '../../utils/logger';
+import { CONCERTO_HTML_RESPONSE_HEADERS, getConcertoHtmlDocumentBody } from '../../concerto-html';
+
+const LOG_CONTEXT = 'WebServer:Concerto';
+
+interface RenderQuery {
+	surface?: string;
+	id?: string;
+	/** Present so a new revision busts the frame's cache; not used for lookup. */
+	revision?: string;
+}
+
+export class ConcertoRoutes {
+	private concertoToken: string;
+
+	constructor(concertoToken: string) {
+		this.concertoToken = concertoToken;
+	}
+
+	registerRoutes(server: FastifyInstance): void {
+		server.get(`/${this.concertoToken}/concerto/render`, async (request, reply) => {
+			const { surface, id } = request.query as RenderQuery;
+			if ((surface !== 'movement' && surface !== 'cadenza') || !id) {
+				return reply.code(400).type('text/plain').send('bad request');
+			}
+			const body = getConcertoHtmlDocumentBody(surface, id);
+			if (body === null) {
+				return reply.code(404).type('text/plain').send('not found');
+			}
+			return reply.headers({ ...CONCERTO_HTML_RESPONSE_HEADERS }).send(body);
+		});
+
+		logger.debug('Concerto routes registered', LOG_CONTEXT);
+	}
+}

--- a/src/main/web-server/routes/index.ts
+++ b/src/main/web-server/routes/index.ts
@@ -18,6 +18,8 @@ export {
 
 // Note: HistoryEntry type is exported from shared/types.ts (canonical location)
 
+export { ConcertoRoutes } from './concertoRoutes';
+
 export { StaticRoutes } from './staticRoutes';
 
 export {

--- a/src/main/web-server/routes/staticRoutes.ts
+++ b/src/main/web-server/routes/staticRoutes.ts
@@ -79,11 +79,21 @@ export class StaticRoutes {
 	// Web-desktop bundle root - the default browser interface, served at the
 	// token root and at /<token>/desktop. Null when the bundle hasn't been built.
 	private webDesktopPath: string | null;
+	// Read-only token for the Concerto HTML document route, handed to the page so
+	// the renderer can point a Movement's iframe at an HTTP URL the browser can
+	// actually load (the desktop app uses the maestro-concerto:// scheme instead).
+	private concertoToken: string;
 
-	constructor(securityToken: string, webAssetsPath: string | null, webDesktopPath: string | null) {
+	constructor(
+		securityToken: string,
+		webAssetsPath: string | null,
+		webDesktopPath: string | null,
+		concertoToken: string
+	) {
 		this.securityToken = securityToken;
 		this.webAssetsPath = webAssetsPath;
 		this.webDesktopPath = webDesktopPath;
+		this.concertoToken = concertoToken;
 	}
 
 	/**
@@ -138,7 +148,8 @@ export class StaticRoutes {
           sessionId: null,
           tabId: null,
           apiBase: "/${token}/api",
-          wsUrl: "/${token}/ws"
+          wsUrl: "/${token}/ws",
+          concertoToken: ${JSON.stringify(this.concertoToken)}
         };
       </script>`;
 

--- a/src/renderer/components/Concerto/ConcertoHtmlPreview.tsx
+++ b/src/renderer/components/Concerto/ConcertoHtmlPreview.tsx
@@ -2,11 +2,13 @@
  * ConcertoHtmlPreview renders an agent-authored, single-page HTML mockup in an
  * isolated iframe. Main serves the document from a dedicated protocol with a
  * restrictive CSP, so inline CSS and JavaScript work without weakening the
- * parent renderer's policy.
+ * parent renderer's policy. In the web-desktop browser bundle the same document
+ * arrives over HTTP instead - see `resolveConcertoHtmlSrc`.
  */
 
 import { memo, useLayoutEffect, useRef } from 'react';
-import { buildConcertoHtmlUrl, type ConcertoHtmlSurface } from '../../../shared/concerto-html';
+import { type ConcertoHtmlSurface } from '../../../shared/concerto-html';
+import { resolveConcertoHtmlSrc } from '../../utils/concertoHtmlSrc';
 import {
 	handleConcertoDesignerMessage,
 	registerConcertoDesignerFrame,
@@ -48,7 +50,7 @@ export const ConcertoHtmlPreview = memo(function ConcertoHtmlPreview({
 			key={revision}
 			ref={frameRef}
 			title={title}
-			src={buildConcertoHtmlUrl(surface, id, revision)}
+			src={resolveConcertoHtmlSrc(surface, id, revision)}
 			sandbox="allow-scripts"
 			referrerPolicy="no-referrer"
 			data-testid="concerto-html-iframe"

--- a/src/renderer/utils/concertoHtmlSrc.ts
+++ b/src/renderer/utils/concertoHtmlSrc.ts
@@ -1,0 +1,36 @@
+/**
+ * Resolve the iframe `src` for an isolated Concerto HTML document.
+ *
+ * The same renderer runs in two hosts that reach the document different ways:
+ *
+ *   - Electron desktop: the `maestro-concerto://` protocol handler registered
+ *     in the main process (see `src/main/index.ts`).
+ *   - web-desktop browser bundle: an HTTP route on the embedded web server,
+ *     because a browser has no handler for a custom scheme and silently renders
+ *     a blank frame instead (#1442).
+ *
+ * Both serve the identical body and the identical sandboxing headers; only the
+ * address differs, so this is the one place that picks between them.
+ */
+
+import { buildConcertoHtmlHttpPath, buildConcertoHtmlUrl } from '../../shared/concerto-html';
+import type { ConcertoHtmlSurface } from '../../shared/concerto-html';
+import { isWebDesktop } from './runtimeContext';
+
+export function resolveConcertoHtmlSrc(
+	surface: ConcertoHtmlSurface,
+	id: string,
+	revision: number
+): string {
+	if (!isWebDesktop()) return buildConcertoHtmlUrl(surface, id, revision);
+	const concertoToken = (window as { __MAESTRO_CONFIG__?: { concertoToken?: unknown } })
+		.__MAESTRO_CONFIG__?.concertoToken;
+	// An older server build serves a page without the token. Fall back to the
+	// custom scheme rather than to a token-less path: the frame fails to load
+	// either way, and a request that omits the token must not look like a
+	// legitimate one the route should have honored.
+	if (typeof concertoToken !== 'string' || !concertoToken) {
+		return buildConcertoHtmlUrl(surface, id, revision);
+	}
+	return buildConcertoHtmlHttpPath(concertoToken, surface, id, revision);
+}

--- a/src/shared/concerto-html.ts
+++ b/src/shared/concerto-html.ts
@@ -72,6 +72,27 @@ export function buildConcertoHtmlUrl(
 	return `${CONCERTO_HTML_SCHEME}://render/?${params.toString()}`;
 }
 
+/**
+ * Path the embedded web server serves the same document from, for clients that
+ * have no custom-scheme handler (the web-desktop browser bundle).
+ *
+ * `concertoToken` is a per-server secret that is deliberately NOT the web
+ * server's master security token: the document is sandboxed but a sandboxed
+ * frame may still navigate ITSELF, so an agent-authored mockup can read its own
+ * URL and carry whatever is in it off the machine. Leaking a read-only key to
+ * Concerto documents is survivable; leaking the token that grants full remote
+ * control of Maestro is not.
+ */
+export function buildConcertoHtmlHttpPath(
+	concertoToken: string,
+	surface: ConcertoHtmlSurface,
+	id: string,
+	revision: number
+): string {
+	const params = new URLSearchParams({ surface, id, revision: String(revision) });
+	return `/${concertoToken}/concerto/render?${params.toString()}`;
+}
+
 export function parseConcertoHtmlUrl(value: string): ConcertoHtmlTarget | null {
 	try {
 		const url = new URL(value);

--- a/src/web-desktop/electron-shim.ts
+++ b/src/web-desktop/electron-shim.ts
@@ -28,7 +28,14 @@ interface BridgeConfig {
 
 declare global {
 	interface Window {
-		__MAESTRO_CONFIG__?: { wsUrl: string; apiBase: string; securityToken: string };
+		__MAESTRO_CONFIG__?: {
+			wsUrl: string;
+			apiBase: string;
+			securityToken: string;
+			/** Read-only token for the Concerto HTML document route. Optional so an
+			 *  older server's page still type-checks against this bundle. */
+			concertoToken?: string;
+		};
 	}
 }
 


### PR DESCRIPTION
Closes #1442

## Problem

In Web-Desktop, clicking an agent-emitted `maestro://concerto/movement/<id>` link in the chat showed a "Concerto unavailable" toast and opened nothing. The same link works in the desktop app.

The toast is misleading: the panel is not gone, it never arrived. Two independent gaps, both of which have to close before the mockup can open.

### 1. Movement payloads never reach browser clients

`setMovementViewCallback` (`src/main/web-server/callbacks/cadenzaMovementCallbacks.ts`) delivers to the Electron renderer via `requestFromRenderer`, which calls `win.webContents.send(...)` directly. Every other main to renderer push goes through `safeSend`, and `safeSend` is what fans events out to web-desktop bridge clients. This one path skips it, so a browser client's `movementStore` stays empty forever, `flashConcertoTarget` finds nothing in `items` or `dismissedItems`, and `MarkdownLink` fires the toast.

Fixed with an explicit `broadcastBridgeEvent('remote:movement', [routedParams])`. It carries **no response channel** on purpose: a web client cannot answer the ad-hoc `remote:movement:response:<uuid>` channel (`handleBridgeInvoke` only routes channels registered with `ipcMain.handle`), and the CLI's ack should stay the desktop renderer's to give. `onRemoteMovement` already treats the response channel as optional, so no renderer change was needed.

### 2. The document itself is unreachable from a browser

An HTML Movement renders in an iframe pointed at `maestro-concerto://render/?...`. That scheme is registered by `protocol.handle` in the Electron main process; a browser has no handler and silently renders a blank frame. So even with the payload delivered, the mockup would show up empty.

The web server now serves the same documents over HTTP at `GET /$CONCERTO_TOKEN/concerto/render?surface=&id=&revision=`. `createConcertoHtmlResponse` and the new route share one body builder (`getConcertoHtmlDocumentBody`) and one header set (`CONCERTO_HTML_RESPONSE_HEADERS`), so a browser client cannot end up with weaker sandboxing than the desktop gets. `resolveConcertoHtmlSrc` is the single place that picks between the two addresses.

## Why a separate token

The route is **not** mounted under the web server's master security token. A Concerto document is sandboxed (`sandbox allow-scripts` in both the CSP header and the iframe attribute, so it runs in an opaque origin with `connect-src 'none'`), but a sandboxed frame may still navigate *itself*. An agent-authored mockup can therefore read its own URL and carry whatever is in it off the machine. Leaking a read-only key to Concerto documents is survivable; leaking the token that grants full remote control of Maestro is not.

`concertoToken` is regenerated every server start (documents are in-memory and never outlive it) and is injected into `window.__MAESTRO_CONFIG__` alongside the existing bridge config.

## Not covered

- **Cadenza** cards remain desktop-only in Web-Desktop. `flashCadenza` and `concerto-html:release` go over `ipcRenderer.send` to `ipcMain.on` handlers, which the bridge does not route (it only dispatches `ipcMain.handle` channels). Widening that is a bridge-wide change with its own security surface, so it is deliberately out of scope here.
- Designer inspection and compositor screenshots (`movement inspect`) stay desktop-only; they capture from Chromium's compositor via the Electron window.
- When no Electron window exists at all, the movement callback still bails before the fanout, unchanged from today.

## Testing

- New: `src/__tests__/main/web-server/routes/concertoRoutes.test.ts` (serves a registered document with the same policy headers as the protocol handler, 400 on a bad surface or missing id, 404 on an unregistered document).
- New: `src/__tests__/main/web-server/callbacks/cadenzaMovementCallbacks.test.ts` (fans the HTML-routed payload out to bridge clients, sends no response channel, stays inert while the Concerto Encore Feature is off).
- New: `src/__tests__/renderer/utils/concertoHtmlSrc.test.ts` (custom scheme on desktop, token-scoped HTTP path in web-desktop, id encoding, fallback when the server served no token, and that the master security token never lands in a document URL).
- Updated: `staticRoutes.test.ts` for the new constructor argument plus an assertion that the page config carries `concertoToken`.
- `npm run lint`, `npx eslint`, and the full `npx vitest run` suite (1631 files / 39026 tests) pass locally on macOS. Both CI matrix legs still need to go green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Concerto HTML previews now work in web-desktop environments through secure, token-scoped browser routes.
  - Preview URLs support movement and Cadenza documents, including encoded document IDs and revision handling.
  - Web-desktop clients now receive live movement updates alongside the desktop application.
  - Concerto documents retain sandboxing and security headers across supported preview environments.

- **Bug Fixes**
  - Invalid or unavailable preview requests now return clear bad-request or not-found responses.
  - Preview URL resolution safely falls back when web-desktop configuration is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->