### PR TITLE
feat(agents): add OpenClaude as a fork of the Claude Code integration

### DIFF
--- a/AGENT_SUPPORT.md
+++ b/AGENT_SUPPORT.md
@@ -840,6 +840,72 @@ describe('YourAgentOutputParser', () => {
 
 ---
 
+### OpenClaude ✅ Implemented (fork of Claude Code)
+
+| Aspect           | Value                                    |
+| ---------------- | ---------------------------------------- |
+| Binary           | `openclaude`                             |
+| Install          | `npm install -g @gitlawb/openclaude`     |
+| JSON Output      | `--output-format stream-json`            |
+| Resume           | `--resume <session-id>`                  |
+| Read-only        | `--permission-mode plan`                 |
+| Session ID Field | `session_id` (snake_case)                |
+| Session Storage  | `~/.openclaude/projects/<encoded-path>/` |
+| Model Selection  | `--model <model>`                        |
+| Provider Setup   | `/provider` inside the TUI               |
+
+[OpenClaude](https://github.com/Gitlawb/openclaude) is a fork of Claude Code
+that routes to whichever backend the user configures (OpenAI-compatible APIs,
+Gemini, GitHub Models, Ollama, Bedrock, Vertex, and others). It keeps the
+headless CLI surface flag for flag and emits a byte-identical stream-json
+schema, down to `session_id`, `modelUsage`, `total_cost_usd` and
+`parent_tool_use_id`.
+
+So the integration is a thin layer rather than a parallel copy:
+
+- `OpenClaudeOutputParser` subclasses `ClaudeOutputParser`, overriding only
+  `agentId` (which is what routes error matching and stamps emitted errors).
+- `OpenClaudeSessionStorage` subclasses `ClaudeSessionStorage` and supplies a
+  `ClaudeStorageBrand` of `{ homeDirName: '.openclaude', originsStoreName:
+'openclaude-session-origins' }`. To make that possible, Claude's projects
+  directory and origins store moved off hard-coded names onto that brand.
+- Error patterns are shared outright. The Claude bank's messages name WHAT
+  failed rather than a brand or a terminal command, and sharing the set is what
+  stops the two from drifting apart.
+
+**Implementation Status:**
+
+- ✅ Output Parser: `src/main/parsers/openclaude-output-parser.ts`
+- ✅ Session Storage: `src/main/storage/openclaude-session-storage.ts`
+- ✅ Error Patterns: shares `CLAUDE_ERROR_PATTERNS`
+- ✅ Provider pickers, wizard logo, path probing (Windows + POSIX), SSH remote
+  PATH, token-coverage maps, context groomer, built-in slash commands
+
+**Deliberately NOT inherited from Claude Code:**
+
+| Not inherited                     | Why                                                                                                                                                                                                                 |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `supportsStandardPermissionMode`  | Standard mode is Maestro's permission relay, which injects `--permission-prompt-tool` + an `--mcp-config` pointing at a local stdio bridge. `handle-spawn.ts` gates that on `claude-code`. See the follow-up below. |
+| `supportsProjectMemory`           | Project memory reads `~/.claude/projects/<path>/memory/`. OpenClaude stores under `~/.openclaude` and explicitly does not read `~/.claude`, so the Memory Viewer would open another provider's notes.               |
+| `interactiveCommand: 'maestro-p'` | `maestro-p` drives the real Claude TUI, a different binary. OpenClaude runs the API/print path only.                                                                                                                |
+| `defaultEnvVars`                  | `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` is a Claude Code knob.                                                                                                                                                       |
+| Tier/effort model tables          | OpenClaude's model IDs are whatever the configured provider exposes, discovered at runtime. A shipped guess would rot into naming a model the user cannot run.                                                      |
+
+**Known follow-ups:**
+
+- OpenClaude does expose `--permission-prompt-tool`, so standard permission mode
+  is reachable. Wiring it means widening the `isClaudeCode` gate in
+  `src/main/ipc/handlers/process/handle-spawn.ts` and verifying the relay's
+  `--mcp-config` payload against a live binary. Left out of the base
+  integration deliberately: advertising the capability without the relay would
+  offer a mode that aborts on the first tool call.
+- No effort discovery. Claude Code's `effort` option is `dynamic: true` and
+  scrapes the Claude CLI's own help text; OpenClaude's wording is its own, so
+  the levels its `--effort` flag documents are listed statically.
+- No Coworking MCP installer or `MCP_CONFIG_BY_AGENT` entry.
+
+---
+
 ### OpenCode 🔄 Stub Ready
 
 | Aspect           | Value                                                         |

--- a/CLAUDE-AGENTS.md
+++ b/CLAUDE-AGENTS.md
@@ -4,20 +4,21 @@ Agent support documentation for the Maestro codebase. For the main guide, see [[
 
 ## Supported Agents
 
-| ID              | Name            | Status     | Notes                                                                                                                                              |
-| --------------- | --------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `claude-code`   | Claude Code     | **Active** | Primary agent, `--print --verbose --output-format stream-json`                                                                                     |
-| `codex`         | Codex           | **Active** | Full support, `--json`, YOLO mode default                                                                                                          |
-| `opencode`      | OpenCode        | **Active** | Multi-provider support (75+ LLMs), stub provider session storage                                                                                   |
-| `factory-droid` | Factory Droid   | **Active** | Factory's AI coding assistant, `-o stream-json`                                                                                                    |
-| `copilot-cli`   | Copilot-CLI     | **Beta**   | `-p/--prompt`, `--output-format json`, `--resume`, `@image` mentions, permission filters, reasoning stream, models.dev model picker                |
-| `grok`          | Grok CLI        | **Beta**   | `-p` headless, `--output-format streaming-json` (JSONL), `--resume`, `--permission-mode plan`, thought/text deltas, models_cache.json model picker |
-| `antigravity`   | Antigravity CLI | **Beta**   | `agy -p`, `--output-format stream-json`, `--conversation <id>`, `--model` / `--effort`, 30m `--print-timeout`                                      |
-| `qwen3-coder`   | Qwen3 Coder     | **Beta**   | Gemini CLI fork, stream-json headless interface, `--resume`                                                                                        |
-| `hermes`        | Hermes          | **Beta**   | Nous Research's coding agent                                                                                                                       |
-| `pi`            | Pi              | **Beta**   | Bring-your-own agent harness                                                                                                                       |
-| `omp`           | Oh My Pi        | **Beta**   | Multi-model coding agent; prompt must be a positional arg, never stdin                                                                             |
-| `terminal`      | Terminal        | Internal   | Hidden from UI, used for shell sessions                                                                                                            |
+| ID              | Name            | Status     | Notes                                                                                                                                               |
+| --------------- | --------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `claude-code`   | Claude Code     | **Active** | Primary agent, `--print --verbose --output-format stream-json`                                                                                      |
+| `codex`         | Codex           | **Active** | Full support, `--json`, YOLO mode default                                                                                                           |
+| `opencode`      | OpenCode        | **Active** | Multi-provider support (75+ LLMs), stub provider session storage                                                                                    |
+| `openclaude`    | OpenClaude      | **Beta**   | Claude Code fork routing to any provider; same `--print --verbose --output-format stream-json` surface, transcripts under `~/.openclaude/projects/` |
+| `factory-droid` | Factory Droid   | **Active** | Factory's AI coding assistant, `-o stream-json`                                                                                                     |
+| `copilot-cli`   | Copilot-CLI     | **Beta**   | `-p/--prompt`, `--output-format json`, `--resume`, `@image` mentions, permission filters, reasoning stream, models.dev model picker                 |
+| `grok`          | Grok CLI        | **Beta**   | `-p` headless, `--output-format streaming-json` (JSONL), `--resume`, `--permission-mode plan`, thought/text deltas, models_cache.json model picker  |
+| `antigravity`   | Antigravity CLI | **Beta**   | `agy -p`, `--output-format stream-json`, `--conversation <id>`, `--model` / `--effort`, 30m `--print-timeout`                                       |
+| `qwen3-coder`   | Qwen3 Coder     | **Beta**   | Gemini CLI fork, stream-json headless interface, `--resume`                                                                                         |
+| `hermes`        | Hermes          | **Beta**   | Nous Research's coding agent                                                                                                                        |
+| `pi`            | Pi              | **Beta**   | Bring-your-own agent harness                                                                                                                        |
+| `omp`           | Oh My Pi        | **Beta**   | Multi-model coding agent; prompt must be a positional arg, never stdin                                                                              |
+| `terminal`      | Terminal        | Internal   | Hidden from UI, used for shell sessions                                                                                                             |
 
 ## Agent Capabilities
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,6 +271,7 @@ Maestro is an Electron desktop app for managing multiple AI coding assistants si
 | `grok`          | Grok CLI        | **Beta**   |
 | `hermes`        | Hermes          | **Beta**   |
 | `omp`           | Oh My Pi        | **Beta**   |
+| `openclaude`    | OpenClaude      | **Beta**   |
 | `opencode`      | OpenCode        | **Beta**   |
 | `pi`            | Pi              | **Beta**   |
 | `qwen3-coder`   | Qwen3 Coder     | **Beta**   |

--- a/src/__tests__/main/agents/openclaude-agent.test.ts
+++ b/src/__tests__/main/agents/openclaude-agent.test.ts
@@ -1,0 +1,214 @@
+/**
+ * OpenClaude integration tests.
+ *
+ * OpenClaude is a fork of Claude Code, and the whole integration is built on
+ * that: the parser and the session storage are subclasses, and the error
+ * patterns are shared outright. These tests pin the parity that makes that
+ * safe, so a future change to Claude Code that should have carried over to
+ * OpenClaude fails here instead of silently leaving the fork behind.
+ *
+ * They also pin the places the fork must NOT inherit - the `~/.claude` home,
+ * project memory, and the permission relay - because those are the ones where
+ * "it's the same CLI" quietly stops being true.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { AGENT_DEFINITIONS, AGENT_CAPABILITIES } from '../../../main/agents';
+import { AGENT_IDS } from '../../../shared/agentIds';
+import {
+	AGENT_DISPLAY_NAMES,
+	AGENT_PICKER_META,
+	PICKABLE_AGENT_IDS,
+	getAgentLoginCommand,
+	isBetaAgent,
+	getReadOnlyModeLabel,
+} from '../../../shared/agentMetadata';
+import { DEFAULT_CONTEXT_WINDOWS } from '../../../shared/agentConstants';
+import { createOutputParser } from '../../../main/parsers/parser-factory';
+import {
+	getErrorPatterns,
+	getSshErrorPatterns,
+	matchSshErrorPattern,
+} from '../../../main/parsers/error-patterns';
+import { ClaudeSessionStorage } from '../../../main/storage/claude-session-storage';
+import { OpenClaudeSessionStorage } from '../../../main/storage/openclaude-session-storage';
+
+const openclaudeDef = AGENT_DEFINITIONS.find((def) => def.id === 'openclaude');
+const claudeDef = AGENT_DEFINITIONS.find((def) => def.id === 'claude-code');
+
+describe('OpenClaude agent', () => {
+	describe('registration', () => {
+		it('is a known agent id', () => {
+			expect(AGENT_IDS).toContain('openclaude');
+		});
+
+		it('has a definition and a display name', () => {
+			expect(openclaudeDef).toBeDefined();
+			expect(AGENT_DISPLAY_NAMES.openclaude).toBe('OpenClaude');
+		});
+
+		it('is offered in the provider pickers and flagged beta', () => {
+			expect(AGENT_PICKER_META.openclaude).not.toBeNull();
+			expect(PICKABLE_AGENT_IDS).toContain('openclaude');
+			expect(isBetaAgent('openclaude')).toBe(true);
+		});
+
+		it('uses plan-mode wording, like Claude Code', () => {
+			expect(getReadOnlyModeLabel('openclaude')).toBe(getReadOnlyModeLabel('claude-code'));
+			expect(getReadOnlyModeLabel('openclaude')).toBe('Plan-Mode');
+		});
+
+		it('has a default context window', () => {
+			expect(DEFAULT_CONTEXT_WINDOWS.openclaude).toBeGreaterThan(0);
+		});
+
+		it('points re-auth at its own binary, not the claude one', () => {
+			const login = getAgentLoginCommand('openclaude');
+			expect(login?.binary).toBe('openclaude');
+			// `/provider` is the guided setup for the backends it actually runs on;
+			// `auth login` would only cover the first-party Anthropic route.
+			expect(login?.followUp).toBe('/provider');
+		});
+	});
+
+	describe('definition', () => {
+		it('drives the openclaude binary', () => {
+			expect(openclaudeDef?.command).toBe('openclaude');
+			expect(openclaudeDef?.binaryName).toBe('openclaude');
+		});
+
+		it('shares the Claude Code headless CLI surface', () => {
+			expect(openclaudeDef?.args).toEqual(claudeDef?.args);
+			expect(openclaudeDef?.fullAccessArgs).toEqual(claudeDef?.fullAccessArgs);
+			expect(openclaudeDef?.readOnlyArgs).toEqual(claudeDef?.readOnlyArgs);
+			expect(openclaudeDef?.readOnlyCliEnforced).toBe(claudeDef?.readOnlyCliEnforced);
+			expect(openclaudeDef?.noToolsArgs).toEqual(claudeDef?.noToolsArgs);
+			expect(openclaudeDef?.resumeArgs?.('abc')).toEqual(claudeDef?.resumeArgs?.('abc'));
+			expect(openclaudeDef?.modelArgs?.('gpt-4o')).toEqual(claudeDef?.modelArgs?.('gpt-4o'));
+		});
+
+		it('grants additional directories the same way Claude Code does', () => {
+			const dirs = [{ path: '/tmp/scratch', access: 'read-write' as const }];
+			expect(openclaudeDef?.additionalDirArgs?.(dirs)).toEqual(
+				claudeDef?.additionalDirArgs?.(dirs)
+			);
+			// The completeness suite asserts this for every agent; repeated here
+			// because a bare `--add-dir` would eat the next arg, which is the prompt.
+			expect(openclaudeDef?.additionalDirArgs?.([])).toEqual([]);
+		});
+
+		it('does not inherit the maestro-p interactive path', () => {
+			// `maestro-p` drives the real Claude TUI, which is a different binary.
+			expect(openclaudeDef?.interactiveCommand).toBeUndefined();
+		});
+
+		it('does not inherit Claude Code’s env defaults', () => {
+			// CLAUDE_CODE_DISABLE_BACKGROUND_TASKS is a Claude Code knob; setting it
+			// on a fork that may not read it is noise at best.
+			expect(openclaudeDef?.defaultEnvVars).toBeUndefined();
+		});
+	});
+
+	describe('capabilities', () => {
+		it('advertises the stream-json feature set', () => {
+			const caps = AGENT_CAPABILITIES.openclaude;
+			expect(caps.supportsJsonOutput).toBe(true);
+			expect(caps.supportsSessionId).toBe(true);
+			expect(caps.supportsResume).toBe(true);
+			expect(caps.supportsStreamJsonInput).toBe(true);
+			expect(caps.supportsAppendSystemPrompt).toBe(true);
+			expect(caps.supportsAdditionalDirectories).toBe(true);
+			expect(caps.usesJsonLineOutput).toBe(false);
+		});
+
+		it('withholds standard permission mode, which is relay-gated to claude-code', () => {
+			// handle-spawn.ts injects --permission-prompt-tool + --mcp-config only for
+			// claude-code. Advertising the capability here would offer a mode that
+			// spawns without the relay and aborts on the first tool call.
+			expect(AGENT_CAPABILITIES.openclaude.supportsStandardPermissionMode).toBe(false);
+		});
+
+		it('withholds project memory, which reads ~/.claude', () => {
+			expect(AGENT_CAPABILITIES.openclaude.supportsProjectMemory).toBe(false);
+		});
+	});
+
+	describe('parser', () => {
+		it('is registered and reports itself as openclaude', () => {
+			const parser = createOutputParser('openclaude');
+			expect(parser).not.toBeNull();
+			expect(parser?.agentId).toBe('openclaude');
+		});
+
+		it('parses Claude-shaped stream-json identically to Claude Code', () => {
+			const line = {
+				type: 'assistant',
+				session_id: 'sess-1',
+				message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+			};
+			const openclaudeEvent = createOutputParser('openclaude')?.parseJsonObject(line);
+			const claudeEvent = createOutputParser('claude-code')?.parseJsonObject(line);
+
+			expect(openclaudeEvent).toEqual(claudeEvent);
+			expect(openclaudeEvent?.text).toBe('hello');
+		});
+
+		it('reads the session ID out of the snake_case field', () => {
+			const parser = createOutputParser('openclaude');
+			const event = parser?.parseJsonObject({
+				type: 'system',
+				subtype: 'init',
+				session_id: 'sess-1',
+			});
+			expect(event && parser?.extractSessionId(event)).toBe('sess-1');
+		});
+	});
+
+	describe('error patterns', () => {
+		it('shares Claude Code’s set rather than falling through to empty', () => {
+			const patterns = getErrorPatterns('openclaude');
+			expect(patterns).toBe(getErrorPatterns('claude-code'));
+			expect(Object.keys(patterns).length).toBeGreaterThan(0);
+		});
+
+		it('names OpenClaude, not Claude Code, when the binary is missing over SSH', () => {
+			// The claude pattern is `.*claude.*`, which also matches "openclaude",
+			// and the first match wins - so this only passes while the OpenClaude
+			// entry stays ahead of it.
+			expect(Object.keys(getSshErrorPatterns()).length).toBeGreaterThan(0);
+			const match = matchSshErrorPattern('bash: openclaude: command not found');
+			expect(match?.message).toContain('OpenClaude');
+			expect(match?.message).not.toContain('Claude Code');
+		});
+	});
+
+	describe('session storage', () => {
+		const storage = new OpenClaudeSessionStorage();
+
+		it('is a Claude storage that identifies as openclaude', () => {
+			expect(storage).toBeInstanceOf(ClaudeSessionStorage);
+			expect(storage.agentId).toBe('openclaude');
+		});
+
+		it('reads from the openclaude home, never Claude’s', () => {
+			// getProjectsDir/getRemoteProjectsDir are private: reach through the
+			// instance the same way the inherited methods do.
+			const asAny = storage as unknown as {
+				getProjectsDir(configDir?: string): string;
+				getRemoteProjectsDir(): string;
+			};
+			expect(asAny.getProjectsDir()).toContain('.openclaude');
+			expect(asAny.getRemoteProjectsDir()).toBe('~/.openclaude/projects');
+		});
+
+		it('does not disturb the Claude Code storage paths', () => {
+			const claude = new ClaudeSessionStorage() as unknown as {
+				getProjectsDir(configDir?: string): string;
+				getRemoteProjectsDir(): string;
+			};
+			expect(claude.getProjectsDir()).toContain('.claude');
+			expect(claude.getProjectsDir()).not.toContain('.openclaude');
+			expect(claude.getRemoteProjectsDir()).toBe('~/.claude/projects');
+		});
+	});
+});

--- a/src/__tests__/main/parsers/index.test.ts
+++ b/src/__tests__/main/parsers/index.test.ts
@@ -93,6 +93,14 @@ describe('parsers/index', () => {
 			expect(hasOutputParser('grok')).toBe(true);
 		});
 
+		it('should register OpenClaude parser', () => {
+			expect(hasOutputParser('openclaude')).toBe(false);
+
+			initializeOutputParsers();
+
+			expect(hasOutputParser('openclaude')).toBe(true);
+		});
+
 		it('should register Antigravity parser', () => {
 			expect(hasOutputParser('antigravity')).toBe(false);
 
@@ -101,21 +109,21 @@ describe('parsers/index', () => {
 			expect(hasOutputParser('antigravity')).toBe(true);
 		});
 
-		it('should register exactly 10 parsers', () => {
+		it('should register exactly 11 parsers', () => {
 			initializeOutputParsers();
 
 			const parsers = getAllOutputParsers();
-			expect(parsers.length).toBe(10);
+			expect(parsers.length).toBe(11);
 		});
 
 		it('should clear existing parsers before registering', () => {
 			// First initialization
 			initializeOutputParsers();
-			expect(getAllOutputParsers().length).toBe(10);
+			expect(getAllOutputParsers().length).toBe(11);
 
-			// Second initialization should still have exactly 10
+			// Second initialization should still have exactly 11
 			initializeOutputParsers();
-			expect(getAllOutputParsers().length).toBe(10);
+			expect(getAllOutputParsers().length).toBe(11);
 		});
 	});
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -861,7 +861,7 @@ program
 	.requiredOption('-d, --cwd <path>', 'Working directory for the agent')
 	.option(
 		'-t, --type <type>',
-		'Agent type (claude-code, codex, opencode, factory-droid, copilot-cli, antigravity, gemini-cli, qwen3-coder)',
+		'Agent type (claude-code, openclaude, codex, opencode, factory-droid, copilot-cli, antigravity, gemini-cli, qwen3-coder)',
 		'claude-code'
 	)
 	.option('-g, --group <id>', 'Group ID to assign the agent to')

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -370,6 +370,7 @@ export async function detectAgent(toolType: ToolType): Promise<DetectResult> {
 export const detectClaude = () => detectAgent('claude-code');
 export const detectCodex = () => detectAgent('codex');
 export const detectOpenCode = () => detectAgent('opencode');
+export const detectOpenClaude = () => detectAgent('openclaude');
 export const detectDroid = () => detectAgent('factory-droid');
 
 /**
@@ -387,6 +388,7 @@ export function getAgentCommand(toolType: ToolType): string {
 export const getClaudeCommand = () => getAgentCommand('claude-code');
 export const getCodexCommand = () => getAgentCommand('codex');
 export const getOpenCodeCommand = () => getAgentCommand('opencode');
+export const getOpenClaudeCommand = () => getAgentCommand('openclaude');
 export const getDroidCommand = () => getAgentCommand('factory-droid');
 
 /**

--- a/src/main/agents/capabilities.ts
+++ b/src/main/agents/capabilities.ts
@@ -404,6 +404,56 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 	},
 
 	/**
+	 * OpenClaude - Open coding CLI that routes to any LLM provider
+	 * https://github.com/Gitlawb/openclaude
+	 *
+	 * A fork of Claude Code that keeps its headless CLI surface flag for flag,
+	 * so the flags and the stream-json schema are Claude's. What is NOT inherited
+	 * is anything that assumes Anthropic specifically, or anything that reaches
+	 * into `~/.claude`.
+	 */
+	openclaude: {
+		supportsResume: true, // -r/--resume <id>, same as Claude Code
+		supportsReadOnlyMode: true, // --permission-mode plan
+		// Deliberately false: standard mode is Maestro's permission RELAY, which
+		// injects --permission-prompt-tool plus an --mcp-config pointing at a local
+		// stdio bridge. That path is wired for claude-code only (see
+		// ipc/handlers/process/handle-spawn.ts), so advertising the capability here
+		// would offer the user a mode that spawns without the relay and aborts on
+		// the first tool call. OpenClaude gets Full Access / Plan-Mode, like every
+		// other non-Claude provider.
+		supportsStandardPermissionMode: false,
+		supportsJsonOutput: true, // --output-format stream-json
+		supportsSessionId: true, // session_id on the stream, same field name
+		supportsImageInput: true, // --input-format stream-json carries image blocks
+		supportsImageInputOnResume: true, // Follows supportsImageInput, as on Claude Code
+		supportsSlashCommands: true, // /provider, /onboard-github, plus skill-backed commands
+		supportsSessionStorage: true, // ~/.openclaude/projects/<encoded-path>/<id>.jsonl
+		supportsCostTracking: true, // total_cost_usd on the result event
+		supportsUsageStats: true, // usage / modelUsage on assistant and result events
+		supportsBatchMode: true, // -p/--print
+		requiresPromptToStart: false, // --print reads the prompt from stdin
+		supportsStreaming: true, // stream-json events
+		supportsResultMessages: true, // "result" event type
+		supportsModelSelection: true, // --model <model>
+		supportsStreamJsonInput: true, // --input-format stream-json
+		supportsPromptViaStdin: true, // `openclaude -p` reads the prompt from stdin
+		supportsThinkingDisplay: true, // Emits streaming assistant messages
+		supportsContextMerge: true, // Can receive merged context via prompts
+		supportsContextExport: true, // Session storage supports context export
+		supportsWizard: true, // Structured output over the same stream-json schema
+		supportsGroupChatModeration: true, // Same spawn path as Claude Code
+		usesJsonLineOutput: false, // stream-json, not the JSONL batch shape
+		usesCombinedContextWindow: false, // Separate input/output limits, as on Claude Code
+		supportsAppendSystemPrompt: true, // --append-system-prompt
+		// Deliberately false: project memory reads ~/.claude/projects/<path>/memory/.
+		// OpenClaude stores under ~/.openclaude and explicitly does not read ~/.claude,
+		// so the Memory Viewer would open on another provider's notes.
+		supportsProjectMemory: false,
+		supportsAdditionalDirectories: true, // --add-dir <dirs...>
+	},
+
+	/**
 	 * Factory Droid - Enterprise AI coding assistant from Factory
 	 * https://docs.factory.ai/cli
 	 *

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -653,6 +653,62 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		],
 	},
 	{
+		id: 'openclaude',
+		name: 'OpenClaude',
+		binaryName: 'openclaude',
+		// OpenClaude is a fork of Claude Code and keeps its headless CLI surface
+		// flag for flag: `--print --verbose --output-format stream-json` emits the
+		// same `system`/`assistant`/`result` schema, down to `session_id`,
+		// `modelUsage`, `total_cost_usd` and `parent_tool_use_id`. What differs is
+		// where the model comes from: OpenClaude routes to whatever provider the
+		// user configured (`/provider`), so nothing here names an Anthropic model.
+		command: 'openclaude',
+		args: ['--print', '--verbose', '--output-format', 'stream-json'],
+		// No interactiveCommand: `maestro-p` drives the real Claude TUI, which is a
+		// different binary. OpenClaude runs the API/print path only.
+		fullAccessArgs: ['--dangerously-skip-permissions'],
+		resumeArgs: (sessionId: string) => ['--resume', sessionId],
+		readOnlyArgs: ['--permission-mode', 'plan'],
+		readOnlyCliEnforced: true,
+		// `--add-dir` grants read AND write, so it maps to every grant the user
+		// made. The {{ADDITIONAL_DIRECTORIES}} prompt block carries "write but
+		// never read", which no flag can express.
+		additionalDirArgs: (dirs) => repeatDirFlag('--add-dir', dirsWithAnyAccess(dirs)),
+		noToolsArgs: ['--tools', ''], // `--tools ""` disables every built-in tool (used by tab naming)
+		modelArgs: (modelId: string) => ['--model', modelId],
+		configOptions: [
+			{
+				key: 'model',
+				type: 'text',
+				label: 'Model',
+				description:
+					'Model override for the configured provider (e.g. "gpt-4o", "qwen2.5-coder:7b", "claude-sonnet-4-6"). Leave empty to use the provider profile default.',
+				default: '',
+				argBuilder: (value: string) => (value && value.trim() ? ['--model', value.trim()] : []),
+			},
+			{
+				key: 'effort',
+				type: 'select',
+				label: 'Effort',
+				description: 'How much effort the model should put into its response.',
+				// Not `dynamic`: effort discovery scrapes the Claude CLI's own help
+				// text, and OpenClaude's wording is its own. These are the levels its
+				// `--effort` flag documents.
+				options: ['', 'low', 'medium', 'high', 'xhigh', 'max'],
+				default: '',
+				argBuilder: (value: string) => (value && value.trim() ? ['--effort', value.trim()] : []),
+			},
+			{
+				key: 'contextWindow',
+				type: 'number',
+				label: 'Context Window Size',
+				description:
+					'Maximum context window size in tokens. OpenClaude can point at any provider, so set this to match the model you configured.',
+				default: 200000,
+			},
+		],
+	},
+	{
 		id: 'factory-droid',
 		name: 'Factory Droid',
 		binaryName: 'droid',

--- a/src/main/agents/path-prober.ts
+++ b/src/main/agents/path-prober.ts
@@ -364,6 +364,13 @@ function getWindowsKnownPaths(binaryName: string): string[] {
 			// WindowsApps (Microsoft Store style)
 			path.join(localAppData, 'Microsoft', 'WindowsApps', 'claude.exe'),
 		],
+		openclaude: [
+			// npm global installation - `npm install -g @gitlawb/openclaude`
+			// creates the .cmd wrapper. This is the documented install path.
+			...npmGlobal('openclaude'),
+			// Possible standalone installer in future
+			...localBin('openclaude'),
+		],
 		codex: [
 			// npm global installation (primary method for Codex)
 			...npmGlobal('codex'),
@@ -534,6 +541,17 @@ function getUnixKnownPaths(binaryName: string): string[] {
 			path.join(home, 'bin', 'claude'),
 			// Node version managers (nvm, fnm, volta, etc.)
 			...nodeVersionManagers('claude'),
+		],
+		openclaude: [
+			// User local bin
+			...localBin('openclaude'),
+			// Homebrew paths
+			...homebrew('openclaude'),
+			// npm global with custom prefix
+			...npmGlobal('openclaude'),
+			// Node version managers (nvm, fnm, volta, etc.). OpenClaude requires
+			// Node >= 22, so a version-managed install is the common case.
+			...nodeVersionManagers('openclaude'),
 		],
 		codex: [
 			// User local bin

--- a/src/main/cue/stats/cue-token-accessor.ts
+++ b/src/main/cue/stats/cue-token-accessor.ts
@@ -83,6 +83,8 @@ export interface SessionTokenSummary {
  */
 const COVERAGE_BY_AGENT: Record<string, 'full' | 'partial'> = {
 	'claude-code': 'full',
+	// Fork of Claude Code: same stream-json schema, same usage and cost fields
+	openclaude: 'full',
 	opencode: 'full',
 	'factory-droid': 'full',
 	codex: 'partial',

--- a/src/main/parsers/index.ts
+++ b/src/main/parsers/index.ts
@@ -55,6 +55,7 @@ export {
 // Import parser implementations
 import { ClaudeOutputParser } from './claude-output-parser';
 import { OpenCodeOutputParser } from './opencode-output-parser';
+import { OpenClaudeOutputParser } from './openclaude-output-parser';
 import { CodexOutputParser } from './codex-output-parser';
 import { FactoryDroidOutputParser } from './factory-droid-output-parser';
 import { CopilotOutputParser } from './copilot-output-parser';
@@ -73,6 +74,7 @@ import { logger } from '../utils/logger';
 // Export parser classes for direct use if needed
 export { ClaudeOutputParser } from './claude-output-parser';
 export { OpenCodeOutputParser } from './opencode-output-parser';
+export { OpenClaudeOutputParser } from './openclaude-output-parser';
 export { CodexOutputParser } from './codex-output-parser';
 export { FactoryDroidOutputParser } from './factory-droid-output-parser';
 export { CopilotOutputParser } from './copilot-output-parser';
@@ -95,6 +97,7 @@ export function initializeOutputParsers(): void {
 	// Register all parser implementations
 	registerOutputParser(new ClaudeOutputParser());
 	registerOutputParser(new OpenCodeOutputParser());
+	registerOutputParser(new OpenClaudeOutputParser());
 	registerOutputParser(new CodexOutputParser());
 	registerOutputParser(new FactoryDroidOutputParser());
 	registerOutputParser(new CopilotOutputParser());

--- a/src/main/parsers/openclaude-output-parser.ts
+++ b/src/main/parsers/openclaude-output-parser.ts
@@ -1,0 +1,20 @@
+/**
+ * OpenClaude Output Parser
+ *
+ * OpenClaude is a fork of Claude Code that keeps its headless CLI surface flag
+ * for flag: `--print --verbose --output-format stream-json` emits a
+ * byte-identical event stream, down to `session_id`, `modelUsage`,
+ * `total_cost_usd` and `parent_tool_use_id`. So the whole parse is inherited.
+ *
+ * Only `agentId` differs, which is what routes error matching to OpenClaude's
+ * pattern set and stamps the right agent on emitted errors.
+ *
+ * @see https://github.com/Gitlawb/openclaude
+ */
+
+import type { ToolType } from '../../shared/types';
+import { ClaudeOutputParser } from './claude-output-parser';
+
+export class OpenClaudeOutputParser extends ClaudeOutputParser {
+	readonly agentId: ToolType = 'openclaude';
+}

--- a/src/main/parsers/parser-factory.ts
+++ b/src/main/parsers/parser-factory.ts
@@ -14,6 +14,7 @@ import type { ToolType } from '../../shared/types';
 import type { AgentOutputParser } from './agent-output-parser';
 import { ClaudeOutputParser } from './claude-output-parser';
 import { OpenCodeOutputParser } from './opencode-output-parser';
+import { OpenClaudeOutputParser } from './openclaude-output-parser';
 import { CodexOutputParser } from './codex-output-parser';
 import { FactoryDroidOutputParser } from './factory-droid-output-parser';
 import { CopilotOutputParser } from './copilot-output-parser';
@@ -26,6 +27,7 @@ import { AntigravityOutputParser } from './antigravity-output-parser';
 const PARSER_CONSTRUCTORS: Record<string, () => AgentOutputParser> = {
 	'claude-code': () => new ClaudeOutputParser(),
 	opencode: () => new OpenCodeOutputParser(),
+	openclaude: () => new OpenClaudeOutputParser(),
 	codex: () => new CodexOutputParser(),
 	'factory-droid': () => new FactoryDroidOutputParser(),
 	'copilot-cli': () => new CopilotOutputParser(),

--- a/src/main/stats/token-usage/token-usage-accessor.ts
+++ b/src/main/stats/token-usage/token-usage-accessor.ts
@@ -58,6 +58,8 @@ const LOG_CONTEXT = '[TokenUsageAccessor]';
  */
 const COVERAGE_BY_AGENT: Record<string, TokenCoverage> = {
 	'claude-code': 'full',
+	// Fork of Claude Code: same stream-json schema, same usage and cost fields
+	openclaude: 'full',
 	opencode: 'full',
 	'factory-droid': 'full',
 	codex: 'partial',

--- a/src/main/storage/claude-session-storage.ts
+++ b/src/main/storage/claude-session-storage.ts
@@ -286,8 +286,33 @@ async function parseSessionFileRemote(
  * Provides access to Claude Code's local session storage at ~/.claude/projects/
  * Supports both local filesystem access and remote access via SSH.
  */
+/**
+ * Which CLI's transcript tree a {@link ClaudeSessionStorage} reads.
+ *
+ * Claude Code and its forks write the same JSONL transcripts under the same
+ * `<home>/projects/<encoded-path>/<session-id>.jsonl` layout; only the home
+ * directory is rebranded. Parameterizing the two names is what lets a fork be a
+ * subclass instead of a second copy of 1200 lines that drifts.
+ */
+export interface ClaudeStorageBrand {
+	/** Home directory under `~`, including the leading dot (e.g. `.claude`). */
+	homeDirName: string;
+	/** electron-store file holding this CLI's session origins. */
+	originsStoreName: string;
+}
+
+const CLAUDE_BRAND: ClaudeStorageBrand = {
+	homeDirName: '.claude',
+	originsStoreName: 'claude-session-origins',
+};
+
 export class ClaudeSessionStorage extends BaseSessionStorage {
 	readonly agentId: ToolType = 'claude-code';
+
+	/** Which CLI's transcript tree this instance reads. Overridden by forks. */
+	protected get brand(): ClaudeStorageBrand {
+		return CLAUDE_BRAND;
+	}
 
 	private originsStore: Store<ClaudeSessionOriginsData>;
 
@@ -297,29 +322,29 @@ export class ClaudeSessionStorage extends BaseSessionStorage {
 		this.originsStore =
 			originsStore ||
 			new Store<ClaudeSessionOriginsData>({
-				name: 'claude-session-origins',
+				name: this.brand.originsStoreName,
 				defaults: { origins: {} },
 			});
 	}
 
 	/**
-	 * Get the Claude projects directory path (local).
+	 * Get the projects directory path (local).
 	 *
-	 * `configDir` selects which Anthropic account's transcripts to read: users
-	 * commonly run several accounts by pointing `CLAUDE_CONFIG_DIR` at separate
-	 * homes (`~/.claude`, `~/.claude-gmail`, ...), and each writes its own
-	 * `projects/` tree. Omit it for the default `~/.claude` account.
+	 * `configDir` selects which account's transcripts to read: users commonly run
+	 * several accounts by pointing `CLAUDE_CONFIG_DIR` at separate homes
+	 * (`~/.claude`, `~/.claude-gmail`, ...), and each writes its own `projects/`
+	 * tree. Omit it for the brand's default home.
 	 */
 	private getProjectsDir(configDir?: string): string {
-		return path.join(configDir ?? path.join(os.homedir(), '.claude'), 'projects');
+		return path.join(configDir ?? path.join(os.homedir(), this.brand.homeDirName), 'projects');
 	}
 
 	/**
-	 * Get the Claude projects directory path (remote via SSH)
+	 * Get the projects directory path (remote via SSH)
 	 * On remote Linux hosts, ~ expands to the user's home directory
 	 */
 	private getRemoteProjectsDir(): string {
-		return '~/.claude/projects';
+		return `~/${this.brand.homeDirName}/projects`;
 	}
 
 	/**

--- a/src/main/storage/index.ts
+++ b/src/main/storage/index.ts
@@ -7,6 +7,7 @@
 
 export { ClaudeSessionStorage, ClaudeSessionOriginsData } from './claude-session-storage';
 export { OpenCodeSessionStorage } from './opencode-session-storage';
+export { OpenClaudeSessionStorage } from './openclaude-session-storage';
 export { CodexSessionStorage } from './codex-session-storage';
 export { FactoryDroidSessionStorage } from './factory-droid-session-storage';
 export { CopilotSessionStorage } from './copilot-session-storage';
@@ -17,6 +18,7 @@ import Store from 'electron-store';
 import { registerSessionStorage } from '../agents';
 import { ClaudeSessionStorage, ClaudeSessionOriginsData } from './claude-session-storage';
 import { OpenCodeSessionStorage } from './opencode-session-storage';
+import { OpenClaudeSessionStorage } from './openclaude-session-storage';
 import { CodexSessionStorage } from './codex-session-storage';
 import { FactoryDroidSessionStorage } from './factory-droid-session-storage';
 import { CopilotSessionStorage } from './copilot-session-storage';
@@ -40,6 +42,7 @@ export interface InitializeSessionStoragesOptions {
 export function initializeSessionStorages(options?: InitializeSessionStoragesOptions): void {
 	registerSessionStorage(new ClaudeSessionStorage(options?.claudeSessionOriginsStore));
 	registerSessionStorage(new OpenCodeSessionStorage());
+	registerSessionStorage(new OpenClaudeSessionStorage());
 	registerSessionStorage(new CodexSessionStorage());
 	registerSessionStorage(new FactoryDroidSessionStorage());
 	registerSessionStorage(new CopilotSessionStorage());

--- a/src/main/storage/openclaude-session-storage.ts
+++ b/src/main/storage/openclaude-session-storage.ts
@@ -1,0 +1,30 @@
+/**
+ * OpenClaude Session Storage
+ *
+ * OpenClaude is a fork of Claude Code: same JSONL transcript format, same
+ * `<home>/projects/<encoded-path>/<session-id>.jsonl` layout, same remote
+ * shape. Only the home directory is rebranded, so this subclass supplies the
+ * brand and inherits the rest.
+ *
+ * The homes are deliberately separate. OpenClaude stores under `~/.openclaude`
+ * and explicitly does NOT read `~/.claude` or honor `CLAUDE_CONFIG_DIR`, so
+ * pointing this at Claude's tree would list another provider's transcripts.
+ *
+ * @see https://github.com/Gitlawb/openclaude
+ */
+
+import type { ToolType } from '../../shared/types';
+import { ClaudeSessionStorage, type ClaudeStorageBrand } from './claude-session-storage';
+
+const OPENCLAUDE_BRAND: ClaudeStorageBrand = {
+	homeDirName: '.openclaude',
+	originsStoreName: 'openclaude-session-origins',
+};
+
+export class OpenClaudeSessionStorage extends ClaudeSessionStorage {
+	readonly agentId: ToolType = 'openclaude';
+
+	protected get brand(): ClaudeStorageBrand {
+		return OPENCLAUDE_BRAND;
+	}
+}

--- a/src/main/utils/ssh-command-builder.ts
+++ b/src/main/utils/ssh-command-builder.ts
@@ -21,6 +21,7 @@ import { parseDataUrl, buildImagePromptPrefix } from '../process-manager/utils/i
 const BASE_SSH_PATH_DIRS = [
 	'$HOME/.local/bin',
 	'$HOME/.opencode/bin',
+	'$HOME/.openclaude/bin',
 	'$HOME/.claude/local',
 	'$HOME/bin',
 	'/usr/local/bin',

--- a/src/renderer/components/Wizard/screens/AgentSelectionScreen/components/AgentLogo.tsx
+++ b/src/renderer/components/Wizard/screens/AgentSelectionScreen/components/AgentLogo.tsx
@@ -313,6 +313,31 @@ export function AgentLogo({
 				</svg>
 			);
 
+		case 'openclaude':
+			// OpenClaude forks Claude Code and routes to any provider, so the mark
+			// keeps Claude's chevron-A and opens the ring around it: one terminal,
+			// many backends.
+			return (
+				<svg
+					className={LOGO_SIZE_CLASS}
+					viewBox="0 0 48 48"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+					style={{ opacity }}
+				>
+					<path
+						d="M34 8.5a19 19 0 1 0 5.5 5.5"
+						stroke={color}
+						strokeWidth="2.5"
+						strokeLinecap="round"
+					/>
+					<path
+						d="M24 15l-7 18h3.4l1.5-4.2h6.2L29.6 33H33l-7-18h-2zm1 4.6l2.2 6.4h-4.4L25 19.6z"
+						fill={color}
+					/>
+				</svg>
+			);
+
 		default:
 			// Marked so a test can prove a pickable provider draws a real mark rather
 			// than landing here. Asserting "an svg rendered" would not: this fallback

--- a/src/renderer/components/Wizard/screens/ConversationScreen/utils/providerName.ts
+++ b/src/renderer/components/Wizard/screens/ConversationScreen/utils/providerName.ts
@@ -7,6 +7,9 @@ export function getConversationProviderName(selectedAgent: ToolType | null): str
 	if (selectedAgent === 'opencode') {
 		return 'OpenCode';
 	}
+	if (selectedAgent === 'openclaude') {
+		return 'OpenClaude';
+	}
 	if (selectedAgent === 'codex') {
 		return 'Codex';
 	}

--- a/src/renderer/components/Wizard/services/conversationManager.ts
+++ b/src/renderer/components/Wizard/services/conversationManager.ts
@@ -658,7 +658,12 @@ class ConversationManager {
 		const agentId = agent.id || this.session?.agentType;
 
 		switch (agentId) {
-			case 'claude-code': {
+			// OpenClaude forks Claude Code and accepts these flags verbatim
+			// (`--output-format`, `--include-partial-messages`, and both the
+			// `--allowedTools` and `--allowed-tools` spellings), so it shares the
+			// branch rather than getting a copy that drifts.
+			case 'claude-code':
+			case 'openclaude': {
 				// Claude Code: start with base args, add required flags for streaming and thinking
 				const args = [...(agent.args || [])];
 				// Ensure stream-json output format for proper parsing and thinking-chunk events

--- a/src/renderer/constants/agentIcons.ts
+++ b/src/renderer/constants/agentIcons.ts
@@ -43,6 +43,7 @@ export const AGENT_ICONS: Record<string, string> = {
 
 	// Open-source alternatives
 	opencode: '📟',
+	openclaude: '◎',
 	hermes: '⚕',
 	pi: 'π',
 

--- a/src/renderer/constants/app.ts
+++ b/src/renderer/constants/app.ts
@@ -102,6 +102,30 @@ export const OPENCODE_BUILTIN_COMMANDS: Record<string, string> = {
 };
 
 /**
+ * Built-in OpenClaude slash commands with their descriptions.
+ *
+ * OpenClaude forks Claude Code and keeps its command set, so the shared entries
+ * are spread rather than retyped. `init` is overridden because OpenClaude does
+ * not read `CLAUDE.md`, and the entries below it are the fork's own.
+ *
+ * This map only supplies DESCRIPTIONS for commands the agent itself reports on
+ * its init event, so an entry for a command a given build does not ship is
+ * never rendered.
+ */
+export const OPENCLAUDE_BUILTIN_COMMANDS: Record<string, string> = {
+	...CLAUDE_BUILTIN_COMMANDS,
+	init: 'Initialize project agent instructions',
+	provider: 'Guided provider setup and saved profiles',
+	'onboard-github': 'Interactive GitHub Models onboarding',
+	model: 'Switch the model for this session',
+	models: 'List models available from the configured provider',
+	effort: 'Set the effort level for model usage',
+	repomap: 'Show the repo map (codebase intelligence)',
+	usage: 'Show provider usage and limits',
+	doctor: 'Check installation health',
+};
+
+/**
  * Built-in GitHub Copilot CLI slash commands with their descriptions
  */
 export const COPILOT_BUILTIN_COMMANDS: Record<string, string> = {
@@ -126,6 +150,7 @@ export const COPILOT_BUILTIN_COMMANDS: Record<string, string> = {
 const AGENT_BUILTIN_COMMANDS: Record<string, Record<string, string>> = {
 	'claude-code': CLAUDE_BUILTIN_COMMANDS,
 	opencode: OPENCODE_BUILTIN_COMMANDS,
+	openclaude: OPENCLAUDE_BUILTIN_COMMANDS,
 	copilot: COPILOT_BUILTIN_COMMANDS,
 };
 

--- a/src/renderer/services/contextGroomer.ts
+++ b/src/renderer/services/contextGroomer.ts
@@ -95,6 +95,28 @@ export const AGENT_ARTIFACTS: Partial<Record<ToolType, string[]>> = {
 		'Claude Code',
 		'CLAUDE.md',
 	],
+	openclaude: [
+		// Slash commands
+		'/clear',
+		'/compact',
+		'/cost',
+		'/doctor',
+		'/help',
+		'/memory',
+		'/model',
+		'/provider',
+		'/repomap',
+		'/review',
+		'/usage',
+		'/logout',
+		'/login',
+		'/config',
+		// Brand references. Deliberately no model names: OpenClaude routes to
+		// whatever provider the user configured, so stripping 'gpt-4o' or
+		// 'qwen2.5-coder' would strip the answer rather than an artifact.
+		'OpenClaude',
+		'openclaude',
+	],
 	opencode: [
 		// Slash commands
 		'/help',
@@ -151,6 +173,14 @@ export const AGENT_TARGET_NOTES: Partial<Record<ToolType, string>> = {
     It can read and edit files, run terminal commands, search code, and interact with git.
     It uses slash commands like /compact, /clear, /cost for session management.
     It can handle large codebases and multi-file changes.
+  `,
+	openclaude: `
+    OpenClaude is an open-source coding-agent CLI, a fork of Claude Code.
+    It routes to whichever provider the user configured (OpenAI-compatible APIs,
+    Gemini, GitHub Models, Ollama, and others), so do not assume an Anthropic model.
+    It can read and edit files, run terminal commands, search code, and interact with git.
+    It uses slash commands like /compact, /clear, /cost for session management,
+    plus /provider for switching backends.
   `,
 	opencode: `
     OpenCode is a multi-model AI coding assistant.

--- a/src/renderer/services/feedbackConversation.ts
+++ b/src/renderer/services/feedbackConversation.ts
@@ -569,7 +569,12 @@ export class FeedbackConversationManager {
 		const baseArgs = (agent.args || []).filter((arg: string) => !PERMISSION_BYPASS_FLAGS.has(arg));
 
 		switch (agentId) {
-			case 'claude-code': {
+			// OpenClaude forks Claude Code and accepts these flags verbatim
+			// (`--output-format`, `--include-partial-messages`, and both the
+			// `--allowedTools` and `--allowed-tools` spellings), so it shares the
+			// branch rather than getting a copy that drifts.
+			case 'claude-code':
+			case 'openclaude': {
 				const args = [...baseArgs];
 				if (!args.includes('--output-format')) {
 					args.push('--output-format', 'stream-json');

--- a/src/renderer/services/inlineWizardConversation.ts
+++ b/src/renderer/services/inlineWizardConversation.ts
@@ -544,7 +544,12 @@ function buildArgsForAgent(agent: any): string[] {
 	const agentId = agent.id;
 
 	switch (agentId) {
-		case 'claude-code': {
+		// OpenClaude forks Claude Code and accepts these flags verbatim
+		// (`--output-format`, `--include-partial-messages`, and both the
+		// `--allowedTools` and `--allowed-tools` spellings), so it shares the
+		// branch rather than getting a copy that drifts.
+		case 'claude-code':
+		case 'openclaude': {
 			const args = [...(agent.args || [])];
 			// Ensure stream-json output format for proper parsing and thinking-chunk events
 			if (!args.includes('--output-format')) {

--- a/src/renderer/services/inlineWizardDocumentGeneration.ts
+++ b/src/renderer/services/inlineWizardDocumentGeneration.ts
@@ -82,8 +82,9 @@ export function extractDisplayTextFromChunk(chunk: string, agentType: ToolType):
 		try {
 			const msg = JSON.parse(line);
 
-			// Claude Code stream-json format
-			if (agentType === 'claude-code') {
+			// Claude Code stream-json format. OpenClaude forks Claude Code and emits
+			// the same schema, so it reads through the same branch.
+			if (agentType === 'claude-code' || agentType === 'openclaude') {
 				// content_block_delta contains streaming text
 				if (msg.type === 'content_block_delta' && msg.delta?.text) {
 					textParts.push(msg.delta.text);
@@ -783,7 +784,12 @@ function buildArgsForAgent(agent: { id: string; args?: string[] }): string[] {
 	const agentId = agent.id;
 
 	switch (agentId) {
-		case 'claude-code': {
+		// OpenClaude forks Claude Code and accepts these flags verbatim
+		// (`--output-format`, `--include-partial-messages`, and both the
+		// `--allowedTools` and `--allowed-tools` spellings), so it shares the
+		// branch rather than getting a copy that drifts.
+		case 'claude-code':
+		case 'openclaude': {
 			const args = [...(agent.args || [])];
 			if (!args.includes('--include-partial-messages')) {
 				args.push('--include-partial-messages');

--- a/src/shared/agentConstants.ts
+++ b/src/shared/agentConstants.ts
@@ -18,6 +18,7 @@ export const DEFAULT_CONTEXT_WINDOWS: Partial<Record<AgentId, number>> = {
 	'claude-code': 200000, // Claude 3.5 Sonnet/Claude 4 default context
 	codex: 200000, // OpenAI o3/o4-mini context window
 	opencode: 128000, // OpenCode (depends on model, 128k is conservative default)
+	openclaude: 200000, // OpenClaude routes to whatever provider the user configured; Claude's window is the fork's own default
 	'factory-droid': 200000, // Factory Droid (varies by model, defaults to Claude Opus)
 	hermes: 200000, // Conservative fallback until runtime-specific reporting lands
 	pi: 200000, // Conservative fallback until runtime-specific reporting lands

--- a/src/shared/agentErrorPatterns.ts
+++ b/src/shared/agentErrorPatterns.ts
@@ -968,6 +968,17 @@ export const SSH_ERROR_PATTERNS: AgentErrorPatterns = {
 			recoverable: false,
 		},
 		{
+			// Agent command not found for openclaude.
+			// MUST stay ahead of the claude entry below: that pattern is
+			// `.*claude.*`, which also matches "openclaude", and the first match
+			// wins - so the order is what stops an OpenClaude failure from telling
+			// the user to go install Claude Code.
+			pattern:
+				/bash:.*openclaude.*command not found|sh:.*openclaude.*command not found|zsh:.*command not found:.*openclaude/i,
+			message: 'OpenClaude command not found. Ensure OpenClaude is installed.',
+			recoverable: false,
+		},
+		{
 			// Agent command not found (shell reports command not found)
 			// bash/sh format: "bash: claude: command not found"
 			// zsh format: "zsh: command not found: claude"
@@ -995,7 +1006,7 @@ export const SSH_ERROR_PATTERNS: AgentErrorPatterns = {
 			// More specific pattern: requires path-like structure before the binary name
 			// Matches: "/usr/local/bin/claude: No such file or directory"
 			// Does NOT match: "claude: error: File 'foo.txt': No such file or directory" (normal file errors)
-			pattern: /\/[^\s:]*\/(claude|opencode|codex):\s*No such file or directory/i,
+			pattern: /\/[^\s:]*\/(openclaude|claude|opencode|codex):\s*No such file or directory/i,
 			message: 'Agent binary not found at the specified path. Ensure the agent is installed.',
 			recoverable: false,
 		},
@@ -1554,6 +1565,10 @@ const ANTIGRAVITY_ERROR_PATTERNS: AgentErrorPatterns = {
 
 const patternRegistry = new Map<ToolType, AgentErrorPatterns>([
 	['claude-code', CLAUDE_ERROR_PATTERNS],
+	// OpenClaude is a fork of Claude Code and fails with the same strings. The
+	// messages in this bank name WHAT failed rather than a brand or a terminal
+	// command, so sharing the set is what keeps the two from drifting apart.
+	['openclaude', CLAUDE_ERROR_PATTERNS],
 	['opencode', OPENCODE_ERROR_PATTERNS],
 	['codex', CODEX_ERROR_PATTERNS],
 	['factory-droid', FACTORY_DROID_ERROR_PATTERNS],

--- a/src/shared/agentIds.ts
+++ b/src/shared/agentIds.ts
@@ -21,6 +21,7 @@ export const AGENT_IDS = [
 	'antigravity',
 	'qwen3-coder',
 	'opencode',
+	'openclaude',
 	'factory-droid',
 	'hermes',
 	'pi',

--- a/src/shared/agentMetadata.ts
+++ b/src/shared/agentMetadata.ts
@@ -22,6 +22,7 @@ export const AGENT_DISPLAY_NAMES: Record<AgentId, string> = {
 	antigravity: 'Antigravity CLI',
 	'qwen3-coder': 'Qwen3 Coder',
 	opencode: 'OpenCode',
+	openclaude: 'OpenClaude',
 	'factory-droid': 'Factory Droid',
 	hermes: 'Hermes',
 	pi: 'Pi',
@@ -43,11 +44,15 @@ export function getAgentDisplayName(agentId: AgentId | string): string {
 
 /**
  * Agents that use "plan mode" rather than true read-only mode.
- * Claude Code uses --permission-mode plan, OpenCode uses --agent plan.
+ * Claude Code and OpenClaude use --permission-mode plan, OpenCode uses --agent plan.
  * These agents can still read files but the CLI calls it "plan mode".
  * Other agents (Codex, Factory Droid) have true read-only enforcement.
  */
-const PLAN_MODE_AGENTS: ReadonlySet<AgentId> = new Set<AgentId>(['claude-code', 'opencode']);
+const PLAN_MODE_AGENTS: ReadonlySet<AgentId> = new Set<AgentId>([
+	'claude-code',
+	'openclaude',
+	'opencode',
+]);
 
 /**
  * Get the UI label for the read-only mode pill based on the agent.
@@ -134,6 +139,7 @@ export function resolveTabPermissionMode(
  */
 export const BETA_AGENTS: ReadonlySet<AgentId> = new Set<AgentId>([
 	'opencode',
+	'openclaude',
 	'factory-droid',
 	'hermes',
 	'pi',
@@ -188,6 +194,7 @@ export const AGENT_PICKER_META: Record<AgentId, AgentPickerMeta | null> = {
 	grok: { description: "xAI's AI coding assistant", brandColor: '#B4B8C0' },
 	hermes: { description: "Nous Research's AI coding assistant", brandColor: '#2323FF' },
 	omp: { description: 'Multi-model coding agent', brandColor: '#9B4DFF' },
+	openclaude: { description: 'Open coding CLI for any LLM provider', brandColor: '#0EA5E9' },
 	opencode: { description: 'Open-source AI coding assistant', brandColor: '#F97316' },
 	pi: { description: 'Your own agent harness', brandColor: '#E4E4E7' },
 	'qwen3-coder': { description: "Alibaba's AI coding assistant", brandColor: '#615CED' },
@@ -264,6 +271,10 @@ const AGENT_LOGIN_COMMANDS: Record<AgentId, AgentLoginCommand | null> = {
 	'gemini-cli': { binary: 'gemini', args: '', followUp: '/auth' },
 	'qwen3-coder': { binary: 'qwen3-coder', args: '', followUp: '/auth' },
 	opencode: { binary: 'opencode', args: 'auth login' },
+	// OpenClaude has no login subcommand for the provider profiles it actually
+	// runs on: `/provider` inside the TUI is the guided setup, and `auth login`
+	// only covers the first-party Anthropic route. Point the user at the TUI.
+	openclaude: { binary: 'openclaude', args: '', followUp: '/provider' },
 	'factory-droid': { binary: 'droid', args: '', followUp: '/login' },
 	'copilot-cli': { binary: 'copilot', args: 'login' },
 	// Antigravity has no login subcommand: headless runs reuse the credentials

--- a/src/shared/pathUtils.ts
+++ b/src/shared/pathUtils.ts
@@ -380,6 +380,7 @@ export function buildExpandedPath(customPaths?: string[]): string {
 			`${home}/bin`, // User bin directory
 			`${home}/.claude/local`, // Claude local install location
 			`${home}/.opencode/bin`, // OpenCode installer default location
+			`${home}/.openclaude/bin`, // OpenClaude installer default location
 			'/home/linuxbrew/.linuxbrew/bin', // Linuxbrew
 			'/usr/bin',
 			'/bin',

--- a/src/shared/templateVariables.ts
+++ b/src/shared/templateVariables.ts
@@ -19,7 +19,7 @@ import type { AdditionalDirectory } from './types';
  *   {{AGENT_HISTORY_PATH}} - Path to agent's history JSON file (for task recall)
  *   {{TAB_ID}}            - This conversation's AI tab ID (for CLI targeting; empty on headless spawns)
  *   {{TAB_NAME}}          - Custom tab name (alias: SESSION_NAME)
- *   {{TOOL_TYPE}}         - Agent type (claude-code, codex, opencode, factory-droid)
+ *   {{TOOL_TYPE}}         - Agent type (claude-code, openclaude, codex, opencode, factory-droid)
  *
  * Path Variables:
  *   {{CWD}}               - Current working directory


### PR DESCRIPTION
Closes #1458

## What

Adds [OpenClaude](https://github.com/Gitlawb/openclaude) as a first-class provider: it shows up in all three provider pickers (New Agent modal, New Agent Wizard tile strip, Group Chat moderator dropdown), gets detected on PATH and in the usual install locations, streams and resumes like any other agent, and its past sessions are browsable.

## Why it's a thin layer

OpenClaude is a fork of Claude Code that routes to whichever backend the user configures (OpenAI-compatible APIs, Gemini, GitHub Models, Ollama, Bedrock, Vertex, and others). It keeps the headless CLI surface flag for flag - `--print --verbose --output-format stream-json`, `--resume`, `--permission-mode plan`, `--add-dir`, `--append-system-prompt`, both `--allowedTools` spellings - and emits a byte-identical stream-json schema, down to `session_id`, `modelUsage`, `total_cost_usd` and `parent_tool_use_id`. Transcripts land in `~/.openclaude/projects/<encoded-path>/<id>.jsonl`, the same layout Claude Code writes under `~/.claude`.

So this follows the same shape as the Kilo/OpenCode fork integration rather than adding a parallel copy:

- `OpenClaudeOutputParser` subclasses `ClaudeOutputParser`, overriding only `agentId`.
- `OpenClaudeSessionStorage` subclasses `ClaudeSessionStorage` and supplies a `ClaudeStorageBrand` of `{ homeDirName: '.openclaude', originsStoreName: 'openclaude-session-origins' }`. To make that possible, Claude's projects directory and origins store moved off hard-coded names onto that brand. The Claude paths are unchanged and pinned by a test.
- Error patterns are shared outright. The Claude bank's messages name *what* failed rather than a brand or a terminal command, so sharing the set is what keeps the two from drifting apart.
- The four wizard/feedback arg builders share the `claude-code` branch by fallthrough rather than gaining a fourth near-identical copy.

## One ordering detail

The SSH command-not-found pattern for Claude is `.*claude.*`, which also matches `openclaude`, and the first match wins. The OpenClaude entry is inserted **ahead** of it, so a missing OpenClaude binary doesn't tell the user to go install Claude Code. There's a test that fails if the order is ever swapped.

## Deliberately NOT inherited

Each is documented in AGENT_SUPPORT.md and pinned by a test, because these are the spots where "it's the same CLI" quietly stops being true:

| Not inherited | Why |
| --- | --- |
| `supportsStandardPermissionMode` | Standard mode is Maestro's permission relay, which injects `--permission-prompt-tool` + an `--mcp-config` pointing at a local stdio bridge; `handle-spawn.ts` gates that on `claude-code`. OpenClaude *does* expose the flag, so wiring it is a real follow-up - but advertising the capability without the relay would offer a mode that spawns and then aborts on the first tool call. OpenClaude gets Full Access / Plan-Mode, like every other non-Claude provider. |
| `supportsProjectMemory` | Project memory reads `~/.claude/projects/<path>/memory/`. OpenClaude explicitly does not read `~/.claude`, so the Memory Viewer would open another provider's notes. |
| `interactiveCommand: 'maestro-p'` | `maestro-p` drives the real Claude TUI, a different binary. OpenClaude runs the API/print path only. |
| `defaultEnvVars` | `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` is a Claude Code knob. |
| Tier/effort model tables | OpenClaude's model IDs are whatever the configured provider exposes, discovered at runtime. A shipped guess would rot into naming a model the user cannot run. |

## Also wired

Agent id and definition, capabilities, path probing (Windows + POSIX), the PATH-expansion list and SSH remote PATH, the provider pickers via `AGENT_PICKER_META`, the wizard logo and tile glyph, plan-mode wording, beta badge, default context window, re-auth command (`openclaude` then `/provider`), built-in slash commands, context groomer artifacts and target notes, both token-coverage maps (same schema, so `full`), and the CLI spawner helpers and `--type` help text.

## Base branch

Targets `rc`, not `main`. Every prior add-a-provider commit landed there, and `main` is ~1100 commits behind and predates `AGENT_PICKER_META` / `PICKABLE_AGENT_IDS` entirely, so half of this change has nothing to attach to over there.

## Validation

Run locally on macOS:

- `npm run lint` - all three tsc configs clean
- `npx eslint src/` - 0 errors (the 5 remaining warnings are pre-existing on `rc`, verified by stashing)
- `npx prettier --check .` - clean
- `npx vitest run` - **1697 files / 40,208 tests passed, 0 failures**
- New: `src/__tests__/main/agents/openclaude-agent.test.ts` (22 tests) covering registration, CLI-surface parity with Claude Code, the withheld capabilities, parser identity, the SSH error-pattern ordering, and storage-path isolation in both directions.

Local validation is single-OS, so this still needs both CI matrix legs green before merge.

## Not verified against a live binary

Everything above is read off the OpenClaude source and docs, not a running install. The pieces most worth a second pair of eyes: the `~/.openclaude/projects/` transcript layout, and whether `--effort` accepts exactly the levels listed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenClaude as a Beta agent with provider selection, model and effort settings, plan mode, and a 200,000-token context window.
  * Added OpenClaude detection across supported installation locations, including remote environments.
  * Added OpenClaude branding, slash-command support, session history, and transcript storage under `~/.openclaude`.
  * Added stream-based responses, error handling, and full token-usage reporting.
* **Documentation**
  * Added setup, CLI behavior, capabilities, and supported-agent documentation for OpenClaude.
* **Tests**
  * Added comprehensive coverage for OpenClaude registration, parsing, storage, and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->