### PR TITLE
refactor(ui): use shared timestamp helpers on history and participant cards

### DIFF
--- a/src/renderer/components/History/HistoryEntryItem.tsx
+++ b/src/renderer/components/History/HistoryEntryItem.tsx
@@ -8,8 +8,6 @@ import { formatTimestamp } from '../../../shared/formatters';
 import { humanizeCueEventType } from '../../../shared/cue/cue-summary';
 import { getTokenSourcePill } from '../../../shared/claudeTokenModeLabel';
 
-const formatTime = (timestamp: number) => formatTimestamp(timestamp, 'smart');
-
 export interface HistoryEntryItemProps {
 	entry: HistoryEntry;
 	index: number;
@@ -172,7 +170,7 @@ export const HistoryEntryItem = memo(function HistoryEntryItem({
 
 				{/* Timestamp */}
 				<span className="text-[10px] flex-shrink-0" style={{ color: theme.colors.textDim }}>
-					{formatTime(entry.timestamp)}
+					{formatTimestamp(entry.timestamp, 'smart')}
 				</span>
 			</div>
 

--- a/src/renderer/components/ParticipantCard.tsx
+++ b/src/renderer/components/ParticipantCard.tsx
@@ -21,7 +21,8 @@ import { getStatusColor } from '../utils/theme';
 import { formatCost } from '../utils/formatters';
 import { safeClipboardWrite } from '../utils/clipboard';
 import { parsePeekOutput, formatPeekLines } from '../utils/peekOutputParser';
-import { formatTimestamp } from '../../shared/formatters';
+import { formatTimestamp, formatRelativeTime } from '../../shared/formatters';
+import { DURATION_MS } from '../../shared/duration';
 import { notifyToast } from '../stores/notificationStore';
 import { logger } from '../utils/logger';
 import { SshRemotePill } from './ui/SshRemotePill';
@@ -38,13 +39,14 @@ interface ParticipantCardProps {
 }
 
 /**
- * Format time as relative or absolute.
+ * Recent activity uses the shared relative formatter (`just now` / `Xm ago`).
+ * Older than an hour stays a clock time so a day-old participant does not
+ * read as `23h ago` / `2d ago` (that would change the card's existing display).
  */
-function formatTime(timestamp: number): string {
-	const now = Date.now();
-	const diff = now - timestamp;
-	if (diff < 60000) return 'just now';
-	if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
+function formatParticipantActivity(timestamp: number): string {
+	if (Date.now() - timestamp < DURATION_MS.hour) {
+		return formatRelativeTime(timestamp);
+	}
 	return formatTimestamp(timestamp, 'time');
 }
 
@@ -217,7 +219,7 @@ export function ParticipantCard({
 						</span>
 					)}
 					{participant.lastActivity && (
-						<span title="Last activity">{formatTime(participant.lastActivity)}</span>
+						<span title="Last activity">{formatParticipantActivity(participant.lastActivity)}</span>
 					)}
 				</div>
 				<span>{participant.agentId}</span>


### PR DESCRIPTION
## Summary
- History list and group-chat participant cards now use the shared timestamp helpers in `src/shared/formatters.ts`
- Display is unchanged: History today = time only, older = date + time; participants = just now / Xm ago / clock after 1 hour

## Test plan
- [x] Right Bar → History: today shows time only; older rows show date + time; click opens detail; list does not switch to "ago"
- [x] Group chat → Participants: just now / Xm ago / clock time after 1 hour (not "2h ago")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Consistency Improvements**
  * Improved timestamp formatting across history entries and participant activity displays.
  * Relative activity times now follow the app’s shared formatting conventions while preserving clock-time formatting for older activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->