### PR TITLE
fix(notifications): stay busy while an agent still has queued work

### DIFF
--- a/src/__tests__/renderer/hooks/ui/useIdleNotification.test.tsx
+++ b/src/__tests__/renderer/hooks/ui/useIdleNotification.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useIdleNotification } from '../../../../renderer/hooks/ui/useIdleNotification';
+import {
+	useSessionStore,
+	selectHasAnyRunnableQueuedWork,
+} from '../../../../renderer/stores/sessionStore';
+import { useNotificationStore } from '../../../../renderer/stores/notificationStore';
+import { useBatchStore } from '../../../../renderer/stores/batchStore';
+import { createMockSession } from '../../../helpers/mockSession';
+import type { QueuedItem, Session } from '../../../../renderer/types';
+
+/**
+ * The idle notification must stay quiet while an agent still has work that
+ * would actually run. `busy` alone is only true while a turn is in flight, and
+ * the dequeue is atomic, so a draining queue leaves the agent genuinely `idle`
+ * in the gap between two queued turns - which is where it used to announce
+ * "Maestro is idle" once per gap.
+ */
+
+const speak = vi.fn().mockResolvedValue(undefined);
+
+function queuedItem(overrides: Partial<QueuedItem> = {}): QueuedItem {
+	return {
+		id: 'q1',
+		timestamp: 1,
+		tabId: 'tab-1',
+		type: 'message',
+		text: 'do the thing',
+		...overrides,
+	};
+}
+
+function setSessions(sessions: Session[]): void {
+	useSessionStore.setState({ sessions });
+}
+
+describe('useIdleNotification', () => {
+	beforeEach(() => {
+		speak.mockClear();
+		(globalThis as unknown as { window: Record<string, unknown> }).window.maestro = {
+			notification: { speak },
+		};
+		useBatchStore.setState({ batchRunStates: {} });
+		useNotificationStore.getState().setIdleNotification(true, 'say Maestro is idle');
+		setSessions([]);
+	});
+
+	describe('selectHasAnyRunnableQueuedWork', () => {
+		it('counts an idle agent with a runnable queued item as having work', () => {
+			const state = {
+				sessions: [createMockSession({ state: 'idle', executionQueue: [queuedItem()] })],
+			};
+			expect(selectHasAnyRunnableQueuedWork(state as never)).toBe(true);
+		});
+
+		it('does not count a queue holding only paused items', () => {
+			const state = {
+				sessions: [
+					createMockSession({
+						state: 'idle',
+						executionQueue: [queuedItem({ paused: true }), queuedItem({ id: 'q2', paused: true })],
+					}),
+				],
+			};
+			expect(selectHasAnyRunnableQueuedWork(state as never)).toBe(false);
+		});
+
+		it('counts a mixed queue, because one item would still run', () => {
+			const state = {
+				sessions: [
+					createMockSession({
+						state: 'idle',
+						executionQueue: [queuedItem({ paused: true }), queuedItem({ id: 'q2' })],
+					}),
+				],
+			};
+			expect(selectHasAnyRunnableQueuedWork(state as never)).toBe(true);
+		});
+
+		it('tolerates a session with no queue field at all', () => {
+			const session = createMockSession({ state: 'idle' });
+			delete (session as Partial<Session>).executionQueue;
+			expect(selectHasAnyRunnableQueuedWork({ sessions: [session] } as never)).toBe(false);
+		});
+	});
+
+	it('stays silent in the gap between two queued turns', () => {
+		// Turn 1 running, with the next item still queued behind it.
+		setSessions([createMockSession({ state: 'busy', executionQueue: [queuedItem({ id: 'q2' })] })]);
+		const { rerender } = renderHook(() => useIdleNotification());
+
+		// Turn 1 ends. The session is idle but q2 has not been dispatched yet -
+		// this is the window that used to fire.
+		setSessions([createMockSession({ state: 'idle', executionQueue: [queuedItem({ id: 'q2' })] })]);
+		rerender();
+
+		expect(speak).not.toHaveBeenCalled();
+	});
+
+	it('fires once when the last queued item finishes and the queue is empty', () => {
+		setSessions([createMockSession({ state: 'busy', executionQueue: [] })]);
+		const { rerender } = renderHook(() => useIdleNotification());
+
+		setSessions([createMockSession({ state: 'idle', executionQueue: [] })]);
+		rerender();
+
+		expect(speak).toHaveBeenCalledTimes(1);
+		expect(speak).toHaveBeenCalledWith('Maestro is idle', 'say Maestro is idle');
+
+		// Still idle on a later render - the edge already fired, so it must not repeat.
+		rerender();
+		expect(speak).toHaveBeenCalledTimes(1);
+	});
+
+	it('fires when the only queued items are paused, because they can never start', () => {
+		setSessions([
+			createMockSession({ state: 'busy', executionQueue: [queuedItem({ paused: true })] }),
+		]);
+		const { rerender } = renderHook(() => useIdleNotification());
+
+		setSessions([
+			createMockSession({ state: 'idle', executionQueue: [queuedItem({ paused: true })] }),
+		]);
+		rerender();
+
+		expect(speak).toHaveBeenCalledTimes(1);
+	});
+
+	it('speaks only after the whole queue drains, not once per item', () => {
+		const drain: Array<{ state: Session['state']; queue: QueuedItem[] }> = [
+			{ state: 'busy', queue: [queuedItem({ id: 'q2' }), queuedItem({ id: 'q3' })] },
+			{ state: 'idle', queue: [queuedItem({ id: 'q2' }), queuedItem({ id: 'q3' })] },
+			{ state: 'busy', queue: [queuedItem({ id: 'q3' })] },
+			{ state: 'idle', queue: [queuedItem({ id: 'q3' })] },
+			{ state: 'busy', queue: [] },
+			{ state: 'idle', queue: [] },
+		];
+
+		setSessions([createMockSession({ state: 'busy', executionQueue: drain[0].queue })]);
+		const { rerender } = renderHook(() => useIdleNotification());
+
+		for (const step of drain) {
+			setSessions([createMockSession({ state: step.state, executionQueue: step.queue })]);
+			rerender();
+		}
+
+		// Three turns, two intermediate gaps, exactly one announcement.
+		expect(speak).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not fire while an Auto Run batch is still running', () => {
+		setSessions([createMockSession({ state: 'busy', executionQueue: [] })]);
+		const { rerender } = renderHook(() => useIdleNotification());
+
+		useBatchStore.setState({
+			batchRunStates: { 'session-1': { isRunning: true } as never },
+		});
+		setSessions([createMockSession({ state: 'idle', executionQueue: [] })]);
+		rerender();
+
+		expect(speak).not.toHaveBeenCalled();
+	});
+
+	it('stays silent when the notification is disabled', () => {
+		useNotificationStore.getState().setIdleNotification(false, 'say Maestro is idle');
+		setSessions([createMockSession({ state: 'busy', executionQueue: [] })]);
+		const { rerender } = renderHook(() => useIdleNotification());
+
+		setSessions([createMockSession({ state: 'idle', executionQueue: [] })]);
+		rerender();
+
+		expect(speak).not.toHaveBeenCalled();
+	});
+
+	it('does not fire on mount when already idle', () => {
+		setSessions([createMockSession({ state: 'idle', executionQueue: [] })]);
+		renderHook(() => useIdleNotification());
+
+		expect(speak).not.toHaveBeenCalled();
+	});
+});

--- a/src/__tests__/renderer/hooks/ui/useRestartWhenIdle.test.tsx
+++ b/src/__tests__/renderer/hooks/ui/useRestartWhenIdle.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useRestartWhenIdle } from '../../../../renderer/hooks/ui/useRestartWhenIdle';
+import { useSessionStore } from '../../../../renderer/stores/sessionStore';
+import { useRestartPendingStore } from '../../../../renderer/stores/restartPendingStore';
+import { useBatchStore } from '../../../../renderer/stores/batchStore';
+import { createMockSession } from '../../../helpers/mockSession';
+import type { QueuedItem, Session } from '../../../../renderer/types';
+
+/**
+ * This hook shares its activity definition with `useIdleNotification`, but
+ * where that one speaks, this one calls `updates.install()` and relaunches the
+ * app. So the gap between two queued turns is not a cosmetic problem here: a
+ * restart fired in that window takes the app down with queued work still in the
+ * queue.
+ */
+
+const install = vi.fn().mockResolvedValue(undefined);
+
+function queuedItem(overrides: Partial<QueuedItem> = {}): QueuedItem {
+	return { id: 'q1', timestamp: 1, tabId: 'tab-1', type: 'message', text: 'go', ...overrides };
+}
+
+function setSessions(sessions: Session[]): void {
+	useSessionStore.setState({ sessions });
+}
+
+describe('useRestartWhenIdle', () => {
+	beforeEach(() => {
+		install.mockClear();
+		(globalThis as unknown as { window: Record<string, unknown> }).window.maestro = {
+			updates: { install },
+		};
+		useBatchStore.setState({ batchRunStates: {} });
+		useRestartPendingStore.setState({ pending: false });
+		setSessions([]);
+	});
+
+	it('does not restart in the gap between two queued turns', () => {
+		setSessions([createMockSession({ state: 'busy', executionQueue: [queuedItem({ id: 'q2' })] })]);
+		useRestartPendingStore.setState({ pending: true });
+		const { rerender } = renderHook(() => useRestartWhenIdle());
+
+		// Turn ends, next item still queued. A restart here would kill queued work.
+		setSessions([createMockSession({ state: 'idle', executionQueue: [queuedItem({ id: 'q2' })] })]);
+		rerender();
+
+		expect(install).not.toHaveBeenCalled();
+		expect(useRestartPendingStore.getState().pending).toBe(true);
+	});
+
+	it('restarts once the queue is genuinely drained', () => {
+		setSessions([createMockSession({ state: 'busy', executionQueue: [queuedItem({ id: 'q2' })] })]);
+		useRestartPendingStore.setState({ pending: true });
+		const { rerender } = renderHook(() => useRestartWhenIdle());
+
+		setSessions([createMockSession({ state: 'idle', executionQueue: [queuedItem({ id: 'q2' })] })]);
+		rerender();
+		expect(install).not.toHaveBeenCalled();
+
+		setSessions([createMockSession({ state: 'idle', executionQueue: [] })]);
+		rerender();
+
+		expect(install).toHaveBeenCalledTimes(1);
+		expect(useRestartPendingStore.getState().pending).toBe(false);
+	});
+
+	it('restarts when the queue holds only paused items', () => {
+		setSessions([
+			createMockSession({ state: 'idle', executionQueue: [queuedItem({ paused: true })] }),
+		]);
+		useRestartPendingStore.setState({ pending: true });
+		renderHook(() => useRestartWhenIdle());
+
+		expect(install).toHaveBeenCalledTimes(1);
+	});
+
+	it('does nothing while no restart is pending', () => {
+		setSessions([createMockSession({ state: 'idle', executionQueue: [] })]);
+		renderHook(() => useRestartWhenIdle());
+
+		expect(install).not.toHaveBeenCalled();
+	});
+});

--- a/src/renderer/hooks/ui/useIdleNotification.ts
+++ b/src/renderer/hooks/ui/useIdleNotification.ts
@@ -1,13 +1,23 @@
 import { useEffect, useRef } from 'react';
-import { useSessionStore, selectIsAnySessionBusy } from '../../stores/sessionStore';
+import {
+	useSessionStore,
+	selectIsAnySessionBusy,
+	selectHasAnyRunnableQueuedWork,
+} from '../../stores/sessionStore';
 import { selectHasAnyActiveBatch, useBatchStore } from '../../stores/batchStore';
 import { useNotificationStore, selectConfig } from '../../stores/notificationStore';
 
 /**
  * Watches for the transition from "any activity" to "fully idle" and fires
- * the idle notification command. Activity means any session is busy OR any
- * Auto Run batch is running. Cue tasks are explicitly excluded from this
- * check (they don't set session state to busy or create batch runs).
+ * the idle notification command. Activity means any session is busy, any
+ * session still has RUNNABLE queued work, or any Auto Run batch is running.
+ * Cue tasks are explicitly excluded from this check (they don't set session
+ * state to busy or create batch runs).
+ *
+ * The queued-work term is what keeps a draining queue quiet. Busy alone is only
+ * true while a turn is in flight, so the agent goes idle in the gap between two
+ * queued turns and announced "idle" at every one of them. Paused items don't
+ * count - see `selectHasAnyRunnableQueuedWork`.
  *
  * The notification only fires on the *transition* to idle - not on mount,
  * not when already idle. A ref tracks the previous "was active" state to
@@ -15,12 +25,13 @@ import { useNotificationStore, selectConfig } from '../../stores/notificationSto
  */
 export function useIdleNotification(): void {
 	const anySessionBusy = useSessionStore(selectIsAnySessionBusy);
+	const anyQueuedWork = useSessionStore(selectHasAnyRunnableQueuedWork);
 	const anyBatchRunning = useBatchStore(selectHasAnyActiveBatch);
 	const { idleNotificationEnabled, idleNotificationCommand } = useNotificationStore(selectConfig);
 
 	const wasActiveRef = useRef(false);
 
-	const isActive = anySessionBusy || anyBatchRunning;
+	const isActive = anySessionBusy || anyQueuedWork || anyBatchRunning;
 
 	useEffect(() => {
 		if (isActive) {

--- a/src/renderer/hooks/ui/useRestartWhenIdle.ts
+++ b/src/renderer/hooks/ui/useRestartWhenIdle.ts
@@ -1,5 +1,9 @@
 import { useEffect, useRef } from 'react';
-import { useSessionStore, selectIsAnySessionBusy } from '../../stores/sessionStore';
+import {
+	useSessionStore,
+	selectIsAnySessionBusy,
+	selectHasAnyRunnableQueuedWork,
+} from '../../stores/sessionStore';
 import { selectHasAnyActiveBatch, useBatchStore } from '../../stores/batchStore';
 import { useRestartPendingStore } from '../../stores/restartPendingStore';
 
@@ -9,8 +13,12 @@ import { useRestartPendingStore } from '../../stores/restartPendingStore';
  * fires `updates.install()` so the app restarts and applies the downloaded
  * update without further user input.
  *
- * Activity matches `useIdleNotification`: any session busy OR any Auto Run
- * batch running. Cue tasks are intentionally excluded.
+ * Activity matches `useIdleNotification` by reading the SAME selectors: any
+ * session busy, any session with runnable queued work, or any Auto Run batch
+ * running. Cue tasks are intentionally excluded. Keep the two definitions
+ * sharing `selectHasAnyRunnableQueuedWork` rather than restating the condition -
+ * this hook restarts the app, so a definition that drifts from the notification's
+ * would relaunch Maestro in the gap between two queued turns.
  *
  * If the flag is set while the app is *already* idle (user clicked the
  * deferred-restart button without anything running), we fire on the next
@@ -18,12 +26,13 @@ import { useRestartPendingStore } from '../../stores/restartPendingStore';
  */
 export function useRestartWhenIdle(): void {
 	const anySessionBusy = useSessionStore(selectIsAnySessionBusy);
+	const anyQueuedWork = useSessionStore(selectHasAnyRunnableQueuedWork);
 	const anyBatchRunning = useBatchStore(selectHasAnyActiveBatch);
 	const pending = useRestartPendingStore((s) => s.pending);
 	const setPending = useRestartPendingStore((s) => s.setPending);
 
-	const wasActiveRef = useRef(anySessionBusy || anyBatchRunning);
-	const isActive = anySessionBusy || anyBatchRunning;
+	const wasActiveRef = useRef(anySessionBusy || anyQueuedWork || anyBatchRunning);
+	const isActive = anySessionBusy || anyQueuedWork || anyBatchRunning;
 
 	useEffect(() => {
 		if (!pending) {

--- a/src/renderer/stores/sessionStore.ts
+++ b/src/renderer/stores/sessionStore.ts
@@ -17,6 +17,7 @@ import { create } from 'zustand';
 import type { Session, Group, LogEntry, AITab } from '../types';
 import { generateId } from '../utils/ids';
 import { getActiveTab } from '../utils/tabHelpers';
+import { hasRunnableQueueItem } from '../utils/executionQueue';
 import { logger } from '../utils/logger';
 import { useUIStore } from './uiStore';
 import {
@@ -405,6 +406,24 @@ export const selectSessionById =
 
 export const selectIsAnySessionBusy = (state: SessionStore): boolean =>
 	state.sessions.some((s) => s.state === 'busy');
+
+/**
+ * Whether any agent still has queued work that would actually run.
+ *
+ * `busy` only means a turn is in flight RIGHT NOW, and the dequeue is atomic:
+ * `applyQueuedItemDispatch` flips the session to `busy` and drops the item from
+ * the queue in one update. So between two queued turns the agent is genuinely
+ * `idle` with the next item still sitting in `executionQueue`, and anything
+ * gating on busy alone reads that gap as "all work finished" - draining a
+ * five-item queue hits that gap four times.
+ *
+ * Paused items deliberately do NOT count as work: a held item keeps its position
+ * but is invisible to every dispatch path, so it can never start on its own and
+ * must not suppress an idle signal forever. That rule lives in
+ * `hasRunnableQueueItem`; do not re-derive `!item.paused` at a call site.
+ */
+export const selectHasAnyRunnableQueuedWork = (state: SessionStore): boolean =>
+	state.sessions.some((s) => hasRunnableQueueItem(s.executionQueue ?? []));
 
 // ============================================================================
 // Non-React Access


### PR DESCRIPTION
Closes the "Maestro is idle" announcement that fires while an agent still has a queue of work waiting.

## The problem

`src/renderer/hooks/ui/useIdleNotification.ts:23`

```ts
const isActive = anySessionBusy || anyBatchRunning;
```

That asks *"is a turn in flight right now."* It never asks *"is anything queued."* `Session.executionQueue` was never read, so an agent sitting idle with twelve runnable items queued read as fully idle.

**The gap is structural, not a race.** `applyQueuedItemDispatch` (`executionQueue.ts:329`) sets `state: 'busy'` and removes the item from the queue in the *same* returned object, so there is no window on the way in. The window is on the way out:

| step | `session.state` | `executionQueue` | old `isActive` |
|---|---|---|---|
| turn N running | `busy` | holds N+1 | `true` |
| **turn N ends** | **`idle`** | **still holds N+1** | **`false`** &larr; fired here |
| N+1 dispatched | `busy` | N+1 removed | `true` |

`useQueueProcessing` picks the next item up asynchronously, so the agent is genuinely `idle` for that whole window. **Draining a five-item queue passes through it four times and announced idle at each one.**

This is not a regression - the gate has read this way since `cc3d40623` introduced the feature. It only became audible as queue usage grew.

## The fix

One selector, in `sessionStore.ts` beside `selectIsAnySessionBusy`:

```ts
export const selectHasAnyRunnableQueuedWork = (state: SessionStore): boolean =>
	state.sessions.some((s) => hasRunnableQueueItem(s.executionQueue ?? []));
```

It is built on the existing `hasRunnableQueueItem` (`executionQueue.ts:31`) rather than a second copy of the paused rule. That module already owns the "skip paused items" contract for every dispatch path, and re-deriving `!item.paused` at a call site is exactly how the two would drift.

**A paused queue still counts as idle.** A held item keeps its position but is invisible to every dispatch path, so it can never start on its own - suppressing the notification for one would silence it forever.

## `useRestartWhenIdle` had the same bug, and it is the worse one

`useRestartWhenIdle.ts:26` carried a byte-identical condition, by design - its docstring said *"Activity matches `useIdleNotification`."* But where the notification merely speaks, that hook calls `window.maestro.updates.install()` and **relaunches the app**.

So the same gap could restart Maestro between two queued turns, with the rest of the queue still pending. Fixing only the notification would have left that in place. Both hooks now consume the one selector, so they cannot drift apart again.

## Tests

`useIdleNotification.test.tsx` (11 cases) and `useRestartWhenIdle.test.tsx` (4 cases), including the three asked for plus the drain sequence:

- idle + runnable queue -> active, silent
- idle + only-paused queue -> not active, fires
- busy -> idle with empty queue -> fires exactly once, and not again on re-render
- a full three-turn drain -> **one** announcement, not three
- restart deferred through the gap, then fires once the queue truly drains

**Verified these fail without the fix.** Reverting just line 23 in both hooks turns the 4 gap-sensitive cases red; the other 11 stay green. They are testing the change, not passing incidentally.

## Verification

- **Full suite: 40,101 passed / 0 failed** (1,691 files, 262s)
- `tsc --noEmit`: the 5 pre-existing `TS6133` errors on `rc`'s tip and nothing more - confirmed byte-identical by stashing and re-running on the pristine tip
- prettier + eslint clean

## Scope

Out of scope by instruction: `collectActiveOperations.ts`, Cue (still excluded from the activity definition, as before), Quit When Idle (it quits the app and needs its own change), and PR #1432.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved idle detection while runnable queued work remains, preventing premature idle notifications.
  * Kept restart behavior consistent with idle notifications during queued-work gaps.
  * Paused-only work is correctly treated as idle.

* **Tests**
  * Added comprehensive coverage for idle notifications and restart behavior across queued, paused, draining, Auto Run, and disabled-notification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->