### PR TITLE
fix(interrupt): stop every in-flight process for the agent, not just the active tab

### DIFF
--- a/src/__tests__/renderer/hooks/useInterruptHandler.test.ts
+++ b/src/__tests__/renderer/hooks/useInterruptHandler.test.ts
@@ -45,6 +45,7 @@ const mockMaestro = {
 	process: {
 		interrupt: vi.fn().mockResolvedValue(undefined),
 		kill: vi.fn().mockResolvedValue(undefined),
+		getActiveProcesses: vi.fn().mockResolvedValue([]),
 	},
 };
 
@@ -359,6 +360,162 @@ describe('useInterruptHandler', () => {
 			const sessions = useSessionStore.getState().sessions;
 			expect(sessions[0].state).toBe('idle'); // active - interrupted
 			expect(sessions[1].state).toBe('busy'); // other - unchanged
+		});
+	});
+
+	// ========================================================================
+	// Stop targets every in-flight process for the agent (issue #1448)
+	//
+	// The state update idles EVERY busy tab, so signalling only the active tab
+	// left a live agent process recorded as idle. Once recorded idle, closing
+	// that tab no longer parks it in orphanedThinkingTabs, dropping the last
+	// reference to a running process with no UI path left to stop it.
+	// ========================================================================
+	describe('stops every busy tab, not just the active one', () => {
+		it('interrupts a busy background tab while a different tab is active', async () => {
+			const backgroundTab = createTab({ id: 'tab-a', state: 'busy' });
+			const activeTab = createTab({ id: 'tab-b', state: 'busy' });
+			const session = createSession({
+				id: 'sess-multi',
+				inputMode: 'ai',
+				state: 'busy',
+				aiTabs: [backgroundTab, activeTab],
+				activeTabId: 'tab-b',
+			});
+			useSessionStore.setState({ sessions: [session], activeSessionId: 'sess-multi' });
+
+			const deps = createDeps({ sessionsRef: { current: [session] } });
+			const { result } = renderHook(() => useInterruptHandler(deps));
+
+			await act(async () => {
+				await result.current.handleInterrupt();
+			});
+
+			expect(mockMaestro.process.interrupt).toHaveBeenCalledWith('sess-multi-ai-tab-b');
+			expect(mockMaestro.process.interrupt).toHaveBeenCalledWith('sess-multi-ai-tab-a');
+		});
+
+		it('interrupts a busy orphaned tab (closed while its turn was running)', async () => {
+			const activeTab = createTab({ id: 'tab-b', state: 'busy' });
+			const orphan = createTab({ id: 'tab-orphan', state: 'busy' });
+			const session = createSession({
+				id: 'sess-orphan',
+				inputMode: 'ai',
+				state: 'busy',
+				aiTabs: [activeTab],
+				activeTabId: 'tab-b',
+				orphanedThinkingTabs: [orphan],
+			});
+			useSessionStore.setState({ sessions: [session], activeSessionId: 'sess-orphan' });
+
+			const deps = createDeps({ sessionsRef: { current: [session] } });
+			const { result } = renderHook(() => useInterruptHandler(deps));
+
+			await act(async () => {
+				await result.current.handleInterrupt();
+			});
+
+			expect(mockMaestro.process.interrupt).toHaveBeenCalledWith('sess-orphan-ai-tab-orphan');
+		});
+
+		it('signals the active tab exactly once when it is also busy', async () => {
+			const tab = createTab({ id: 'tab-solo', state: 'busy' });
+			const session = createSession({
+				id: 'sess-dedupe',
+				inputMode: 'ai',
+				state: 'busy',
+				aiTabs: [tab],
+				activeTabId: 'tab-solo',
+			});
+			useSessionStore.setState({ sessions: [session], activeSessionId: 'sess-dedupe' });
+
+			const deps = createDeps({ sessionsRef: { current: [session] } });
+			const { result } = renderHook(() => useInterruptHandler(deps));
+
+			await act(async () => {
+				await result.current.handleInterrupt();
+			});
+
+			const calls = mockMaestro.process.interrupt.mock.calls.filter(
+				([id]) => id === 'sess-dedupe-ai-tab-solo'
+			);
+			expect(calls).toHaveLength(1);
+		});
+
+		it('leaves idle background tabs alone', async () => {
+			const idleTab = createTab({ id: 'tab-idle', state: 'idle' });
+			const activeTab = createTab({ id: 'tab-b', state: 'busy' });
+			const session = createSession({
+				id: 'sess-idle-bg',
+				inputMode: 'ai',
+				state: 'busy',
+				aiTabs: [idleTab, activeTab],
+				activeTabId: 'tab-b',
+			});
+			useSessionStore.setState({ sessions: [session], activeSessionId: 'sess-idle-bg' });
+
+			const deps = createDeps({ sessionsRef: { current: [session] } });
+			const { result } = renderHook(() => useInterruptHandler(deps));
+
+			await act(async () => {
+				await result.current.handleInterrupt();
+			});
+
+			expect(mockMaestro.process.interrupt).not.toHaveBeenCalledWith('sess-idle-bg-ai-tab-idle');
+		});
+
+		it('interrupts forced-parallel processes of a busy background tab', async () => {
+			mockMaestro.process.getActiveProcesses.mockResolvedValueOnce([
+				{ sessionId: 'sess-fp-ai-tab-a-fp-1700000000' },
+				{ sessionId: 'sess-fp-ai-tab-unrelated' },
+			]);
+
+			const backgroundTab = createTab({ id: 'tab-a', state: 'busy' });
+			const activeTab = createTab({ id: 'tab-b', state: 'busy' });
+			const session = createSession({
+				id: 'sess-fp',
+				inputMode: 'ai',
+				state: 'busy',
+				aiTabs: [backgroundTab, activeTab],
+				activeTabId: 'tab-b',
+			});
+			useSessionStore.setState({ sessions: [session], activeSessionId: 'sess-fp' });
+
+			const deps = createDeps({ sessionsRef: { current: [session] } });
+			const { result } = renderHook(() => useInterruptHandler(deps));
+
+			await act(async () => {
+				await result.current.handleInterrupt();
+			});
+
+			expect(mockMaestro.process.interrupt).toHaveBeenCalledWith('sess-fp-ai-tab-a-fp-1700000000');
+			expect(mockMaestro.process.interrupt).not.toHaveBeenCalledWith('sess-fp-ai-tab-unrelated');
+		});
+
+		it('force-kills every target when the primary interrupt fails', async () => {
+			mockMaestro.process.interrupt.mockRejectedValueOnce(new Error('interrupt failed'));
+			window.confirm = vi.fn(() => true);
+
+			const backgroundTab = createTab({ id: 'tab-a', state: 'busy' });
+			const activeTab = createTab({ id: 'tab-b', state: 'busy' });
+			const session = createSession({
+				id: 'sess-kill-all',
+				inputMode: 'ai',
+				state: 'busy',
+				aiTabs: [backgroundTab, activeTab],
+				activeTabId: 'tab-b',
+			});
+			useSessionStore.setState({ sessions: [session], activeSessionId: 'sess-kill-all' });
+
+			const deps = createDeps({ sessionsRef: { current: [session] } });
+			const { result } = renderHook(() => useInterruptHandler(deps));
+
+			await act(async () => {
+				await result.current.handleInterrupt();
+			});
+
+			expect(mockMaestro.process.kill).toHaveBeenCalledWith('sess-kill-all-ai-tab-b');
+			expect(mockMaestro.process.kill).toHaveBeenCalledWith('sess-kill-all-ai-tab-a');
 		});
 	});
 

--- a/src/renderer/hooks/agent/useInterruptHandler.ts
+++ b/src/renderer/hooks/agent/useInterruptHandler.ts
@@ -2,7 +2,7 @@
  * useInterruptHandler - extracted from App.tsx
  *
  * Handles interrupting/stopping running AI processes:
- *   - Sends SIGINT to active process (AI or terminal mode)
+ *   - Sends SIGINT to every process this agent still has in flight (AI or terminal mode)
  *   - Cancels pending synopsis before interrupting
  *   - Cleans up thinking/tool logs from interrupted tabs
  *   - Processes execution queue after interruption
@@ -17,6 +17,7 @@ import { useSessionStore, selectActiveSession } from '../../stores/sessionStore'
 import { generateId } from '../../utils/ids';
 import {
 	getActiveTab,
+	getBusyTabs,
 	markTabRunningQueuedItem,
 	resolveQueuedItemTarget,
 } from '../../utils/tabHelpers';
@@ -43,6 +44,63 @@ export interface UseInterruptHandlerDeps {
 export interface UseInterruptHandlerReturn {
 	/** Interrupt the active session's running process */
 	handleInterrupt: () => Promise<void>;
+}
+
+// ============================================================================
+// Target resolution
+// ============================================================================
+
+/**
+ * Every process id Stop must signal for this agent.
+ *
+ * Stop is an AGENT-level action, not a tab-level one: `handleInterrupt` idles
+ * EVERY busy tab, so signalling only the active tab left the other tabs'
+ * agent processes running while the store recorded them as idle. Once a tab is
+ * recorded idle, `closeTab` no longer parks it in `orphanedThinkingTabs`, so
+ * closing it dropped the last reference to a live agent process and left no UI
+ * path to stop it (issue #1448).
+ *
+ * Orphans are included for the same reason: a closed-but-still-draining tab is
+ * still writing under this agent, and Stop is the only control the user has.
+ *
+ * The primary target is always first so callers can tell a failed primary
+ * interrupt (which escalates to force-kill) from a non-critical secondary one.
+ *
+ * @param session - The agent whose processes should be signalled
+ * @param primaryTargetId - Process id for the active tab / terminal
+ * @param includeAiTabs - False in terminal mode, where AI tabs are not the target
+ * @returns Deduped process ids, primary first
+ */
+async function collectInterruptTargets(
+	session: Session,
+	primaryTargetId: string,
+	includeAiTabs: boolean
+): Promise<string[]> {
+	const targets = [primaryTargetId];
+	if (!includeAiTabs) return targets;
+
+	for (const tab of getBusyTabs(session, { includeOrphans: true })) {
+		const tabTargetId = `${session.id}-ai-${tab.id}`;
+		if (!targets.includes(tabTargetId)) targets.push(tabTargetId);
+	}
+
+	// Forced-parallel spawns append `-fp-{timestamp}` to their tab's process id,
+	// so they have to be discovered from the live process list rather than derived.
+	try {
+		const activeProcesses = await window.maestro.process.getActiveProcesses();
+		for (const base of [...targets]) {
+			const fpPrefix = `${base}-fp-`;
+			for (const proc of activeProcesses) {
+				if (proc.sessionId.startsWith(fpPrefix) && !targets.includes(proc.sessionId)) {
+					targets.push(proc.sessionId);
+				}
+			}
+		}
+	} catch {
+		// Non-critical - forced parallel lookup failure shouldn't block interrupt
+	}
+
+	return targets;
 }
 
 // ============================================================================
@@ -82,30 +140,20 @@ export function useInterruptHandler(deps: UseInterruptHandlerDeps): UseInterrupt
 			);
 		}
 
+		// Every in-flight process for this agent, not just the active tab's. Resolved
+		// once and reused by the force-kill fallback below.
+		const targetSessionIds = await collectInterruptTargets(
+			activeSession,
+			targetSessionId,
+			currentMode === 'ai'
+		);
+
 		try {
-			// Interrupt the primary process and any forced-parallel processes for this tab.
-			// Forced parallel spawns append `-fp-{timestamp}` to the session ID, so we need
-			// to find and interrupt those as well.
-			const interruptPromises: Promise<void>[] = [
-				(window as any).maestro.process.interrupt(targetSessionId),
-			];
-
-			if (currentMode === 'ai') {
-				try {
-					const activeProcesses = await window.maestro.process.getActiveProcesses();
-					const fpPrefix = `${targetSessionId}-fp-`;
-					const fpProcesses = activeProcesses.filter((p) => p.sessionId.startsWith(fpPrefix));
-					for (const fp of fpProcesses) {
-						interruptPromises.push((window as any).maestro.process.interrupt(fp.sessionId));
-					}
-				} catch {
-					// Non-critical - forced parallel lookup failure shouldn't block interrupt
-				}
-			}
-
-			const results = await Promise.allSettled(interruptPromises);
+			const results = await Promise.allSettled(
+				targetSessionIds.map((id) => window.maestro.process.interrupt(id))
+			);
 			// If the primary interrupt failed, throw to trigger force-kill fallback.
-			// Secondary (forced-parallel) failures are non-critical.
+			// Secondary (other busy tabs, forced-parallel) failures are non-critical.
 			if (results[0].status === 'rejected') {
 				throw results[0].reason;
 			}
@@ -263,24 +311,12 @@ export function useInterruptHandler(deps: UseInterruptHandlerDeps): UseInterrupt
 
 			if (shouldKill) {
 				try {
-					// Kill primary process and any forced-parallel processes
-					const killPromises: Promise<void>[] = [
-						(window as any).maestro.process.kill(targetSessionId),
-					];
-					if (currentMode === 'ai') {
-						try {
-							const activeProcesses = await window.maestro.process.getActiveProcesses();
-							const fpPrefix = `${targetSessionId}-fp-`;
-							for (const fp of activeProcesses.filter((p) => p.sessionId.startsWith(fpPrefix))) {
-								killPromises.push((window as any).maestro.process.kill(fp.sessionId));
-							}
-						} catch {
-							// Non-critical
-						}
-					}
-					const killResults = await Promise.allSettled(killPromises);
+					// Kill the same set the interrupt targeted (primary first).
+					const killResults = await Promise.allSettled(
+						targetSessionIds.map((id) => window.maestro.process.kill(id))
+					);
 					// If the primary kill failed, throw to trigger kill error handling.
-					// Secondary (forced-parallel) failures are non-critical.
+					// Secondary (other busy tabs, forced-parallel) failures are non-critical.
 					if (killResults[0].status === 'rejected') {
 						throw killResults[0].reason;
 					}


### PR DESCRIPTION
Closes #1448

## The bug

A Codex turn kept running after the user pressed Stop. The agent persisted as `state: 'idle'` with `aiPid: 0`, `orphanedThinkingTabs` was empty, and the tab was gone from `aiTabs` - while `codex exec --json resume <thread>`, its native binary child, and `codex-code-mode-host` were all still alive under Maestro's PID. There was no UI control left that could reach it.

## Root cause

Stop is an agent-level action, but it was only half agent-level.

`handleInterrupt`'s state update idles **every** busy tab:

```ts
if (tab.state === 'busy') {
    return { ...tab, state: 'idle' as const, ... };
}
```

...but it only ever signalled the **active** tab's process (`${session.id}-ai-${activeTab.id}`, plus that one tab's `-fp-` forced-parallel spawns). A busy background tab was therefore recorded as idle in the store while its agent process kept running.

That mismatch is what strands the process. `closeTab` only parks a tab in `orphanedThinkingTabs` when `tabToClose.state === 'busy'`:

```ts
const closedTabWasBusy = tabToClose.state === 'busy';
```

So once Stop had wrongly marked the tab idle, closing it dropped the last renderer reference to a live agent process. That reproduces the reported state exactly: agent idle, `aiPid 0`, empty orphans, process still running.

This also explains why the reporter's step 2 worked and step 5 did not - the first Stop was pressed on the active tab, the second was not.

## The fix

Collect the interrupt targets up front rather than deriving one:

- the active tab / terminal (stays first),
- every busy `aiTab`,
- every busy orphaned (closed-but-still-draining) tab, via the existing `getBusyTabs(session, { includeOrphans: true })`,
- the `-fp-` forced-parallel spawns of all of the above.

The primary target stays at index 0 so a failed primary interrupt still escalates to the force-kill fallback, which now kills the same set instead of re-deriving a narrower one. Terminal mode is unchanged: it targets only the shell.

Including orphans is the part that gives a closed-but-still-running tab a Stop path at all, which was the reporter's "no UI control that stops tab A's process".

## Tests

Six regression tests in `src/__tests__/renderer/hooks/useInterruptHandler.test.ts`; four of them fail on `main` and pass here:

- interrupts a busy background tab while a different tab is active
- interrupts a busy orphaned tab (closed while its turn was running)
- signals the active tab exactly once when it is also busy (dedupe)
- leaves idle background tabs alone
- interrupts forced-parallel processes of a busy background tab
- force-kills every target when the primary interrupt fails

## Validation

- `npm run lint` (all three tsconfigs) clean
- `npx eslint` on the changed source clean
- `npx vitest run src/__tests__/renderer/hooks/` - 190 files, 4804 passed
- `npx vitest run src/__tests__/renderer/utils/` - 68 files, 2371 passed

## Deliberately not in scope

The issue also flags `ChildProcessSpawner`'s `handleExit(sessionId, code || 0, ...)`, which coerces a signal kill (`code === null`) to exit 0 and is why the ledger recorded "run completed (exit 0)" for a turn that was killed mid-tool-call. That is a real second defect, but changing exit-code semantics feeds `detectErrorFromExit`, the retry paths, and the run ledger, so it deserves its own PR rather than riding along with the stop-path fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interrupting an agent now stops all of its active processes across busy tabs, including background and orphaned tabs.
  * Forced-parallel processes are also stopped, with duplicate signals prevented.
  * If a graceful interruption fails, all affected processes are force-terminated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->