### PR TITLE
fix(notifications): stay active while an agent still has queued work

### DIFF
--- a/src/__tests__/renderer/hooks/ui/useIdleNotification.test.tsx
+++ b/src/__tests__/renderer/hooks/ui/useIdleNotification.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * Tests for useIdleNotification.
+ *
+ * The rule under test: announce idle only when there is genuinely nothing left
+ * to do. "No turn in flight" is NOT the same question - the exit reducer parks
+ * an agent at `state: 'idle'` while holding its queue whenever a retry is
+ * counting down, so a busy -> idle edge can happen with a dozen messages still
+ * lined up. A paused item is waiting on the user rather than on us, so a queue
+ * holding only paused items is genuinely finished and must still announce.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { useIdleNotification } from '../../../../renderer/hooks/ui/useIdleNotification';
+import { useSessionStore } from '../../../../renderer/stores/sessionStore';
+import { useNotificationStore } from '../../../../renderer/stores/notificationStore';
+import { useBatchStore } from '../../../../renderer/stores/batchStore';
+import { createMockSession } from '../../../helpers/mockSession';
+import type { QueuedItem, Session } from '../../../../renderer/types';
+
+const speak = vi.fn().mockResolvedValue(undefined);
+
+function queuedItem(overrides: Partial<QueuedItem> = {}): QueuedItem {
+	return {
+		id: 'q-1',
+		timestamp: 1700000000000,
+		tabId: 'tab-1',
+		type: 'message',
+		text: 'do the thing',
+		...overrides,
+	} as QueuedItem;
+}
+
+/** Put a single agent in the store with the given state and queue. */
+function setSession(state: Session['state'], executionQueue: QueuedItem[] = []): void {
+	useSessionStore.setState({
+		sessions: [createMockSession({ id: 'sess-1', state, executionQueue })],
+	});
+}
+
+beforeEach(() => {
+	speak.mockClear();
+	(globalThis as any).window.maestro = {
+		...((globalThis as any).window.maestro ?? {}),
+		notification: { speak },
+	};
+
+	useSessionStore.setState({ sessions: [] });
+	useBatchStore.setState({ batches: {} } as any);
+	useNotificationStore.setState((s) => ({
+		config: {
+			...s.config,
+			idleNotificationEnabled: true,
+			idleNotificationCommand: 'say Maestro is idle',
+		},
+	}));
+});
+
+describe('useIdleNotification', () => {
+	it('does not announce idle while an agent still has runnable queued work', () => {
+		setSession('busy', [queuedItem()]);
+		const { rerender } = renderHook(() => useIdleNotification());
+
+		// Turn ends, but the queue is held (a retry is counting down). The agent
+		// is genuinely idle and genuinely not finished.
+		act(() => setSession('idle', [queuedItem()]));
+		rerender();
+
+		expect(speak).not.toHaveBeenCalled();
+	});
+
+	it('announces idle when the queue holds only paused items', () => {
+		setSession('busy', [queuedItem({ paused: true })]);
+		const { rerender } = renderHook(() => useIdleNotification());
+
+		act(() => setSession('idle', [queuedItem({ paused: true })]));
+		rerender();
+
+		// A held item waits on the user, so this agent really is done.
+		expect(speak).toHaveBeenCalledTimes(1);
+	});
+
+	it('announces once on the busy -> idle edge with an empty queue', () => {
+		setSession('busy', []);
+		const { rerender } = renderHook(() => useIdleNotification());
+
+		act(() => setSession('idle', []));
+		rerender();
+		expect(speak).toHaveBeenCalledTimes(1);
+
+		// Staying idle must not re-announce - it fires on the edge, not the level.
+		act(() => setSession('idle', []));
+		rerender();
+		expect(speak).toHaveBeenCalledTimes(1);
+	});
+
+	it('announces when the queue drains down to only paused items', () => {
+		setSession('busy', [queuedItem(), queuedItem({ id: 'q-2', paused: true })]);
+		const { rerender } = renderHook(() => useIdleNotification());
+
+		// The runnable item is still queued: silent.
+		act(() => setSession('idle', [queuedItem(), queuedItem({ id: 'q-2', paused: true })]));
+		rerender();
+		expect(speak).not.toHaveBeenCalled();
+
+		// It ran and left only the held one behind: now we are done.
+		act(() => setSession('idle', [queuedItem({ id: 'q-2', paused: true })]));
+		rerender();
+		expect(speak).toHaveBeenCalledTimes(1);
+	});
+
+	it('stays silent when another agent still has queued work', () => {
+		useSessionStore.setState({
+			sessions: [
+				createMockSession({ id: 'sess-1', state: 'busy', executionQueue: [] }),
+				createMockSession({ id: 'sess-2', state: 'idle', executionQueue: [queuedItem()] }),
+			],
+		});
+		const { rerender } = renderHook(() => useIdleNotification());
+
+		useSessionStore.setState({
+			sessions: [
+				createMockSession({ id: 'sess-1', state: 'idle', executionQueue: [] }),
+				createMockSession({ id: 'sess-2', state: 'idle', executionQueue: [queuedItem()] }),
+			],
+		});
+		act(() => {});
+		rerender();
+
+		expect(speak).not.toHaveBeenCalled();
+	});
+
+	it('does not announce when the setting is disabled', () => {
+		useNotificationStore.setState((s) => ({
+			config: { ...s.config, idleNotificationEnabled: false },
+		}));
+		setSession('busy', []);
+		const { rerender } = renderHook(() => useIdleNotification());
+
+		act(() => setSession('idle', []));
+		rerender();
+
+		expect(speak).not.toHaveBeenCalled();
+	});
+});

--- a/src/__tests__/renderer/hooks/ui/useRestartWhenIdle.test.tsx
+++ b/src/__tests__/renderer/hooks/ui/useRestartWhenIdle.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * Tests for useRestartWhenIdle.
+ *
+ * This hook reads the SAME activity selectors as useIdleNotification, which is
+ * the point: the two must not drift on what "idle" means. The stakes are higher
+ * here - announcing idle over a full queue is annoying, restarting the app out
+ * from under one throws the queued work away.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { useRestartWhenIdle } from '../../../../renderer/hooks/ui/useRestartWhenIdle';
+import { useSessionStore } from '../../../../renderer/stores/sessionStore';
+import { useRestartPendingStore } from '../../../../renderer/stores/restartPendingStore';
+import { useBatchStore } from '../../../../renderer/stores/batchStore';
+import { createMockSession } from '../../../helpers/mockSession';
+import type { QueuedItem, Session } from '../../../../renderer/types';
+
+const install = vi.fn();
+
+function queuedItem(overrides: Partial<QueuedItem> = {}): QueuedItem {
+	return {
+		id: 'q-1',
+		timestamp: 1700000000000,
+		tabId: 'tab-1',
+		type: 'message',
+		text: 'do the thing',
+		...overrides,
+	} as QueuedItem;
+}
+
+function setSession(state: Session['state'], executionQueue: QueuedItem[] = []): void {
+	useSessionStore.setState({
+		sessions: [createMockSession({ id: 'sess-1', state, executionQueue })],
+	});
+}
+
+beforeEach(() => {
+	install.mockClear();
+	(globalThis as any).window.maestro = {
+		...((globalThis as any).window.maestro ?? {}),
+		updates: { install },
+	};
+
+	useSessionStore.setState({ sessions: [] });
+	useBatchStore.setState({ batches: {} } as any);
+	useRestartPendingStore.setState({ pending: true });
+});
+
+describe('useRestartWhenIdle', () => {
+	it('does not restart while an agent still has runnable queued work', () => {
+		setSession('busy', [queuedItem()]);
+		const { rerender } = renderHook(() => useRestartWhenIdle());
+
+		act(() => setSession('idle', [queuedItem()]));
+		rerender();
+
+		expect(install).not.toHaveBeenCalled();
+		// The pending flag must survive, or the deferred restart is silently lost.
+		expect(useRestartPendingStore.getState().pending).toBe(true);
+	});
+
+	it('restarts when the queue holds only paused items', () => {
+		setSession('busy', [queuedItem({ paused: true })]);
+		const { rerender } = renderHook(() => useRestartWhenIdle());
+
+		act(() => setSession('idle', [queuedItem({ paused: true })]));
+		rerender();
+
+		expect(install).toHaveBeenCalledTimes(1);
+	});
+
+	it('restarts on the busy -> idle edge with an empty queue', () => {
+		setSession('busy', []);
+		const { rerender } = renderHook(() => useRestartWhenIdle());
+
+		act(() => setSession('idle', []));
+		rerender();
+
+		expect(install).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not restart when no update is pending', () => {
+		useRestartPendingStore.setState({ pending: false });
+		setSession('busy', []);
+		const { rerender } = renderHook(() => useRestartWhenIdle());
+
+		act(() => setSession('idle', []));
+		rerender();
+
+		expect(install).not.toHaveBeenCalled();
+	});
+});

--- a/src/renderer/hooks/ui/useIdleNotification.ts
+++ b/src/renderer/hooks/ui/useIdleNotification.ts
@@ -1,13 +1,28 @@
 import { useEffect, useRef } from 'react';
-import { useSessionStore, selectIsAnySessionBusy } from '../../stores/sessionStore';
+import {
+	useSessionStore,
+	selectIsAnySessionBusy,
+	selectHasAnyRunnableQueuedWork,
+} from '../../stores/sessionStore';
 import { selectHasAnyActiveBatch, useBatchStore } from '../../stores/batchStore';
 import { useNotificationStore, selectConfig } from '../../stores/notificationStore';
 
 /**
  * Watches for the transition from "any activity" to "fully idle" and fires
- * the idle notification command. Activity means any session is busy OR any
- * Auto Run batch is running. Cue tasks are explicitly excluded from this
- * check (they don't set session state to busy or create batch runs).
+ * the idle notification command. Activity means any session is busy, any
+ * session still has runnable queued work, OR any Auto Run batch is running.
+ * Cue tasks are explicitly excluded from this check (they don't set session
+ * state to busy or create batch runs).
+ *
+ * The queue term is not redundant with the busy term. A turn ending does not
+ * mean the work is over: the exit reducer parks the agent at `state: 'idle'`
+ * while holding the queue whenever a retry is counting down, so "no turn in
+ * flight" and "nothing left to do" are genuinely different questions. Without
+ * it, announcing idle was the first thing the user heard while a dozen
+ * messages were still lined up.
+ *
+ * Paused items are excluded by `selectHasAnyRunnableQueuedWork`, so a queue the
+ * user has held does not keep the notification suppressed forever.
  *
  * The notification only fires on the *transition* to idle - not on mount,
  * not when already idle. A ref tracks the previous "was active" state to
@@ -15,12 +30,13 @@ import { useNotificationStore, selectConfig } from '../../stores/notificationSto
  */
 export function useIdleNotification(): void {
 	const anySessionBusy = useSessionStore(selectIsAnySessionBusy);
+	const anyQueuedWork = useSessionStore(selectHasAnyRunnableQueuedWork);
 	const anyBatchRunning = useBatchStore(selectHasAnyActiveBatch);
 	const { idleNotificationEnabled, idleNotificationCommand } = useNotificationStore(selectConfig);
 
 	const wasActiveRef = useRef(false);
 
-	const isActive = anySessionBusy || anyBatchRunning;
+	const isActive = anySessionBusy || anyQueuedWork || anyBatchRunning;
 
 	useEffect(() => {
 		if (isActive) {

--- a/src/renderer/hooks/ui/useRestartWhenIdle.ts
+++ b/src/renderer/hooks/ui/useRestartWhenIdle.ts
@@ -1,5 +1,9 @@
 import { useEffect, useRef } from 'react';
-import { useSessionStore, selectIsAnySessionBusy } from '../../stores/sessionStore';
+import {
+	useSessionStore,
+	selectIsAnySessionBusy,
+	selectHasAnyRunnableQueuedWork,
+} from '../../stores/sessionStore';
 import { selectHasAnyActiveBatch, useBatchStore } from '../../stores/batchStore';
 import { useRestartPendingStore } from '../../stores/restartPendingStore';
 
@@ -9,8 +13,11 @@ import { useRestartPendingStore } from '../../stores/restartPendingStore';
  * fires `updates.install()` so the app restarts and applies the downloaded
  * update without further user input.
  *
- * Activity matches `useIdleNotification`: any session busy OR any Auto Run
- * batch running. Cue tasks are intentionally excluded.
+ * Activity matches `useIdleNotification`, reading the SAME selectors so the two
+ * cannot drift on what counts as idle: any session busy, any session holding
+ * runnable queued work, OR any Auto Run batch running. Cue tasks are
+ * intentionally excluded. Restarting the app out from under a full queue is the
+ * same mistake as announcing idle over one, only louder.
  *
  * If the flag is set while the app is *already* idle (user clicked the
  * deferred-restart button without anything running), we fire on the next
@@ -18,12 +25,13 @@ import { useRestartPendingStore } from '../../stores/restartPendingStore';
  */
 export function useRestartWhenIdle(): void {
 	const anySessionBusy = useSessionStore(selectIsAnySessionBusy);
+	const anyQueuedWork = useSessionStore(selectHasAnyRunnableQueuedWork);
 	const anyBatchRunning = useBatchStore(selectHasAnyActiveBatch);
 	const pending = useRestartPendingStore((s) => s.pending);
 	const setPending = useRestartPendingStore((s) => s.setPending);
 
-	const wasActiveRef = useRef(anySessionBusy || anyBatchRunning);
-	const isActive = anySessionBusy || anyBatchRunning;
+	const wasActiveRef = useRef(anySessionBusy || anyQueuedWork || anyBatchRunning);
+	const isActive = anySessionBusy || anyQueuedWork || anyBatchRunning;
 
 	useEffect(() => {
 		if (!pending) {

--- a/src/renderer/stores/sessionStore.ts
+++ b/src/renderer/stores/sessionStore.ts
@@ -17,6 +17,7 @@ import { create } from 'zustand';
 import type { Session, Group, LogEntry, AITab } from '../types';
 import { generateId } from '../utils/ids';
 import { getActiveTab } from '../utils/tabHelpers';
+import { hasRunnableQueueItem } from '../utils/executionQueue';
 import { logger } from '../utils/logger';
 import { useUIStore } from './uiStore';
 
@@ -359,6 +360,25 @@ export const selectSessionById =
 
 export const selectIsAnySessionBusy = (state: SessionStore): boolean =>
 	state.sessions.some((s) => s.state === 'busy');
+
+/**
+ * Whether any agent still has queued work that would actually run.
+ *
+ * `selectIsAnySessionBusy` only answers "is a turn in flight right now", which
+ * is a different question from "is there anything left to do". An agent that
+ * finishes a turn with items still queued sits at `state: 'idle'`, and since
+ * `e5acfd47f` a pending Agent Resilience retry parks it there for the whole
+ * countdown while the queue is deliberately held. Anything that reads idle as
+ * "all work is done" (the idle notification, restart-when-idle) has to ask this
+ * too, or it fires on an agent with a full queue.
+ *
+ * Paused items do NOT count: a held item is waiting on the user, not on us, so
+ * a queue holding only paused items is genuinely finished. That rule lives in
+ * `hasRunnableQueueItem` and is reused rather than restated here - a second copy
+ * of the paused check is exactly how these two ideas drift apart.
+ */
+export const selectHasAnyRunnableQueuedWork = (state: SessionStore): boolean =>
+	state.sessions.some((s) => hasRunnableQueueItem(s.executionQueue ?? []));
 
 // ============================================================================
 // Non-React Access


### PR DESCRIPTION
## The problem

The idle notification announced "Maestro is idle" while a dozen messages were still queued.

`src/renderer/hooks/ui/useIdleNotification.ts:23`

```ts
const isActive = anySessionBusy || anyBatchRunning;
```

`Session.executionQueue` was never read. That line asks "is a turn in flight right now", which is a different question from "is there anything left to do".

## Why it started ~7 days ago

The exit reducer parks an agent at `state: 'idle'` while deliberately holding its queue whenever an Agent Resilience retry is counting down.

That branch arrived in `e5acfd47f` (2026-08-22, *"hold the execution queue while a retry counts down"*). Before it, entering that path required `otherTabsBusy === true`, which forced `state: 'busy'` - idle-with-a-runnable-queue was structurally impossible. After it, `retryPending` alone enters with no other tab busy, so the session sits idle with a full queue for the entire countdown.

Not a race and not a timing gap. Draining a queue was already silent between items: the reducer marks the next tab busy in the *same* `setSessions` update that idles the exited one, so the store never renders an idle frame. This is a genuine, persistent idle state that the notifier was wrong to read as "done".

## The fix

One selector in `sessionStore.ts`, built on the existing `hasRunnableQueueItem` rather than a second copy of the paused rule:

```ts
export const selectHasAnyRunnableQueuedWork = (state: SessionStore): boolean =>
	state.sessions.some((s) => hasRunnableQueueItem(s.executionQueue ?? []));
```

Line 23 becomes:

```ts
const isActive = anySessionBusy || anyQueuedWork || anyBatchRunning;
```

**Paused items still do not count.** A held item waits on the user, not on us, so a queue holding only paused items is genuinely finished and still announces. That rule already lives in `hasRunnableQueueItem` and is reused, not restated - a second copy is how the two ideas drift apart.

`useRestartWhenIdle` had the identical gate and now reads the **same** selector, so they cannot diverge again. It matters more: announcing idle over a full queue is annoying, restarting the app out from under one discards the work.

## Tests

Ten new tests across two files. Verified they actually catch the bug: with the source change reverted, **3 fail** (queued-work suppression, drain-to-paused, cross-agent) and the 3 regression guards still pass.

- idle + runnable queue -> stays active, silent
- idle + only-paused queue -> fires
- busy -> idle, empty queue -> fires exactly once, and does not re-fire while idle
- queue draining down to only-paused -> silent, then fires
- another agent still holding a queue -> silent
- restart: pending flag survives a suppressed idle, so the deferred restart is not lost

## Verification

- Full suite: **1307 files / 35476 passed**, 1 skipped, 0 failed
- `tsc` clean on all three configs (`lint`, `main`, `cli`)
- `eslint` clean, including the em-dash guard on tests
- `prettier --check` clean

## Out of scope

`collectActiveOperations.ts` (behind **Quit When Idle**) has the same blind spot - it checks busy agents, batches, terminals, Cue runs and group chats, but never the execution queue. It **quits the app** on a poll, so it is a different shape and a bigger blast radius. Flagging, not fixing here. Cue is also untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Idle notifications are now suppressed while runnable queued work remains.
  * Automatic restarts now wait until all runnable queued work is complete.
  * Paused queue items do not prevent idle notifications or restarts.
  * Idle and busy transitions now behave correctly across multiple sessions and queued-work states.

* **Tests**
  * Added comprehensive coverage for idle notifications, automatic restarts, queue draining, paused work, and duplicate announcement prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->