### PR TITLE
fix(sentry): match noise rules against the whole exception chain, not values[0]

### DIFF
--- a/src/__tests__/shared/sentryFilters.test.ts
+++ b/src/__tests__/shared/sentryFilters.test.ts
@@ -234,6 +234,27 @@ describe('shouldDropSentryEvent', () => {
 			).toBe(true);
 		});
 
+		// Regression (MAESTRO-MR): MarketplaceFetchError carries the original failure
+		// as its `cause`, so Sentry's LinkedErrors integration ships TWO exception
+		// values ordered root-cause-first. The classifier used to read values[0]
+		// only, saw the bare `TypeError: fetch failed`, and let the event through -
+		// the rule above looked correct but never fired in the field.
+		it('drops marketplace fetch failures when Sentry expanded the cause chain', () => {
+			expect(
+				shouldDropSentryEvent({
+					exception: {
+						values: [
+							{ type: 'TypeError', value: 'fetch failed' },
+							{
+								type: 'MarketplaceFetchError',
+								value: 'Network error fetching document: fetch failed',
+							},
+						],
+					},
+				})
+			).toBe(true);
+		});
+
 		it('drops GitHub CLI network failures when the user is offline', () => {
 			expect(
 				shouldDropSentryEvent(

--- a/src/shared/sentryFilters.ts
+++ b/src/shared/sentryFilters.ts
@@ -28,11 +28,18 @@ interface MinimalSentryEvent {
  * (OS env issues, native crashes, user-typed bad paths, third-party JS injection).
  */
 export function shouldDropSentryEvent(event: MinimalSentryEvent): boolean {
-	const firstException = event.exception?.values?.[0];
+	const values = event.exception?.values ?? [];
+	const firstException = values[0];
 	const value = firstException?.value ?? '';
 	const type = firstException?.type ?? '';
 	const message = event.message ?? '';
-	const haystack = `${type}: ${value}\n${message}`;
+	// Match against EVERY exception in the chain, not just values[0]. Sentry's
+	// LinkedErrors integration expands an Error's `cause` into extra entries and
+	// orders them root-cause-first, so when we wrap a low-level failure the
+	// wrapper we actually named a rule after lands at the END of the array. That
+	// made the MarketplaceFetchError rule in section 5 dead on arrival: it only
+	// ever saw the underlying `TypeError: fetch failed` at values[0]. (MAESTRO-MR)
+	const haystack = [...values.map((v) => `${v.type ?? ''}: ${v.value ?? ''}`), message].join('\n');
 
 	// ---- 1. OS / filesystem environment ----
 


### PR DESCRIPTION
## The bug

`shouldDropSentryEvent` built its match haystack from `exception.values[0]` only:

```ts
const firstException = event.exception?.values?.[0];
const haystack = `${type}: ${value}\n${message}`;
```

Sentry's LinkedErrors integration expands an `Error`'s `cause` into **additional** `exception.values` entries, ordered **root-cause-first**. So for any error we wrap, the wrapper we actually named a rule after lands at the *end* of the array, not at index 0.

That makes the section-5 rule on `main` dead on arrival:

```ts
if (/MarketplaceFetchError: Network error fetching .*: fetch failed/i.test(haystack)) return true;
```

`MarketplaceFetchError` takes the underlying failure as its `cause` (`src/shared/marketplace-types.ts:145`), and `marketplace-service.ts` throws it that way at every network boundary. The classifier therefore only ever saw the bare `TypeError: fetch failed` at `values[0]`, and every offline marketplace fetch was reported instead of dropped.

This is **MAESTRO-MR**. It was fixed on `rc` in #1214; `main` is a separate lineage that never receives `rc` merges (`git rev-list --left-right --count origin/main...origin/rc` = `0 1122`), so `main` still had it.

## The fix

```ts
const values = event.exception?.values ?? [];
const haystack = [...values.map((v) => `${v.type ?? ''}: ${v.value ?? ''}`), message].join('\n');
```

- **Byte-identical to `rc`'s hunk** (verified with `diff` against `origin/rc:src/shared/sentryFilters.ts`), so the two branches converge. A dry-run `git merge --no-ff origin/rc` auto-merges `sentryFilters.ts` with no conflict.
- `type` and `value` stay bound to `values[0]`. The native-crash rules in section 3 and the Windows `lstat` rule test those directly, and they are properties of the *reported* exception, not of the chain.
- No haystack rule is `^`-anchored (checked all of them), so widening the haystack cannot break an existing match.

## Test

The pre-existing marketplace test passed while the rule was dead in the field, because it constructed a **single-value** event, which is a shape the field never produces for a wrapped error. The added regression test builds the real two-value chain.

Proven non-vacuous: `git stash push -- src/shared/sentryFilters.ts` (source only, keeping the test), then `npx vitest run src/__tests__/shared/sentryFilters.test.ts` fails exactly the new case (`expected false to be true`) and nothing else. With the fix, 30/30 pass.

## Checks

- `npx eslint src/shared/sentryFilters.ts` - clean, no output.
- `npx tsc --noEmit -p tsconfig.json` - 112 errors, **identical count on clean `main`** (`git stash push -u` + re-run), none in the touched files. Pre-existing missing optional deps.
- Prior Sentry guards re-verified intact at HEAD: M9 `RangeError` carve-out (both loops), `write EPIPE`, `isExpectedGroomingFailure`, 3x `db.isReady()`, `isExpectedQuotaStatus`, `isExpectedConnectionFailure`, `isExpectedSqliteError`, `EXPECTED_WATCH_ERROR_CODES`, `killPty`, `resolveConfigDirKey` memo, `asarUnpack` native chain.
- IPC wiring sweep: 437 `ipcMain.handle` vs 438 preload `ipcRenderer.invoke`; the only gap is the known-dead `tempfile:*` surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error filtering to correctly identify and suppress marketplace fetch errors, including those with nested exception details.
  * Prevented duplicate or unnecessary reporting of these network-related errors to error monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->