### PR TITLE
feat(themes): Surface Gloss setting and the Left Bar row layout

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -926,6 +926,15 @@ Switch the active Maestro theme (applies live). Use --list to see options.
 | `-l, --list` | List available themes          | -       |
 | `--json`     | Output as JSON (for scripting) | -       |
 
+## `maestro-cli gloss [level]`
+
+Set the surface gloss level: off, sheen, strong or max (applies live). Omit the level to see the current one.
+
+| Option       | Description                                  | Default |
+| ------------ | -------------------------------------------- | ------- |
+| `-l, --list` | List the gloss levels and what each one does | -       |
+| `--json`     | Output as JSON (for scripting)               | -       |
+
 ## `maestro-cli theme`
 
 Manage the custom theme palette

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -797,6 +797,13 @@ maestro-cli set-theme "Catppuccin Mocha"
 # See every available theme
 maestro-cli set-theme --list
 
+# Set how much light the app chrome catches (Settings -> Themes -> Surface Gloss)
+maestro-cli gloss strong
+
+# See the current level and what each one does
+maestro-cli gloss
+maestro-cli gloss --list
+
 # List Encore (experimental) features and whether each is enabled
 maestro-cli encore list
 
@@ -806,6 +813,8 @@ maestro-cli encore disable maestroCue
 ```
 
 Encore feature IDs: `directorNotes`, `usageStats`, `symphony`, `maestroCue`. Friendly aliases are accepted (for example `group-chat` for `symphony`, `cue` for `maestroCue`).
+
+Gloss levels, least to most: `off` (the shipped flat look), `sheen`, `strong`, `max`. Gloss only adds highlights and shadows to the sidebars, headers, tab bar and composer, so it changes no theme color and leaves text exactly as legible. It has no effect on light themes.
 
 ### Custom Theme Palette
 

--- a/src/__tests__/cli/commands/gloss.test.ts
+++ b/src/__tests__/cli/commands/gloss.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @file gloss.test.ts
+ * @description Tests for the gloss CLI command
+ */
+
+import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest';
+
+vi.mock('../../../cli/services/maestro-client', () => ({ withMaestroClient: vi.fn() }));
+vi.mock('../../../cli/services/storage', () => ({ readSettingValue: vi.fn() }));
+vi.mock('../../../cli/output/formatter', () => ({
+	formatError: vi.fn((msg) => `Error: ${msg}`),
+	formatSuccess: vi.fn((msg) => `Success: ${msg}`),
+}));
+
+import { gloss } from '../../../cli/commands/gloss';
+import { withMaestroClient } from '../../../cli/services/maestro-client';
+import { readSettingValue } from '../../../cli/services/storage';
+import { formatError } from '../../../cli/output/formatter';
+
+function mockSend(result: Record<string, unknown>) {
+	let captured: Record<string, unknown> = {};
+	vi.mocked(withMaestroClient).mockImplementation(async (action) =>
+		action({
+			sendCommand: vi.fn().mockImplementation((payload: Record<string, unknown>) => {
+				captured = payload;
+				return Promise.resolve(result);
+			}),
+		} as never)
+	);
+	return () => captured;
+}
+
+describe('gloss command', () => {
+	let consoleSpy: MockInstance;
+	let processExitSpy: MockInstance;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(readSettingValue).mockReturnValue('off');
+		consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+			throw new Error('__exit__');
+		});
+	});
+
+	it('sets a level via set_setting/themeGloss', async () => {
+		const getPayload = mockSend({ success: true });
+		await gloss('strong', {});
+		const p = getPayload();
+		expect(p.type).toBe('set_setting');
+		expect(p.key).toBe('themeGloss');
+		expect(p.value).toBe('strong');
+	});
+
+	it('accepts a level in any case', async () => {
+		const getPayload = mockSend({ success: true });
+		await gloss('  MAX ', {});
+		expect(getPayload().value).toBe('max');
+	});
+
+	it('rejects an unknown level without connecting', async () => {
+		// A typo must fail loudly here. Written through `settings set` instead it
+		// lands on <html data-gloss>, matches no CSS rule, and renders as off with
+		// no error anywhere.
+		await expect(gloss('shiny', {})).rejects.toThrow('__exit__');
+		expect(formatError).toHaveBeenCalledWith(expect.stringContaining('Unknown gloss level'));
+		expect(withMaestroClient).not.toHaveBeenCalled();
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it('reports the current level without connecting when no level is given', async () => {
+		vi.mocked(readSettingValue).mockReturnValue('sheen');
+		await gloss(undefined, {});
+		expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Gloss levels'));
+		expect(withMaestroClient).not.toHaveBeenCalled();
+	});
+
+	it('reports an unrecognized stored level as off rather than echoing it back', async () => {
+		vi.mocked(readSettingValue).mockReturnValue('nonsense');
+		await gloss(undefined, { json: true });
+		const parsed = JSON.parse(consoleSpy.mock.calls[0][0]);
+		expect(parsed.level).toBe('off');
+		expect(parsed.levels.map((l: { value: string }) => l.value)).toEqual([
+			'off',
+			'sheen',
+			'strong',
+			'max',
+		]);
+	});
+
+	it('reports a server failure', async () => {
+		mockSend({ success: false, error: 'Setting modification not configured' });
+		await expect(gloss('max', {})).rejects.toThrow('__exit__');
+		expect(formatError).toHaveBeenCalledWith('Setting modification not configured');
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+});

--- a/src/__tests__/renderer/components/Settings/tabs/ThemeTab.test.tsx
+++ b/src/__tests__/renderer/components/Settings/tabs/ThemeTab.test.tsx
@@ -22,6 +22,10 @@ const mockSetCustomThemeColors = vi.fn();
 const mockSetCustomThemeBaseId = vi.fn();
 const mockSetThemeGloss = vi.fn();
 
+// Mutable so a test can model a store that has not hydrated `themeGloss` yet,
+// or a settings blob written by a build that predates the setting.
+let mockThemeGloss: string | undefined = 'off';
+
 // Mock useSettings hook
 vi.mock('../../../../../renderer/hooks/settings/useSettings', () => ({
 	useSettings: () => ({
@@ -45,7 +49,7 @@ vi.mock('../../../../../renderer/hooks/settings/useSettings', () => ({
 		setCustomThemeColors: mockSetCustomThemeColors,
 		customThemeBaseId: 'dracula',
 		setCustomThemeBaseId: mockSetCustomThemeBaseId,
-		themeGloss: 'off',
+		themeGloss: mockThemeGloss,
 		setThemeGloss: mockSetThemeGloss,
 	}),
 }));
@@ -117,6 +121,7 @@ describe('ThemeTab', () => {
 	afterEach(() => {
 		vi.useRealTimers();
 		vi.clearAllMocks();
+		mockThemeGloss = 'off';
 	});
 
 	it('should display theme mode sections', async () => {
@@ -349,6 +354,32 @@ describe('ThemeTab', () => {
 			});
 
 			expect(mockSetThemeGloss).toHaveBeenCalledWith('strong');
+		});
+
+		it('survives an undefined level instead of taking the whole modal down', async () => {
+			// `GLOSS_LEVEL_META[level]` is a lookup, so an undefined level threw and
+			// unmounted the ENTIRE Settings modal, not just this section. The store
+			// hydrates asynchronously and an older settings blob has no `themeGloss`
+			// at all, so this is a state that really occurs.
+			mockThemeGloss = undefined;
+
+			render(<ThemeTab theme={mockTheme} themes={mockThemes} />);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(100);
+			});
+
+			expect(screen.getByRole('slider', { name: 'Intensity' })).toHaveValue('0');
+		});
+
+		it('falls back to Off for an unrecognized stored level', async () => {
+			mockThemeGloss = 'shiny';
+
+			render(<ThemeTab theme={mockTheme} themes={mockThemes} />);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(100);
+			});
+
+			expect(screen.getByRole('slider', { name: 'Intensity' })).toHaveValue('0');
 		});
 
 		it('disables the slider on a light theme, where gloss has no effect', async () => {

--- a/src/__tests__/renderer/components/Settings/tabs/ThemeTab.test.tsx
+++ b/src/__tests__/renderer/components/Settings/tabs/ThemeTab.test.tsx
@@ -20,6 +20,7 @@ import { mockTheme } from '../../../../helpers/mockTheme';
 const mockSetActiveThemeId = vi.fn();
 const mockSetCustomThemeColors = vi.fn();
 const mockSetCustomThemeBaseId = vi.fn();
+const mockSetThemeGloss = vi.fn();
 
 // Mock useSettings hook
 vi.mock('../../../../../renderer/hooks/settings/useSettings', () => ({
@@ -44,6 +45,8 @@ vi.mock('../../../../../renderer/hooks/settings/useSettings', () => ({
 		setCustomThemeColors: mockSetCustomThemeColors,
 		customThemeBaseId: 'dracula',
 		setCustomThemeBaseId: mockSetCustomThemeBaseId,
+		themeGloss: 'off',
+		setThemeGloss: mockSetThemeGloss,
 	}),
 }));
 
@@ -317,5 +320,46 @@ describe('ThemeTab', () => {
 		});
 
 		expect(screen.getByTestId('custom-theme-builder')).toBeInTheDocument();
+	});
+
+	describe('Surface Gloss', () => {
+		it('renders the gloss slider with every level named, starting at Off', async () => {
+			render(<ThemeTab theme={mockTheme} themes={mockThemes} />);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(100);
+			});
+
+			const slider = screen.getByRole('slider', { name: 'Intensity' });
+			expect(slider).toHaveValue('0');
+			// The stop names are what make a 0-3 range legible. Losing them would
+			// leave the user sliding between unlabelled notches.
+			for (const label of ['Off', 'Sheen', 'Strong', 'Max']) {
+				expect(screen.getAllByText(label).length).toBeGreaterThan(0);
+			}
+		});
+
+		it('maps the slider position onto the level name, not the raw index', async () => {
+			render(<ThemeTab theme={mockTheme} themes={mockThemes} />);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(100);
+			});
+
+			fireEvent.change(screen.getByRole('slider', { name: 'Intensity' }), {
+				target: { value: '2' },
+			});
+
+			expect(mockSetThemeGloss).toHaveBeenCalledWith('strong');
+		});
+
+		it('disables the slider on a light theme, where gloss has no effect', async () => {
+			render(<ThemeTab theme={mockLightTheme} themes={mockThemes} />);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(100);
+			});
+
+			// The CSS opts out on light themes, so an enabled control here would
+			// let the user move a slider that changes nothing on screen.
+			expect(screen.getByRole('slider', { name: 'Intensity' })).toBeDisabled();
+		});
 	});
 });

--- a/src/__tests__/renderer/components/SettingsModal.test.tsx
+++ b/src/__tests__/renderer/components/SettingsModal.test.tsx
@@ -144,6 +144,8 @@ vi.mock('../../../renderer/hooks/settings/useSettings', () => ({
 		setCustomThemeColors: mockSetCustomThemeColors,
 		customThemeBaseId: 'dracula',
 		setCustomThemeBaseId: mockSetCustomThemeBaseId,
+		themeGloss: 'off',
+		setThemeGloss: vi.fn(),
 		// LLM settings
 		llmProvider: 'openrouter',
 		setLlmProvider: mockSetLlmProvider,

--- a/src/__tests__/renderer/hooks/useThemeStyles.test.ts
+++ b/src/__tests__/renderer/hooks/useThemeStyles.test.ts
@@ -57,7 +57,9 @@ describe('useThemeStyles', () => {
 
 	describe('CSS variable injection', () => {
 		it('sets all expected CSS variables from theme colors on mount', () => {
-			renderHook(() => useThemeStyles({ themeColors: DARK_COLORS }));
+			renderHook(() =>
+				useThemeStyles({ themeColors: DARK_COLORS, themeMode: 'dark', glossLevel: 'off' })
+			);
 
 			expect(getCssVar('--accent-color')).toBe('#bd93f9');
 			expect(getCssVar('--highlight-color')).toBe('#bd93f9');
@@ -71,7 +73,9 @@ describe('useThemeStyles', () => {
 			// --highlight-color is a legacy alias kept for backwards compat with
 			// older CSS rules that reference it (e.g. animations in index.css).
 			// Both must point to the same color.
-			renderHook(() => useThemeStyles({ themeColors: DARK_COLORS }));
+			renderHook(() =>
+				useThemeStyles({ themeColors: DARK_COLORS, themeMode: 'dark', glossLevel: 'off' })
+			);
 			expect(getCssVar('--accent-color')).toBe(getCssVar('--highlight-color'));
 		});
 
@@ -79,14 +83,20 @@ describe('useThemeStyles', () => {
 			// Regression: previously the idle thumb was hardcoded
 			// rgba(255,255,255,0.15) which was invisible on light themes. Using
 			// the theme `border` token makes it work on both light and dark.
-			renderHook(() => useThemeStyles({ themeColors: LIGHT_COLORS }));
+			renderHook(() =>
+				useThemeStyles({ themeColors: LIGHT_COLORS, themeMode: 'light', glossLevel: 'off' })
+			);
 			expect(getCssVar('--scrollbar-thumb')).toBe('#d0d7de');
 		});
 
 		it('updates CSS variables when theme colors change', () => {
-			const { rerender } = renderHook(({ colors }) => useThemeStyles({ themeColors: colors }), {
-				initialProps: { colors: DARK_COLORS },
-			});
+			const { rerender } = renderHook(
+				({ colors }) =>
+					useThemeStyles({ themeColors: colors, themeMode: 'dark', glossLevel: 'off' }),
+				{
+					initialProps: { colors: DARK_COLORS },
+				}
+			);
 			expect(getCssVar('--scrollbar-thumb')).toBe('#44475a');
 			expect(getCssVar('--accent-color')).toBe('#bd93f9');
 
@@ -102,9 +112,13 @@ describe('useThemeStyles', () => {
 		it('does not re-set unchanged variables when an unrelated theme field changes', () => {
 			// Sanity: the effect's dependency array lists every consumed field.
 			// If we add a new CSS var, its source field must be in the deps.
-			const { rerender } = renderHook(({ colors }) => useThemeStyles({ themeColors: colors }), {
-				initialProps: { colors: DARK_COLORS },
-			});
+			const { rerender } = renderHook(
+				({ colors }) =>
+					useThemeStyles({ themeColors: colors, themeMode: 'dark', glossLevel: 'off' }),
+				{
+					initialProps: { colors: DARK_COLORS },
+				}
+			);
 
 			rerender({ colors: { ...DARK_COLORS, accent: '#ff0000' } });
 
@@ -116,9 +130,55 @@ describe('useThemeStyles', () => {
 		});
 	});
 
+	describe('theme attributes on <html>', () => {
+		it('publishes the theme mode and the gloss level together', () => {
+			renderHook(() =>
+				useThemeStyles({ themeColors: DARK_COLORS, themeMode: 'dark', glossLevel: 'strong' })
+			);
+
+			expect(document.documentElement.dataset.themeMode).toBe('dark');
+			expect(document.documentElement.dataset.gloss).toBe('strong');
+		});
+
+		it('updates both attributes when the theme changes', () => {
+			// They are written in one effect on purpose: the gloss rules in
+			// index.css opt out on light themes, so a build that updated the mode
+			// without the level could paint a light theme with dark highlights.
+			const { rerender } = renderHook(
+				({ colors, mode }: { colors: ThemeColors; mode: 'dark' | 'light' }) =>
+					useThemeStyles({ themeColors: colors, themeMode: mode, glossLevel: 'max' }),
+				{ initialProps: { colors: DARK_COLORS, mode: 'dark' as 'dark' | 'light' } }
+			);
+			expect(document.documentElement.dataset.themeMode).toBe('dark');
+
+			rerender({ colors: LIGHT_COLORS, mode: 'light' });
+
+			expect(document.documentElement.dataset.themeMode).toBe('light');
+			expect(document.documentElement.dataset.gloss).toBe('max');
+		});
+
+		it('writes the level verbatim when gloss is off, rather than omitting the attribute', () => {
+			// `off` is a real level with no rules behind it, not an absent value.
+			// Leaving the attribute unset would leave a stale level on <html>
+			// after the user slid back down to Off.
+			const { rerender } = renderHook(
+				({ level }: { level: 'off' | 'sheen' }) =>
+					useThemeStyles({ themeColors: DARK_COLORS, themeMode: 'dark', glossLevel: level }),
+				{ initialProps: { level: 'sheen' as 'off' | 'sheen' } }
+			);
+			expect(document.documentElement.dataset.gloss).toBe('sheen');
+
+			rerender({ level: 'off' });
+
+			expect(document.documentElement.dataset.gloss).toBe('off');
+		});
+	});
+
 	describe('return value', () => {
 		it('returns an empty object (all functionality is via side effects)', () => {
-			const { result } = renderHook(() => useThemeStyles({ themeColors: DARK_COLORS }));
+			const { result } = renderHook(() =>
+				useThemeStyles({ themeColors: DARK_COLORS, themeMode: 'dark', glossLevel: 'off' })
+			);
 			expect(result.current).toEqual({});
 		});
 	});

--- a/src/__tests__/renderer/hooks/useThemeStyles.test.ts
+++ b/src/__tests__/renderer/hooks/useThemeStyles.test.ts
@@ -19,6 +19,7 @@ const DARK_COLORS: ThemeColors = {
 	border: '#44475a',
 	textDim: '#6272a4',
 	bgActivity: '#343746',
+	textMain: '#f8f8f2',
 };
 
 const LIGHT_COLORS: ThemeColors = {
@@ -26,6 +27,7 @@ const LIGHT_COLORS: ThemeColors = {
 	border: '#d0d7de',
 	textDim: '#656d76',
 	bgActivity: '#f6f8fa',
+	textMain: '#1f2328',
 };
 
 function getCssVar(name: string): string {
@@ -42,6 +44,8 @@ describe('useThemeStyles', () => {
 		root.removeProperty('--scrollbar-thumb-hover');
 		root.removeProperty('--scrollbar-thumb-active');
 		root.removeProperty('--scrollbar-track');
+		root.removeProperty('--fx-quiet');
+		root.removeProperty('--sheen-rgb');
 	});
 
 	afterEach(() => {
@@ -53,6 +57,8 @@ describe('useThemeStyles', () => {
 		root.removeProperty('--scrollbar-thumb-hover');
 		root.removeProperty('--scrollbar-thumb-active');
 		root.removeProperty('--scrollbar-track');
+		root.removeProperty('--fx-quiet');
+		root.removeProperty('--sheen-rgb');
 	});
 
 	describe('CSS variable injection', () => {
@@ -127,6 +133,45 @@ describe('useThemeStyles', () => {
 			// Other vars stay at their previous values
 			expect(getCssVar('--scrollbar-thumb')).toBe('#44475a');
 			expect(getCssVar('--scrollbar-thumb-hover')).toBe('#6272a4');
+		});
+	});
+
+	describe('--sheen-rgb (the gloss light source)', () => {
+		it('publishes textMain as an R G B triple, not a hex', () => {
+			// The gloss rules mix it as `rgb(var(--sheen-rgb) / 7%)`, so the alpha
+			// stays in index.css where the levels live and only the hue crosses.
+			renderHook(() =>
+				useThemeStyles({ themeColors: DARK_COLORS, themeMode: 'dark', glossLevel: 'sheen' })
+			);
+			expect(getCssVar('--sheen-rgb')).toBe('248 248 242');
+		});
+
+		it('tracks textMain rather than any inherited color', () => {
+			// It replaced `currentColor`, which made the sheen strength depend on
+			// whatever text color each chrome root happened to inherit.
+			const { rerender } = renderHook(
+				({ colors }) =>
+					useThemeStyles({ themeColors: colors, themeMode: 'dark', glossLevel: 'sheen' }),
+				{ initialProps: { colors: DARK_COLORS } }
+			);
+			expect(getCssVar('--sheen-rgb')).toBe('248 248 242');
+
+			rerender({ colors: { ...DARK_COLORS, textMain: '#c5c8c6' } });
+
+			expect(getCssVar('--sheen-rgb')).toBe('197 200 198');
+		});
+
+		it('falls back to white when the palette carries a non-hex color', () => {
+			// A custom theme may use any CSS color. White is the right failure:
+			// gloss is dark-theme only and every dark theme's textMain is near it.
+			renderHook(() =>
+				useThemeStyles({
+					themeColors: { ...DARK_COLORS, textMain: 'rgb(200, 200, 200)' },
+					themeMode: 'dark',
+					glossLevel: 'sheen',
+				})
+			);
+			expect(getCssVar('--sheen-rgb')).toBe('255 255 255');
 		});
 	});
 

--- a/src/__tests__/shared/themeGloss.test.ts
+++ b/src/__tests__/shared/themeGloss.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @file themeGloss.test.ts
+ * @description Tests for the surface gloss vocabulary shared by the Settings
+ * slider, the renderer's `<html data-gloss>` publisher, and `maestro-cli gloss`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	GLOSS_LEVELS,
+	GLOSS_LEVEL_META,
+	DEFAULT_GLOSS_LEVEL,
+	asGlossLevel,
+	glossLevelIndex,
+	glossLevelAtIndex,
+	isGlossOff,
+	type GlossLevel,
+} from '../../shared/themeGloss';
+
+describe('themeGloss', () => {
+	it('orders the levels least to most, which is what makes the control a slider', () => {
+		expect([...GLOSS_LEVELS]).toEqual(['off', 'sheen', 'strong', 'max']);
+	});
+
+	it('defaults to off, so an install that never opens Settings is unchanged', () => {
+		expect(DEFAULT_GLOSS_LEVEL).toBe('off');
+	});
+
+	it('names and describes every level, so a new one cannot ship unlabelled', () => {
+		for (const level of GLOSS_LEVELS) {
+			expect(GLOSS_LEVEL_META[level].label.length).toBeGreaterThan(0);
+			expect(GLOSS_LEVEL_META[level].description.length).toBeGreaterThan(0);
+		}
+	});
+
+	describe('asGlossLevel', () => {
+		it('passes every valid level through untouched', () => {
+			for (const level of GLOSS_LEVELS) {
+				expect(asGlossLevel(level)).toBe(level);
+			}
+		});
+
+		it.each([
+			['an unknown string', 'shiny'],
+			['a boolean', true],
+			['a number', 2],
+			['null', null],
+			['undefined', undefined],
+			['an object', {}],
+			['the wrong case', 'Strong'],
+		])('falls back to the default for %s', (_label, input) => {
+			expect(asGlossLevel(input)).toBe(DEFAULT_GLOSS_LEVEL);
+		});
+	});
+
+	describe('isGlossOff', () => {
+		it("is true only for 'off'", () => {
+			expect(isGlossOff('off')).toBe(true);
+			expect(isGlossOff('sheen')).toBe(false);
+		});
+
+		it("exists because 'off' is a truthy string", () => {
+			// The trap this guards: `if (level)` is true for every level, including
+			// the one that means "do nothing".
+			const level: GlossLevel = 'off';
+			expect(Boolean(level)).toBe(true);
+			expect(isGlossOff(level)).toBe(true);
+		});
+	});
+
+	describe('index round-trip', () => {
+		it('converts both ways for every level', () => {
+			for (const level of GLOSS_LEVELS) {
+				expect(glossLevelAtIndex(glossLevelIndex(level))).toBe(level);
+			}
+		});
+
+		it('clamps out-of-range positions instead of returning undefined', () => {
+			// A range input cannot produce these, but the CLI and older persisted
+			// values can, and an undefined level would land on <html> as the
+			// string "undefined".
+			expect(glossLevelAtIndex(-5)).toBe('off');
+			expect(glossLevelAtIndex(99)).toBe('max');
+			expect(glossLevelAtIndex(Number.NaN)).toBe(DEFAULT_GLOSS_LEVEL);
+		});
+
+		it('rounds a fractional position to the nearest stop', () => {
+			expect(glossLevelAtIndex(1.4)).toBe('sheen');
+			expect(glossLevelAtIndex(1.6)).toBe('strong');
+		});
+	});
+});

--- a/src/cli/commands/gloss.ts
+++ b/src/cli/commands/gloss.ts
@@ -1,0 +1,86 @@
+// Surface gloss command - read or set how much light the app chrome catches.
+//
+// The point-and-click equivalent is Settings -> Themes -> Surface Gloss, and
+// both ends go through the same `themeGloss` setting and the same vocabulary in
+// `src/shared/themeGloss.ts`, so a slider drag and a CLI call cannot disagree
+// about the levels or their order.
+//
+// Reads come off the on-disk settings store, so `maestro-cli gloss` answers
+// even with the app closed. Writes route through the running app's `set_setting`
+// WS bridge so the change applies live and persists, the same way `set-theme`
+// works. `maestro-cli settings set themeGloss <level>` also works and is picked
+// up by the settings watcher, but it skips the validation below, so a typo
+// lands as a value that matches no CSS rule and silently renders as off.
+
+import {
+	GLOSS_LEVELS,
+	GLOSS_LEVEL_META,
+	asGlossLevel,
+	type GlossLevel,
+} from '../../shared/themeGloss';
+import { readSettingValue } from '../services/storage';
+import { sendSimpleCommand, reportResult, failCommand } from '../services/session-command';
+
+interface GlossOptions {
+	list?: boolean;
+	json?: boolean;
+}
+
+/** Current level as stored on disk, narrowed. */
+function readCurrentGloss(): GlossLevel {
+	return asGlossLevel(readSettingValue('themeGloss'));
+}
+
+function printLevels(current: GlossLevel): void {
+	console.log('Gloss levels (least to most):');
+	for (const level of GLOSS_LEVELS) {
+		const marker = level === current ? '*' : ' ';
+		const pad = ' '.repeat(Math.max(1, 10 - level.length));
+		console.log(`  ${marker} ${level}${pad}${GLOSS_LEVEL_META[level].description}`);
+	}
+	console.log('\nUsage: maestro-cli gloss <off|sheen|strong|max>');
+	console.log('Note: gloss has no effect on light themes.');
+}
+
+export async function gloss(level: string | undefined, options: GlossOptions): Promise<void> {
+	const current = readCurrentGloss();
+
+	// No level given, or --list: report rather than change anything.
+	if (options.list || !level) {
+		if (options.json) {
+			console.log(
+				JSON.stringify({
+					success: true,
+					level: current,
+					levels: GLOSS_LEVELS.map((value) => ({ value, ...GLOSS_LEVEL_META[value] })),
+				})
+			);
+		} else {
+			printLevels(current);
+		}
+		return;
+	}
+
+	const requested = level.trim().toLowerCase();
+	if (!(GLOSS_LEVELS as readonly string[]).includes(requested)) {
+		failCommand(
+			`Unknown gloss level "${level}". Valid levels: ${GLOSS_LEVELS.join(', ')}.`,
+			options.json
+		);
+	}
+	const next = requested as GlossLevel;
+
+	try {
+		const result = await sendSimpleCommand(
+			{ type: 'set_setting', key: 'themeGloss', value: next },
+			'set_setting_result'
+		);
+		reportResult(result, {
+			json: options.json,
+			successMessage: `Surface gloss set to ${GLOSS_LEVEL_META[next].label} (${next})`,
+			jsonExtra: { level: next, previousLevel: current },
+		});
+	} catch (error) {
+		failCommand(error instanceof Error ? error.message : String(error), options.json);
+	}
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -96,6 +96,7 @@ import {
 } from './commands/tab';
 import { setBookmark } from './commands/bookmark';
 import { setTheme } from './commands/set-theme';
+import { gloss } from './commands/gloss';
 import { themeShow, themeExport, themeImport, themeSet } from './commands/theme';
 import { encoreList, encoreSet } from './commands/encore';
 import { setVerbosity } from './output/verbosity';
@@ -1052,6 +1053,18 @@ program
 	.option('-l, --list', 'List available themes')
 	.option('--json', 'Output as JSON (for scripting)')
 	.action((nameOrId, options) => setTheme(nameOrId, options));
+
+// Gloss command - how much light the app chrome catches (the themeGloss
+// setting). Mirrors Settings -> Themes -> Surface Gloss. Prints the current
+// level when called with no argument.
+program
+	.command('gloss [level]')
+	.description(
+		'Set the surface gloss level: off, sheen, strong or max (applies live). Omit the level to see the current one.'
+	)
+	.option('-l, --list', 'List the gloss levels and what each one does')
+	.option('--json', 'Output as JSON (for scripting)')
+	.action((level, options) => gloss(level, options));
 
 // Theme commands - manage the user-configurable "Custom" theme palette
 // (the customThemeColors / customThemeBaseId settings). Mirrors the in-app

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -3262,6 +3262,7 @@ export class WebSocketMessageHandler {
 		'activeThemeId',
 		'customThemeColors',
 		'customThemeBaseId',
+		'themeGloss',
 		'fontSize',
 		'enterToSendAI',
 		'defaultSaveToHistory',

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1207,6 +1207,15 @@ function MaestroConsoleInner() {
 		themeColors: theme.colors,
 	});
 
+	// GLOSS DEMO HARNESS (branch gloss-demo only). Publishes the active theme's
+	// mode onto <html> so the chrome-sheen rules can exclude light themes, and
+	// seeds data-gloss so the option can be flipped live from the console.
+	useEffect(() => {
+		const root = document.documentElement;
+		root.dataset.themeMode = theme.mode;
+		if (!root.dataset.gloss) root.dataset.gloss = 'off';
+	}, [theme.mode]);
+
 	// Get capabilities for the active session's agent type
 	const { hasCapability: hasActiveSessionCapability } = useAgentCapabilities(
 		activeSession?.toolType
@@ -2877,7 +2886,7 @@ function MaestroConsoleInner() {
 				{/* --- DRAGGABLE TITLE BAR (hidden in mobile landscape or when using native title bar) --- */}
 				{!isMobileLandscape && !useNativeTitleBar && (
 					<div
-						className="fixed top-0 left-0 right-0 h-10 flex items-center justify-center"
+						className="chrome-sheen fixed top-0 left-0 right-0 h-10 flex items-center justify-center"
 						style={
 							{
 								WebkitAppRegion: 'drag',

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -451,6 +451,7 @@ function MaestroConsoleInner() {
 		keyboardMasteryStats,
 		recordShortcutUsage,
 		colorBlindMode,
+		themeGloss,
 		defaultStatsTimeRange,
 		documentGraphShowExternalLinks,
 		documentGraphMaxNodes,
@@ -1205,17 +1206,9 @@ function MaestroConsoleInner() {
 	// Theme styles hook - manages CSS variables and scrollbar fade animations
 	useThemeStyles({
 		themeColors: theme.colors,
+		themeMode: theme.mode,
+		glossLevel: themeGloss,
 	});
-
-	// GLOSS DEMO HARNESS (branch gloss-demo only). Publishes the active theme's
-	// mode onto <html> so the chrome-sheen rules can exclude light themes, and
-	// seeds data-gloss so the option can be flipped live from the console.
-	useEffect(() => {
-		const root = document.documentElement;
-		root.dataset.themeMode = theme.mode;
-		if (!root.dataset.gloss) root.dataset.gloss = 'off';
-		if (!root.dataset.rowdesign) root.dataset.rowdesign = 'a';
-	}, [theme.mode]);
 
 	// Get capabilities for the active session's agent type
 	const { hasCapability: hasActiveSessionCapability } = useAgentCapabilities(

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1214,6 +1214,7 @@ function MaestroConsoleInner() {
 		const root = document.documentElement;
 		root.dataset.themeMode = theme.mode;
 		if (!root.dataset.gloss) root.dataset.gloss = 'off';
+		if (!root.dataset.rowdesign) root.dataset.rowdesign = 'a';
 	}, [theme.mode]);
 
 	// Get capabilities for the active session's agent type

--- a/src/renderer/components/FileExplorerPanel/FileExplorerPanel.tsx
+++ b/src/renderer/components/FileExplorerPanel/FileExplorerPanel.tsx
@@ -532,7 +532,7 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 								setTimeout(() => fileTreeFilterInputRef?.current?.focus(), 0);
 							}
 						}}
-						className="flex-1 flex items-center justify-center gap-1 py-0.5 px-2 rounded text-xs font-medium transition-colors hover:bg-white/10"
+						className="fx-btn fx-primary flex-1 flex items-center justify-center gap-1 py-0.5 px-2 rounded text-xs font-medium transition-colors hover:bg-white/10"
 						style={{
 							color: fileTreeFilterOpen ? theme.colors.accent : theme.colors.accent,
 							border: `1px solid ${theme.colors.accent}40`,
@@ -551,7 +551,7 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 							onClick={() =>
 								window.maestro?.shell?.openPath(session.fullPath || session.projectRoot)
 							}
-							className="flex-1 flex items-center justify-center gap-1 py-0.5 px-2 rounded text-xs font-medium transition-colors hover:bg-white/10"
+							className="fx-btn flex-1 flex items-center justify-center gap-1 py-0.5 px-2 rounded text-xs font-medium transition-colors hover:bg-white/10"
 							style={{
 								color: theme.colors.accent,
 								border: `1px solid ${theme.colors.accent}40`,
@@ -567,7 +567,7 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 					{!dotfilesToggleHidden && (
 						<button
 							onClick={() => setShowHiddenFiles(!showHiddenFiles)}
-							className="flex-1 flex items-center justify-center gap-1 py-0.5 px-2 rounded text-xs font-medium transition-colors hover:bg-white/10"
+							className="fx-btn flex-1 flex items-center justify-center gap-1 py-0.5 px-2 rounded text-xs font-medium transition-colors hover:bg-white/10"
 							style={{
 								color: theme.colors.accent,
 								border: `1px solid ${theme.colors.accent}40`,
@@ -588,7 +588,7 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 						onClick={handleRefresh}
 						onMouseEnter={handleRefreshMouseEnter}
 						onMouseLeave={handleRefreshMouseLeave}
-						className="flex-1 flex items-center justify-center gap-1 py-0.5 px-2 rounded text-xs font-medium transition-colors hover:bg-white/10"
+						className="fx-btn flex-1 flex items-center justify-center gap-1 py-0.5 px-2 rounded text-xs font-medium transition-colors hover:bg-white/10"
 						style={{
 							color: theme.colors.accent,
 							border: `1px solid ${theme.colors.accent}40`,

--- a/src/renderer/components/InputArea/InputArea.tsx
+++ b/src/renderer/components/InputArea/InputArea.tsx
@@ -520,7 +520,7 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 			<div className="flex gap-3">
 				<div className="flex-1 flex flex-col">
 					<div
-						className="flex-1 relative border rounded-lg bg-opacity-50 flex flex-col"
+						className="chrome-raised flex-1 relative border rounded-lg bg-opacity-50 flex flex-col"
 						style={{
 							borderColor: showQueueingBorder ? theme.colors.warning : theme.colors.border,
 							backgroundColor: showQueueingBorder

--- a/src/renderer/components/MainPanel/MainPanelHeader.tsx
+++ b/src/renderer/components/MainPanel/MainPanelHeader.tsx
@@ -207,7 +207,7 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 	return (
 		<div
 			ref={headerRef}
-			className={`header-container h-16 border-b flex items-center justify-between px-6 shrink-0 relative z-20 ${isCurrentSessionAutoMode ? 'header-auto-mode' : ''}`}
+			className={`chrome-sheen header-container h-16 border-b flex items-center justify-between px-6 shrink-0 relative z-20 ${isCurrentSessionAutoMode ? 'header-auto-mode' : ''}`}
 			style={{
 				borderColor: theme.colors.border,
 				backgroundColor: theme.colors.bgSidebar,

--- a/src/renderer/components/RightPanel.tsx
+++ b/src/renderer/components/RightPanel.tsx
@@ -422,7 +422,7 @@ export const RightPanel = memo(
 			<div
 				ref={panelRef}
 				tabIndex={0}
-				className={`border-l flex flex-col ${rightPanelTransitionClass} outline-none relative ${rightPanelOpen ? '' : 'w-0 overflow-hidden opacity-0'}`}
+				className={`chrome-sheen border-l flex flex-col ${rightPanelTransitionClass} outline-none relative ${rightPanelOpen ? '' : 'w-0 overflow-hidden opacity-0'}`}
 				style={
 					{
 						width: rightPanelOpen ? `${rightPanelWidth}px` : '0',

--- a/src/renderer/components/SessionItem.tsx
+++ b/src/renderer/components/SessionItem.tsx
@@ -358,7 +358,7 @@ export const SessionItem = memo(function SessionItem({
 							</span>
 						)}
 						<span
-							className={`font-medium truncate ${variant === 'worktree' ? 'text-xs' : 'text-sm'}`}
+							className={`row-name font-medium truncate ${variant === 'worktree' ? 'text-xs' : 'text-sm'}`}
 							style={{ color: theme.colors.textMain }}
 						>
 							{session.name}
@@ -413,8 +413,11 @@ export const SessionItem = memo(function SessionItem({
 								{jumpNumber}
 							</div>
 						)}
-						<Activity className="w-3 h-3" /> {session.toolType}
-						{session.sessionSshRemoteConfig?.enabled ? ' (SSH)' : ''}
+						<Activity className="row-provider-icon w-3 h-3" />{' '}
+						<span className="row-provider">
+							{session.toolType}
+							{session.sessionSshRemoteConfig?.enabled ? ' (SSH)' : ''}
+						</span>
 					</div>
 				)}
 			</div>
@@ -427,7 +430,7 @@ export const SessionItem = memo(function SessionItem({
 				    name, truncated with the complete value available on hover. */}
 				{variant === 'bookmark' && group && showGroupLabelInBookmarks && (
 					<span
-						className={`text-[9px] px-1 py-0.5 rounded${
+						className={`row-group-chip text-[9px] px-1 py-0.5 rounded${
 							showFullGroupLabelInBookmarks ? ' max-w-[140px] truncate' : ''
 						}`}
 						style={{ backgroundColor: theme.colors.bgActivity, color: theme.colors.textDim }}

--- a/src/renderer/components/SessionItem.tsx
+++ b/src/renderer/components/SessionItem.tsx
@@ -252,7 +252,7 @@ export const SessionItem = memo(function SessionItem({
 	const getContainerClassName = () => {
 		// Worktree items get a dashed left border to visually distinguish from regular agents
 		const borderClass = variant === 'worktree' ? 'border-l-2 border-dashed' : 'border-l-2';
-		const base = `cursor-move flex items-center justify-between group ${borderClass} transition-all hover:bg-opacity-50 ${isDragging ? 'opacity-50' : ''}`;
+		const base = `session-row cursor-move flex items-center justify-between group ${borderClass} transition-all hover:bg-opacity-50 ${isDragging ? 'opacity-50' : ''}`;
 
 		if (variant === 'flat') {
 			return `mx-3 px-3 py-2 rounded mb-1 ${base}`;
@@ -289,7 +289,7 @@ export const SessionItem = memo(function SessionItem({
 			}}
 		>
 			{/* Left side: Session name and metadata */}
-			<div className="min-w-0 flex-1">
+			<div className="row-main min-w-0 flex-1">
 				{isEditing ? (
 					<input
 						autoFocus
@@ -310,7 +310,7 @@ export const SessionItem = memo(function SessionItem({
 						}}
 					/>
 				) : (
-					<div className="flex items-center gap-1.5" onDoubleClick={onStartRename}>
+					<div className="row-title flex items-center gap-1.5" onDoubleClick={onStartRename}>
 						{/* Worktree expand/collapse chevron for parent agents (rotates 90deg when expanded) */}
 						{isWorktreeParent && onToggleWorktrees && (
 							<button
@@ -400,7 +400,7 @@ export const SessionItem = memo(function SessionItem({
 
 				{/* Session metadata row (hidden for compact worktree variant) */}
 				{variant !== 'worktree' && (
-					<div className="flex items-center gap-2 text-[10px] mt-0.5 opacity-70">
+					<div className="row-meta flex items-center gap-2 text-[10px] mt-0.5 opacity-70">
 						{/* Session Jump Number Badge (Opt+Cmd+NUMBER) */}
 						{jumpNumber && (
 							<div
@@ -423,7 +423,7 @@ export const SessionItem = memo(function SessionItem({
 			</div>
 
 			{/* Right side: Indicators and actions */}
-			<div className="flex items-center gap-2 ml-2">
+			<div className="row-actions flex items-center gap-2 ml-2">
 				{/* Group badge (only in bookmark variant when session belongs to a group).
 				    Hidden entirely when showGroupLabelInBookmarks is off. Abbreviated by
 				    default; the showFullGroupLabelInBookmarks setting swaps in the full group

--- a/src/renderer/components/SessionItem.tsx
+++ b/src/renderer/components/SessionItem.tsx
@@ -252,7 +252,13 @@ export const SessionItem = memo(function SessionItem({
 	const getContainerClassName = () => {
 		// Worktree items get a dashed left border to visually distinguish from regular agents
 		const borderClass = variant === 'worktree' ? 'border-l-2 border-dashed' : 'border-l-2';
-		const base = `session-row cursor-move flex items-center justify-between group ${borderClass} transition-all hover:bg-opacity-50 ${isDragging ? 'opacity-50' : ''}`;
+		// `session-row` switches the row to the two-line grid in index.css: title
+		// on line one at full width, meta and actions on line two. The worktree
+		// variant is deliberately excluded because it renders no meta row at all,
+		// so the grid would put its actions on an otherwise empty second line and
+		// turn a compact child row into a two-line one.
+		const layoutClass = variant === 'worktree' ? '' : 'session-row ';
+		const base = `${layoutClass}cursor-move flex items-center justify-between group ${borderClass} transition-all hover:bg-opacity-50 ${isDragging ? 'opacity-50' : ''}`;
 
 		if (variant === 'flat') {
 			return `mx-3 px-3 py-2 rounded mb-1 ${base}`;

--- a/src/renderer/components/SessionList/SessionList.tsx
+++ b/src/renderer/components/SessionList/SessionList.tsx
@@ -1082,7 +1082,7 @@ function SessionListInner(props: SessionListProps) {
 		<div
 			ref={sidebarContainerRef}
 			tabIndex={0}
-			className={`border-r flex flex-col shrink-0 ${sidebarTransitionClass} outline-none relative z-20`}
+			className={`chrome-sheen border-r flex flex-col shrink-0 ${sidebarTransitionClass} outline-none relative z-20`}
 			style={
 				{
 					width: leftSidebarOpen ? `${leftSidebarWidthState}px` : '64px',

--- a/src/renderer/components/Settings/searchableSettings.ts
+++ b/src/renderer/components/Settings/searchableSettings.ts
@@ -851,6 +851,35 @@ export const SHORTCUTS_SETTINGS: SearchableSetting[] = [
 // ---------------------------------------------------------------------------
 export const THEME_SETTINGS: SearchableSetting[] = [
 	{
+		id: 'theme-surface-gloss',
+		tab: 'theme',
+		tabLabel: 'Themes',
+		label: 'Surface Gloss',
+		description:
+			'Add a light source to the app chrome so panels read as stacked layers instead of one flat sheet',
+		keywords: [
+			'gloss',
+			'glossy',
+			'sheen',
+			'shine',
+			'intensity',
+			'depth',
+			'elevation',
+			'shadow',
+			'highlight',
+			'flat',
+			'ashy',
+			'dull',
+			'pop',
+			'contrast',
+			'chrome',
+			'surface',
+			'off',
+			'strong',
+			'max',
+		],
+	},
+	{
 		id: 'theme-picker',
 		tab: 'theme',
 		tabLabel: 'Themes',

--- a/src/renderer/components/Settings/tabs/ThemeTab.tsx
+++ b/src/renderer/components/Settings/tabs/ThemeTab.tsx
@@ -6,10 +6,21 @@
  */
 
 import React, { useRef, useEffect } from 'react';
-import { Moon, Sun, Sparkles, Check } from 'lucide-react';
+import { Moon, Sun, Sparkles, Check, Lightbulb } from 'lucide-react';
 import { useSettings } from '../../../hooks';
 import { CustomThemeBuilder } from '../../CustomThemeBuilder';
+import { SettingsSectionHeading } from '../SettingsSectionHeading';
+import { Slider } from '../../widgets';
+import {
+	GLOSS_LEVELS,
+	GLOSS_LEVEL_META,
+	glossLevelAtIndex,
+	glossLevelIndex,
+} from '../../../../shared/themeGloss';
 import type { Theme, ThemeId } from '../../../types';
+
+/** Stop names for the gloss slider, in ladder order. Derived so a new level cannot be added without a name. */
+const GLOSS_TICK_LABELS = GLOSS_LEVELS.map((level) => GLOSS_LEVEL_META[level].label);
 
 export interface ThemeTabProps {
 	theme: Theme;
@@ -31,9 +42,12 @@ export function ThemeTab({
 		setCustomThemeColors,
 		customThemeBaseId,
 		setCustomThemeBaseId,
+		themeGloss,
+		setThemeGloss,
 	} = useSettings();
 
 	const themePickerRef = useRef<HTMLDivElement>(null);
+	const isLightTheme = theme.mode === 'light';
 
 	// Auto-focus theme picker on mount
 	useEffect(() => {
@@ -90,78 +104,104 @@ export function ThemeTab({
 	};
 
 	return (
-		<div
-			data-setting-id="theme-picker"
-			ref={themePickerRef}
-			className="space-y-6 outline-none"
-			tabIndex={0}
-			onKeyDown={handleThemePickerKeyDown}
-			role="group"
-			aria-label="Theme picker"
-		>
-			{['dark', 'light', 'vibe'].map((mode) => (
-				<div key={mode}>
-					<div
-						className="text-xs font-bold uppercase mb-3 flex items-center gap-2"
-						style={{ color: theme.colors.textDim }}
-					>
-						{mode === 'dark' ? (
-							<Moon className="w-3 h-3" />
-						) : mode === 'light' ? (
-							<Sun className="w-3 h-3" />
-						) : (
-							<Sparkles className="w-3 h-3" />
-						)}
-						{mode} Mode
-					</div>
-					<div className="grid grid-cols-2 gap-3">
-						{groupedThemes[mode]?.map((t: Theme) => (
-							<button
-								key={t.id}
-								data-theme-id={t.id}
-								onClick={() => setActiveThemeId(t.id)}
-								className={`p-3 rounded-lg border text-left transition-all ${activeThemeId === t.id ? 'ring-2' : ''}`}
-								style={
-									{
-										borderColor: theme.colors.border,
-										backgroundColor: t.colors.bgSidebar,
-										'--tw-ring-color': t.colors.accent,
-									} as React.CSSProperties
-								}
-								tabIndex={-1}
-							>
-								<div className="flex justify-between items-center mb-2">
-									<span className="text-sm font-bold" style={{ color: t.colors.textMain }}>
-										{t.name}
-									</span>
-									{activeThemeId === t.id && (
-										<Check className="w-4 h-4" style={{ color: t.colors.accent }} />
-									)}
-								</div>
-								<div className="flex h-3 rounded overflow-hidden">
-									<div className="flex-1" style={{ backgroundColor: t.colors.bgMain }} />
-									<div className="flex-1" style={{ backgroundColor: t.colors.bgActivity }} />
-									<div className="flex-1" style={{ backgroundColor: t.colors.accent }} />
-								</div>
-							</button>
-						))}
-					</div>
-				</div>
-			))}
-
-			{/* Custom Theme Builder */}
-			<div data-theme-id="custom">
-				<CustomThemeBuilder
+		<div className="space-y-5">
+			{/* Surface Gloss. Sits above the picker because it applies to whichever
+			    theme is chosen below, rather than being a property of one of them. */}
+			<div data-setting-id="theme-surface-gloss">
+				<SettingsSectionHeading icon={Lightbulb}>Surface Gloss</SettingsSectionHeading>
+				<p className="text-xs opacity-70 mb-2">
+					Adds a light source to the sidebars, headers, tab bar and composer so panels read as
+					stacked layers instead of one flat sheet. It only adds highlights and shadows, so no theme
+					color changes and text stays exactly as legible as it is now.
+				</p>
+				<Slider
 					theme={theme}
-					customThemeColors={customThemeColors}
-					setCustomThemeColors={setCustomThemeColors}
-					customThemeBaseId={customThemeBaseId}
-					setCustomThemeBaseId={setCustomThemeBaseId}
-					isSelected={activeThemeId === 'custom'}
-					onSelect={() => setActiveThemeId('custom')}
-					onImportError={onThemeImportError}
-					onImportSuccess={onThemeImportSuccess}
+					label="Intensity"
+					value={glossLevelIndex(themeGloss)}
+					onChange={(index) => setThemeGloss(glossLevelAtIndex(index))}
+					tickLabels={GLOSS_TICK_LABELS}
+					disabled={isLightTheme}
 				/>
+				<p className="text-[11px] opacity-55 mt-2">
+					{isLightTheme
+						? 'Gloss is off on light themes: a white highlight on a light surface is invisible at best and muddy at worst.'
+						: GLOSS_LEVEL_META[themeGloss].description}
+				</p>
+			</div>
+
+			<div
+				data-setting-id="theme-picker"
+				ref={themePickerRef}
+				className="space-y-6 outline-none"
+				tabIndex={0}
+				onKeyDown={handleThemePickerKeyDown}
+				role="group"
+				aria-label="Theme picker"
+			>
+				{['dark', 'light', 'vibe'].map((mode) => (
+					<div key={mode}>
+						<div
+							className="text-xs font-bold uppercase mb-3 flex items-center gap-2"
+							style={{ color: theme.colors.textDim }}
+						>
+							{mode === 'dark' ? (
+								<Moon className="w-3 h-3" />
+							) : mode === 'light' ? (
+								<Sun className="w-3 h-3" />
+							) : (
+								<Sparkles className="w-3 h-3" />
+							)}
+							{mode} Mode
+						</div>
+						<div className="grid grid-cols-2 gap-3">
+							{groupedThemes[mode]?.map((t: Theme) => (
+								<button
+									key={t.id}
+									data-theme-id={t.id}
+									onClick={() => setActiveThemeId(t.id)}
+									className={`p-3 rounded-lg border text-left transition-all ${activeThemeId === t.id ? 'ring-2' : ''}`}
+									style={
+										{
+											borderColor: theme.colors.border,
+											backgroundColor: t.colors.bgSidebar,
+											'--tw-ring-color': t.colors.accent,
+										} as React.CSSProperties
+									}
+									tabIndex={-1}
+								>
+									<div className="flex justify-between items-center mb-2">
+										<span className="text-sm font-bold" style={{ color: t.colors.textMain }}>
+											{t.name}
+										</span>
+										{activeThemeId === t.id && (
+											<Check className="w-4 h-4" style={{ color: t.colors.accent }} />
+										)}
+									</div>
+									<div className="flex h-3 rounded overflow-hidden">
+										<div className="flex-1" style={{ backgroundColor: t.colors.bgMain }} />
+										<div className="flex-1" style={{ backgroundColor: t.colors.bgActivity }} />
+										<div className="flex-1" style={{ backgroundColor: t.colors.accent }} />
+									</div>
+								</button>
+							))}
+						</div>
+					</div>
+				))}
+
+				{/* Custom Theme Builder */}
+				<div data-theme-id="custom">
+					<CustomThemeBuilder
+						theme={theme}
+						customThemeColors={customThemeColors}
+						setCustomThemeColors={setCustomThemeColors}
+						customThemeBaseId={customThemeBaseId}
+						setCustomThemeBaseId={setCustomThemeBaseId}
+						isSelected={activeThemeId === 'custom'}
+						onSelect={() => setActiveThemeId('custom')}
+						onImportError={onThemeImportError}
+						onImportSuccess={onThemeImportSuccess}
+					/>
+				</div>
 			</div>
 		</div>
 	);

--- a/src/renderer/components/Settings/tabs/ThemeTab.tsx
+++ b/src/renderer/components/Settings/tabs/ThemeTab.tsx
@@ -14,6 +14,7 @@ import { Slider } from '../../widgets';
 import {
 	GLOSS_LEVELS,
 	GLOSS_LEVEL_META,
+	asGlossLevel,
 	glossLevelAtIndex,
 	glossLevelIndex,
 } from '../../../../shared/themeGloss';
@@ -48,6 +49,13 @@ export function ThemeTab({
 
 	const themePickerRef = useRef<HTMLDivElement>(null);
 	const isLightTheme = theme.mode === 'light';
+
+	// Narrowed rather than trusted. `GLOSS_LEVEL_META[level]` is a lookup, so an
+	// undefined or unrecognized value throws and takes the ENTIRE Settings modal
+	// down with it, not just this section. The store hydrates asynchronously and
+	// a settings blob written by an older build has no `themeGloss` at all, so
+	// undefined is a state that really occurs rather than a theoretical one.
+	const glossLevel = asGlossLevel(themeGloss);
 
 	// Auto-focus theme picker on mount
 	useEffect(() => {
@@ -117,7 +125,7 @@ export function ThemeTab({
 				<Slider
 					theme={theme}
 					label="Intensity"
-					value={glossLevelIndex(themeGloss)}
+					value={glossLevelIndex(glossLevel)}
 					onChange={(index) => setThemeGloss(glossLevelAtIndex(index))}
 					tickLabels={GLOSS_TICK_LABELS}
 					disabled={isLightTheme}
@@ -125,7 +133,7 @@ export function ThemeTab({
 				<p className="text-[11px] opacity-55 mt-2">
 					{isLightTheme
 						? 'Gloss is off on light themes: a white highlight on a light surface is invisible at best and muddy at worst.'
-						: GLOSS_LEVEL_META[themeGloss].description}
+						: GLOSS_LEVEL_META[glossLevel].description}
 				</p>
 			</div>
 

--- a/src/renderer/components/TabBar/AITab.tsx
+++ b/src/renderer/components/TabBar/AITab.tsx
@@ -456,6 +456,7 @@ export const AITab = memo(function AITab({
 			className={`
         relative flex items-center gap-1.5 px-3 py-1.5 cursor-pointer
         transition-all duration-150 select-none shrink-0 outline-none
+        ${isActive ? 'chrome-raised-active' : ''}
         ${isDragging ? 'opacity-50' : ''}
         ${isDragOver ? 'ring-2 ring-inset' : ''}
       `}

--- a/src/renderer/components/TabBar/TabBar.tsx
+++ b/src/renderer/components/TabBar/TabBar.tsx
@@ -447,7 +447,7 @@ function TabBarInner({
 	return (
 		<div
 			ref={tabBarRef}
-			className="flex items-end gap-0.5 pt-2 border-b overflow-x-auto overflow-y-hidden no-scrollbar"
+			className="chrome-sheen flex items-end gap-0.5 pt-2 border-b overflow-x-auto overflow-y-hidden no-scrollbar"
 			data-tour="tab-bar"
 			style={{ backgroundColor: theme.colors.bgSidebar, borderColor: theme.colors.border }}
 		>

--- a/src/renderer/components/widgets/input/Slider.tsx
+++ b/src/renderer/components/widgets/input/Slider.tsx
@@ -1,27 +1,45 @@
 /**
  * Slider
  *
- * Starter input primitive for the shared widget library: a themed, controlled
- * wrapper around a native `<input type="range">`. Minimal but real - it is the
- * proof that the `InputWidgetProps<T>` contract works end to end and the seed
- * for the upcoming dynamic-interface input family.
+ * Themed, controlled wrapper around a native `<input type="range">`, and the
+ * proof that the `InputWidgetProps<T>` contract works end to end.
  *
- * Theme-aware (accent-colored track via the `accent-*` utility plus an inline
- * accent color), accessible (label wired to the input, live value read out), and
- * fully controlled (the parent owns the value and re-renders on change).
+ * Two shapes, one component:
+ *
+ * - **Continuous.** Pass `min` / `max` / `step` and optionally `formatValue`.
+ *   The read-out shows the formatted number.
+ * - **Discrete, with named stops.** Pass `tickLabels`. The track then runs from
+ *   0 to `tickLabels.length - 1` in whole steps, the read-out shows the current
+ *   stop's name, and the names are drawn beneath the track so the user can see
+ *   what they are sliding between before they slide. Reach for this whenever
+ *   the underlying value is an ordered vocabulary rather than a quantity; the
+ *   ladder is the reason it is a slider and not a row of buttons, and the
+ *   labels are what stop it reading as a meaningless 0-3.
+ *
+ * Theme-aware (accent-colored track), accessible (label wired to the input, the
+ * value announced via `aria-valuetext`), and fully controlled.
  */
 
 import { memo, useId } from 'react';
 import type { InputWidgetProps, SliderValue } from './types';
 
 interface SliderProps extends InputWidgetProps<SliderValue> {
-	/** Minimum value (default 0). */
+	/** Minimum value. Defaults to 0. */
 	min?: number;
-	/** Maximum value (default 100). */
+	/**
+	 * Maximum value. Defaults to `tickLabels.length - 1` when `tickLabels` is
+	 * given, otherwise 100, so a labelled slider cannot end up with more stops
+	 * than names.
+	 */
 	max?: number;
 	/** Step increment (default 1). */
 	step?: number;
-	/** Optional formatter for the value read-out (defaults to the raw number). */
+	/**
+	 * Names for each stop, in ladder order. Turns the slider discrete: it also
+	 * supplies the default `max` and the default read-out.
+	 */
+	tickLabels?: string[];
+	/** Formatter for the value read-out. Defaults to the stop's name when `tickLabels` is set, otherwise the raw number. */
 	formatValue?: (value: SliderValue) => string;
 }
 
@@ -32,12 +50,20 @@ export const Slider = memo(function Slider({
 	disabled = false,
 	label,
 	min = 0,
-	max = 100,
+	max,
 	step = 1,
+	tickLabels,
 	formatValue,
 }: SliderProps) {
 	const inputId = useId();
-	const display = formatValue ? formatValue(value) : String(value);
+	const hasTicks = Array.isArray(tickLabels) && tickLabels.length > 1;
+	const resolvedMax = max ?? (hasTicks ? tickLabels.length - 1 : 100);
+
+	const display = formatValue
+		? formatValue(value)
+		: hasTicks
+			? (tickLabels[value] ?? String(value))
+			: String(value);
 
 	return (
 		<div className="flex flex-col gap-1.5" style={{ opacity: disabled ? 0.5 : 1 }}>
@@ -63,7 +89,7 @@ export const Slider = memo(function Slider({
 				id={inputId}
 				type="range"
 				min={min}
-				max={max}
+				max={resolvedMax}
 				step={step}
 				value={value}
 				disabled={disabled}
@@ -73,6 +99,22 @@ export const Slider = memo(function Slider({
 				aria-label={label}
 				aria-valuetext={display}
 			/>
+			{hasTicks && (
+				/* Presentational only. The stops are already reachable through the
+				   input itself, so these carry aria-hidden rather than becoming a
+				   second, silent set of controls in the tab order. */
+				<div className="flex justify-between text-[10px]" aria-hidden="true">
+					{tickLabels.map((tick, index) => (
+						<span
+							key={tick}
+							className={index === value ? 'font-semibold' : 'opacity-55'}
+							style={index === value ? { color: theme.colors.accent } : undefined}
+						>
+							{tick}
+						</span>
+					))}
+				</div>
+			)}
 		</div>
 	);
 });

--- a/src/renderer/hooks/settings/useSettings.ts
+++ b/src/renderer/hooks/settings/useSettings.ts
@@ -31,6 +31,7 @@ import type {
 } from '../../types';
 import type { FileExplorerIconTheme } from '../../utils/fileExplorerIcons/shared';
 import type { ToastWidth } from '../../../shared/toastWidth';
+import type { GlossLevel } from '../../../shared/themeGloss';
 import {
 	useSettingsStore,
 	loadAllSettings,
@@ -260,6 +261,10 @@ export interface UseSettingsReturn {
 	// Accessibility settings
 	colorBlindMode: boolean;
 	setColorBlindMode: (value: boolean) => void;
+
+	// Surface gloss (app-chrome lighting; changes no theme color)
+	themeGloss: GlossLevel;
+	setThemeGloss: (value: GlossLevel) => void;
 
 	// Tab filtering settings
 	showStarredInUnreadFilter: boolean;

--- a/src/renderer/hooks/ui/useThemeStyles.ts
+++ b/src/renderer/hooks/ui/useThemeStyles.ts
@@ -83,6 +83,8 @@ export function useThemeStyles(deps: UseThemeStylesDeps): UseThemeStylesReturn {
 		root.setProperty('--scrollbar-thumb-hover', themeColors.textDim);
 		root.setProperty('--scrollbar-thumb-active', themeColors.accent);
 		root.setProperty('--scrollbar-track', themeColors.bgActivity);
+		// Quiet/secondary control colour, consumed by the Files toolbar hierarchy.
+		root.setProperty('--fx-quiet', themeColors.textDim);
 	}, [themeColors.accent, themeColors.border, themeColors.textDim, themeColors.bgActivity]);
 
 	// Add scroll listeners to highlight scrollbars during active scrolling

--- a/src/renderer/hooks/ui/useThemeStyles.ts
+++ b/src/renderer/hooks/ui/useThemeStyles.ts
@@ -1,4 +1,6 @@
 import { useEffect } from 'react';
+import type { ThemeMode } from '../../../shared/theme-types';
+import type { GlossLevel } from '../../../shared/themeGloss';
 
 /**
  * Theme colors required for CSS variable management.
@@ -30,6 +32,10 @@ export interface ThemeColors {
 export interface UseThemeStylesDeps {
 	/** Theme colors to apply as CSS variables */
 	themeColors: ThemeColors;
+	/** Active theme's mode, published as `<html data-theme-mode>` so CSS can opt out on light themes. */
+	themeMode: ThemeMode;
+	/** Surface gloss level, published as `<html data-gloss>`. */
+	glossLevel: GlossLevel;
 }
 
 /**
@@ -61,6 +67,18 @@ export interface UseThemeStylesReturn {
  * variables. To add a new themed CSS rule app-wide, set the property here and
  * reference it in index.css with a sensible fallback.
  *
+ * It is also the single place that publishes theme-driven ATTRIBUTES on the
+ * same element:
+ *
+ *   data-theme-mode = 'light' | 'dark' | 'vibe'
+ *   data-gloss      = the `themeGloss` setting
+ *
+ * Both are written together on purpose. The gloss rules in index.css opt out
+ * entirely on light themes, so a build that sets one attribute from here and
+ * the other from a stray effect elsewhere can render a light theme with a dark
+ * theme's highlights for a frame, and nothing in a diff shows it. If you need a
+ * new theme-driven attribute, add it here rather than starting a second writer.
+ *
  * This hook also handles the scrollbar fade-on-idle animation by toggling
  * `.scrolling` / `.fading` classes on elements with `.scrollbar-thin`. Those
  * classes drive the bright-on-scroll → fade-to-transparent transition in CSS.
@@ -69,7 +87,7 @@ export interface UseThemeStylesReturn {
  * @returns Empty object (all functionality via side effects)
  */
 export function useThemeStyles(deps: UseThemeStylesDeps): UseThemeStylesReturn {
-	const { themeColors } = deps;
+	const { themeColors, themeMode, glossLevel } = deps;
 
 	// Set CSS variables for theme colors. App-wide scrollbar styling in
 	// index.css references these via var(--scrollbar-*) so every scrollable
@@ -86,6 +104,16 @@ export function useThemeStyles(deps: UseThemeStylesDeps): UseThemeStylesReturn {
 		// Quiet/secondary control colour, consumed by the Files toolbar hierarchy.
 		root.setProperty('--fx-quiet', themeColors.textDim);
 	}, [themeColors.accent, themeColors.border, themeColors.textDim, themeColors.bgActivity]);
+
+	// Publish the theme mode and the gloss level as attributes. Kept in one
+	// effect so the pair is always written in the same commit: the gloss rules
+	// key off both, and updating them out of step paints a light theme with dark
+	// highlights until the second effect catches up.
+	useEffect(() => {
+		const root = document.documentElement;
+		root.dataset.themeMode = themeMode;
+		root.dataset.gloss = glossLevel;
+	}, [themeMode, glossLevel]);
 
 	// Add scroll listeners to highlight scrollbars during active scrolling
 	// Uses passive listener and batched RAF updates to avoid blocking scroll

--- a/src/renderer/hooks/ui/useThemeStyles.ts
+++ b/src/renderer/hooks/ui/useThemeStyles.ts
@@ -1,6 +1,26 @@
 import { useEffect } from 'react';
+import { hexToRgb } from '../../../shared/colorContrast';
 import type { ThemeMode } from '../../../shared/theme-types';
 import type { GlossLevel } from '../../../shared/themeGloss';
+
+/**
+ * The light source the gloss rules mix, as an `R G B` triple for `rgb(... / a%)`.
+ *
+ * Derived from the theme's own `textMain` so a theme declares what colour its
+ * light is, rather than the sheen picking up whatever `color` happens to be
+ * inherited at each chrome root. That was the earlier approach and it makes the
+ * gloss non-deterministic: a container that sets a dim text colour glosses
+ * differently from one that does not, so the same level renders at two
+ * strengths in the same window for reasons no one chose.
+ *
+ * Falls back to white when the palette carries a non-hex colour (a custom theme
+ * may use any CSS colour). White is the right failure: gloss is dark-theme only,
+ * and a white light source is what every dark theme's `textMain` approximates.
+ */
+function sheenRgbTriple(textMain: string): string {
+	const rgb = hexToRgb(textMain);
+	return rgb ? `${rgb.r} ${rgb.g} ${rgb.b}` : '255 255 255';
+}
 
 /**
  * Theme colors required for CSS variable management.
@@ -24,6 +44,8 @@ export interface ThemeColors {
 	 *  Track is mostly transparent so this only matters for tall narrow
 	 *  containers where the track is visible. */
 	bgActivity: string;
+	/** Main text color - the light source the surface-gloss rules mix. */
+	textMain: string;
 }
 
 /**
@@ -62,6 +84,8 @@ export interface UseThemeStylesReturn {
  *   --scrollbar-thumb-hover  = themeColors.textDim
  *   --scrollbar-thumb-active = themeColors.accent
  *   --scrollbar-track        = themeColors.bgActivity
+ *   --fx-quiet               = themeColors.textDim
+ *   --sheen-rgb              = themeColors.textMain as "R G B"
  *
  * Scrollbar styling lives in `src/renderer/index.css` and consumes these
  * variables. To add a new themed CSS rule app-wide, set the property here and
@@ -103,7 +127,17 @@ export function useThemeStyles(deps: UseThemeStylesDeps): UseThemeStylesReturn {
 		root.setProperty('--scrollbar-track', themeColors.bgActivity);
 		// Quiet/secondary control colour, consumed by the Files toolbar hierarchy.
 		root.setProperty('--fx-quiet', themeColors.textDim);
-	}, [themeColors.accent, themeColors.border, themeColors.textDim, themeColors.bgActivity]);
+		// Light source for the surface-gloss rules. A triple rather than a finished
+		// colour, so the alpha stays in index.css where the levels are defined and
+		// only the hue crosses the bridge.
+		root.setProperty('--sheen-rgb', sheenRgbTriple(themeColors.textMain));
+	}, [
+		themeColors.accent,
+		themeColors.border,
+		themeColors.textDim,
+		themeColors.bgActivity,
+		themeColors.textMain,
+	]);
 
 	// Publish the theme mode and the gloss level as attributes. Kept in one
 	// effect so the pair is always written in the same commit: the gloss rules

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -1381,6 +1381,78 @@ html[data-theme-mode='light'] .chrome-raised-active {
      b  - name is allowed to wrap to two lines, provider demoted to a chip
    ============================================================================ */
 
+/* ---------------------------------------------------------------------------
+   Variant C - Ryan Dawson's correction, and it is the better idea.
+
+   B fought for width by letting the title wrap. C gives the title the ENTIRE
+   row instead: everything else moves down to a second line, so a long name has
+   the full sidebar to itself and never needs a second line at all.
+
+   The mechanism is `display: contents` on the row's left wrapper, which
+   dissolves that wrapper as a box and promotes the title and meta rows to
+   direct grid children of the row. Without it the title cannot span past the
+   wrapper, and the actions cluster cannot be pulled onto the meta line, since
+   the two live in different parents.
+   --------------------------------------------------------------------------- */
+
+html[data-rowdesign='c'] .session-row {
+	display: grid;
+	grid-template-columns: 1fr auto;
+	align-items: center;
+	column-gap: 0.5rem;
+}
+
+html[data-rowdesign='c'] .row-main {
+	display: contents;
+}
+
+html[data-rowdesign='c'] .row-title {
+	grid-column: 1 / -1;
+	grid-row: 1;
+	min-width: 0;
+}
+
+/* Single line, full row width. The ellipsis is now a genuine last resort
+   rather than the normal case it was at fourteen characters. */
+html[data-rowdesign='c'] .row-name {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	min-width: 0;
+	flex: 1 1 auto;
+}
+
+html[data-rowdesign='c'] .row-meta {
+	grid-column: 1;
+	grid-row: 2;
+	min-width: 0;
+}
+
+html[data-rowdesign='c'] .row-actions {
+	grid-column: 2;
+	grid-row: 2;
+	margin-left: 0;
+	justify-self: end;
+}
+
+html[data-rowdesign='c'] .row-provider {
+	font-size: 9px;
+	opacity: 0.5;
+	white-space: nowrap;
+}
+
+html[data-rowdesign='c'] .row-provider-icon {
+	opacity: 0.45;
+}
+
+html[data-rowdesign='c'] .row-group-chip {
+	max-width: 90px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	opacity: 0.7;
+}
+
 html[data-rowdesign='b'] .row-name {
 	/* The variable gets the room. Two lines is enough for every real agent name
 	   without letting one pathological name push the row to five. */

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -1365,3 +1365,61 @@ html[data-theme-mode='light'] .chrome-raised-active {
 	box-shadow: none;
 	background-image: none;
 }
+
+/* ============================================================================
+   LEFT BAR ROW REDESIGN (temporary; branch gloss-demo only)
+
+   The row spends its width on the constant and clips the variable. The agent
+   name is the only thing that differs between rows and the only thing anyone
+   scans for, yet it truncates around fourteen characters; the provider label
+   underneath reads the same string on nine rows out of ten and gets a full
+   uncontested line at almost the same weight.
+
+   Driven by html[data-rowdesign] so the shipped row and the redesign can be
+   compared in one running app:
+     a  - shipped
+     b  - name is allowed to wrap to two lines, provider demoted to a chip
+   ============================================================================ */
+
+html[data-rowdesign='b'] .row-name {
+	/* The variable gets the room. Two lines is enough for every real agent name
+	   without letting one pathological name push the row to five. */
+	display: -webkit-box;
+	-webkit-line-clamp: 3;
+	-webkit-box-orient: vertical;
+	white-space: normal;
+	overflow: hidden;
+	text-overflow: unset;
+	line-height: 1.25;
+}
+
+html[data-rowdesign='b'] .row-provider {
+	/* The constant stops competing: same information, a fraction of the visual
+	   weight. Deliberately NOT uppercased - caps plus letter-spacing is an
+	   emphasis treatment, and the first pass at this made the label MORE
+	   prominent while trying to demote it. It must also never wrap: the
+	   two-line "CLAUDE-/CODE" it produced took more room than the name it was
+	   supposed to yield to. */
+	font-size: 9px;
+	opacity: 0.5;
+	white-space: nowrap;
+}
+
+html[data-rowdesign='b'] .row-provider-icon {
+	opacity: 0.45;
+}
+
+html[data-rowdesign='b'] .row-group-chip {
+	/* The chip sits on the NAME's line and holds width, which is why a
+	   bookmarked row still truncated after the name was allowed to wrap. The
+	   group is recoverable - the same agent appears under its group heading
+	   further down the list, and the full name is on the chip's tooltip - while
+	   the agent name is recoverable from nothing. So the chip yields first. */
+	max-width: 64px;
+	flex-shrink: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	opacity: 0.7;
+}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -1435,14 +1435,18 @@ html[data-rowdesign='c'] .row-actions {
 	justify-self: end;
 }
 
+/* The provider label deliberately keeps its SHIPPED weight.
+   An earlier draft demoted it to 9px at opacity .5, which was wrong twice
+   over. CSS opacity nests: `.row-meta` already carries `opacity-70`, so the
+   effective alpha was .70 * .50 = .35, not .50. Measured on the shipped
+   palettes that put the label at 1.46:1 on Dracula and 2.34:1 on Olive
+   Nights, against 2.18:1 and 6.13:1 today. At 9px nothing there qualifies as
+   large text, so the 3:1 floor is the kindest reading and every theme misses
+   it. The layout below is what fixes truncation; dimming the label was taste,
+   it was never measured, and it made the row less legible. Do not reintroduce
+   it without running the contrast numbers on more than one theme. */
 html[data-rowdesign='c'] .row-provider {
-	font-size: 9px;
-	opacity: 0.5;
 	white-space: nowrap;
-}
-
-html[data-rowdesign='c'] .row-provider-icon {
-	opacity: 0.45;
 }
 
 html[data-rowdesign='c'] .row-group-chip {

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -1293,23 +1293,28 @@ svg.wand-profiling-active path:nth-child(8) {
 }
 
 /* ============================================================================
-   GLOSS DEMO HARNESS (temporary; branch gloss-demo only)
+   SURFACE GLOSS
 
    Adds a light source to the app chrome so surfaces read as stacked layers
    instead of one flat sheet of paint. Composes with the existing inline
    `backgroundColor` on every chrome root because `box-shadow` and
    `background-image` are different longhands than `background-color`, so no
-   theme token and no component style object has to change.
+   theme token and no component style object has to change. That is the whole
+   reason this is CSS rather than a palette edit: it works identically on all
+   built-in themes and on a user's custom one, and it changes no colour value.
 
-   Intensity is driven by `html[data-gloss]` so the options can be compared
-   live in one running app:
-     off     - shipped behavior
+   Intensity comes from the `themeGloss` setting, published onto <html> as
+   `data-gloss` by `useThemeStyles`. The vocabulary lives in
+   `src/shared/themeGloss.ts`; every level named there needs rules here, or the
+   Settings slider offers a stop that renders the same as the one before it.
+
+     off     - shipped behaviour, no rules at all
      sheen   - inset top highlight + short top-down wash
      strong  - same, roughly 1.6x, plus a drop edge under each bar
-     max     - strong + accent glow on the active/selected surface (the ceiling)
+     max     - strong + accent glow on the active surface
 
-   Light themes are excluded: a white highlight on a white surface is invisible
-   at best and muddy at worst.
+   Light themes are excluded outright: a white highlight on a white surface is
+   invisible at best and muddy at worst.
    ============================================================================ */
 
 html[data-gloss='sheen'] .chrome-sheen {
@@ -1349,8 +1354,6 @@ html[data-gloss='max'] .chrome-raised {
 		0 3px 14px rgba(0, 0, 0, 0.42);
 }
 
-/* The ceiling. Included so the review has an upper bound to reject, not
-   because it is the recommendation. */
 html[data-gloss='max'] .chrome-raised-active {
 	box-shadow:
 		inset 0 1px 0 color-mix(in srgb, currentColor 14%, transparent),
@@ -1358,7 +1361,8 @@ html[data-gloss='max'] .chrome-raised-active {
 		0 0 18px color-mix(in srgb, var(--accent-color) 22%, transparent);
 }
 
-/* Never on light themes. */
+/* Never on light themes. Placed last so it wins over every level above without
+   needing a level-by-level opt-out. */
 html[data-theme-mode='light'] .chrome-sheen,
 html[data-theme-mode='light'] .chrome-raised,
 html[data-theme-mode='light'] .chrome-raised-active {
@@ -1367,46 +1371,49 @@ html[data-theme-mode='light'] .chrome-raised-active {
 }
 
 /* ============================================================================
-   LEFT BAR ROW REDESIGN (temporary; branch gloss-demo only)
+   LEFT BAR ROW LAYOUT
 
-   The row spends its width on the constant and clips the variable. The agent
-   name is the only thing that differs between rows and the only thing anyone
-   scans for, yet it truncates around fourteen characters; the provider label
-   underneath reads the same string on nine rows out of ten and gets a full
-   uncontested line at almost the same weight.
+   The row used to spend its width on the constant and clip the variable. The
+   agent name is the only thing that differs between rows and the only thing
+   anyone scans for, yet it truncated around fourteen characters, while the
+   provider label underneath reads the same string on nine rows out of ten and
+   got a full uncontested line at almost the same weight.
 
-   Driven by html[data-rowdesign] so the shipped row and the redesign can be
-   compared in one running app:
-     a  - shipped
-     b  - name is allowed to wrap to two lines, provider demoted to a chip
-   ============================================================================ */
-
-/* ---------------------------------------------------------------------------
-   Variant C - Ryan Dawson's correction, and it is the better idea.
-
-   B fought for width by letting the title wrap. C gives the title the ENTIRE
-   row instead: everything else moves down to a second line, so a long name has
-   the full sidebar to itself and never needs a second line at all.
+   The fix gives the title the ENTIRE first line and moves everything else to a
+   second line, so a long name has the full sidebar to itself. It is always two
+   lines, which is what the shipped row already was, and it costs 0.5px of row
+   height.
 
    The mechanism is `display: contents` on the row's left wrapper, which
    dissolves that wrapper as a box and promotes the title and meta rows to
    direct grid children of the row. Without it the title cannot span past the
    wrapper, and the actions cluster cannot be pulled onto the meta line, since
    the two live in different parents.
-   --------------------------------------------------------------------------- */
 
-html[data-rowdesign='c'] .session-row {
+   NOTHING HERE CHANGES LEGIBILITY. An earlier draft also demoted the provider
+   label to 9px at opacity .5 and faded the group chip to .7, and both were
+   wrong for the same measured reason: CSS opacity nests, `.row-meta` already
+   carries `opacity-70`, so the effective alpha was .35 rather than .5. On the
+   shipped palettes that put the label at 1.46:1 on Dracula and 2.34:1 on Olive
+   Nights, against 2.18:1 and 6.13:1 today, and at 9px none of it qualifies as
+   large text, so even the relaxed 3:1 floor is missed on every theme. Moving
+   text costs nothing and buys the actual fix; dimming text costs real
+   legibility and buys an impression. Do not reintroduce a dim here without
+   running the contrast numbers on more than one theme.
+   ============================================================================ */
+
+.session-row {
 	display: grid;
 	grid-template-columns: 1fr auto;
 	align-items: center;
 	column-gap: 0.5rem;
 }
 
-html[data-rowdesign='c'] .row-main {
+.session-row .row-main {
 	display: contents;
 }
 
-html[data-rowdesign='c'] .row-title {
+.session-row .row-title {
 	grid-column: 1 / -1;
 	grid-row: 1;
 	min-width: 0;
@@ -1414,7 +1421,7 @@ html[data-rowdesign='c'] .row-title {
 
 /* Single line, full row width. The ellipsis is now a genuine last resort
    rather than the normal case it was at fourteen characters. */
-html[data-rowdesign='c'] .row-name {
+.session-row .row-name {
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -1422,122 +1429,62 @@ html[data-rowdesign='c'] .row-name {
 	flex: 1 1 auto;
 }
 
-html[data-rowdesign='c'] .row-meta {
+.session-row .row-meta {
 	grid-column: 1;
 	grid-row: 2;
 	min-width: 0;
 }
 
-html[data-rowdesign='c'] .row-actions {
+.session-row .row-actions {
 	grid-column: 2;
 	grid-row: 2;
 	margin-left: 0;
 	justify-self: end;
 }
 
-/* The provider label deliberately keeps its SHIPPED weight.
-   An earlier draft demoted it to 9px at opacity .5, which was wrong twice
-   over. CSS opacity nests: `.row-meta` already carries `opacity-70`, so the
-   effective alpha was .70 * .50 = .35, not .50. Measured on the shipped
-   palettes that put the label at 1.46:1 on Dracula and 2.34:1 on Olive
-   Nights, against 2.18:1 and 6.13:1 today. At 9px nothing there qualifies as
-   large text, so the 3:1 floor is the kindest reading and every theme misses
-   it. The layout below is what fixes truncation; dimming the label was taste,
-   it was never measured, and it made the row less legible. Do not reintroduce
-   it without running the contrast numbers on more than one theme. */
-html[data-rowdesign='c'] .row-provider {
-	white-space: nowrap;
-}
-
-/* Width only. The chip sits beside the title and would otherwise hold its
-   natural width, so it is capped and given an ellipsis; that is layout.
-   An `opacity: .7` used to live here as well and it has been removed for the
-   same reason the provider dimming was: measured on the shipped palettes it
-   took the chip from 11.19:1 to 5.98:1 on Olive Nights and from 2.51:1 to
-   1.92:1 on Dracula, and at 9px it is never large text. This variant now
-   changes WHERE things sit and nothing about how legible they are. */
-html[data-rowdesign='c'] .row-group-chip {
+/* Width only, no dimming. The chip sits beside the title and would otherwise
+   hold its natural width, so it is capped and given an ellipsis. */
+.session-row .row-group-chip {
 	max-width: 90px;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
 
-html[data-rowdesign='b'] .row-name {
-	/* The variable gets the room. Two lines is enough for every real agent name
-	   without letting one pathological name push the row to five. */
-	display: -webkit-box;
-	-webkit-line-clamp: 3;
-	-webkit-box-orient: vertical;
-	white-space: normal;
-	overflow: hidden;
-	text-overflow: unset;
-	line-height: 1.25;
-}
-
-html[data-rowdesign='b'] .row-provider {
-	/* The constant stops competing: same information, a fraction of the visual
-	   weight. Deliberately NOT uppercased - caps plus letter-spacing is an
-	   emphasis treatment, and the first pass at this made the label MORE
-	   prominent while trying to demote it. It must also never wrap: the
-	   two-line "CLAUDE-/CODE" it produced took more room than the name it was
-	   supposed to yield to. */
-	font-size: 9px;
-	opacity: 0.5;
-	white-space: nowrap;
-}
-
-html[data-rowdesign='b'] .row-provider-icon {
-	opacity: 0.45;
-}
-
-html[data-rowdesign='b'] .row-group-chip {
-	/* The chip sits on the NAME's line and holds width, which is why a
-	   bookmarked row still truncated after the name was allowed to wrap. The
-	   group is recoverable - the same agent appears under its group heading
-	   further down the list, and the full name is on the chip's tooltip - while
-	   the agent name is recoverable from nothing. So the chip yields first. */
-	max-width: 64px;
-	flex-shrink: 1;
-	min-width: 0;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	opacity: 0.7;
-}
-
-/* ---------------------------------------------------------------------------
-   Files toolbar hierarchy (rowdesign 'c', same flag as the sidebar row).
+/* ============================================================================
+   FILES TOOLBAR HIERARCHY (dormant; no UI and nothing seeds this attribute)
 
    The same defect the Left Bar had, in another panel: Find, Open, .files and
-   Refresh are rendered from an identical class string, so four buttons plus
-   two icon controls all carry the accent colour, the accent border and the
-   accent fill at equal weight. Six controls shout in unison and the eye has
-   nowhere to land.
+   Refresh are rendered from an identical class string, so four buttons plus two
+   icon controls all carry the accent colour, the accent border and the accent
+   fill at equal weight. Six controls shout in unison and the eye has nowhere to
+   land. Find is the one with a keyboard shortcut and the one used constantly,
+   so it becomes the primary and the rest drop to the panel's own text colour.
 
-   Find is the primary: it is the one with a keyboard shortcut and the one used
-   constantly. It keeps the accent. The other three are utilities and drop to
-   the panel's own text colour with a hairline edge, so they read as available
-   rather than as urgent. Inline styles set the colour, so these need
-   !important to win - the alternative is threading a variant prop through the
-   component, which is not worth it for a comparison build.
-   --------------------------------------------------------------------------- */
+   NOT SHIPPED, and deliberately behind its own attribute rather than the gloss
+   setting, because it is a different decision. Flip it live to review:
 
-html[data-rowdesign='c'] .fx-btn:not(.fx-primary) {
+       document.documentElement.dataset.fxToolbar = 'on'
+
+   Two things must change before this can ship: the `!important` below exists
+   only because `FileExplorerPanel` sets these colours inline, so the inline
+   styles need to become a real variant prop; and the hover rules hard-code
+   white alphas, which are wrong on a light theme.
+   ============================================================================ */
+
+html[data-fx-toolbar='on'] .fx-btn:not(.fx-primary) {
 	color: var(--fx-quiet, #98a0bd) !important;
 	border-color: rgba(255, 255, 255, 0.09) !important;
 	background-color: transparent !important;
 	font-weight: 400 !important;
 }
 
-html[data-rowdesign='c'] .fx-btn:not(.fx-primary):hover {
+html[data-fx-toolbar='on'] .fx-btn:not(.fx-primary):hover {
 	border-color: rgba(255, 255, 255, 0.18) !important;
 	background-color: rgba(255, 255, 255, 0.05) !important;
 }
 
-/* The primary earns a solid fill rather than the same 15% wash as everything
-   else, so "the thing you came here to do" is unambiguous. */
-html[data-rowdesign='c'] .fx-btn.fx-primary {
+html[data-fx-toolbar='on'] .fx-btn.fx-primary {
 	background-color: var(--accent-color) !important;
 	border-color: var(--accent-color) !important;
 	color: #16171f !important;

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -1495,3 +1495,41 @@ html[data-rowdesign='b'] .row-group-chip {
 	white-space: nowrap;
 	opacity: 0.7;
 }
+
+/* ---------------------------------------------------------------------------
+   Files toolbar hierarchy (rowdesign 'c', same flag as the sidebar row).
+
+   The same defect the Left Bar had, in another panel: Find, Open, .files and
+   Refresh are rendered from an identical class string, so four buttons plus
+   two icon controls all carry the accent colour, the accent border and the
+   accent fill at equal weight. Six controls shout in unison and the eye has
+   nowhere to land.
+
+   Find is the primary: it is the one with a keyboard shortcut and the one used
+   constantly. It keeps the accent. The other three are utilities and drop to
+   the panel's own text colour with a hairline edge, so they read as available
+   rather than as urgent. Inline styles set the colour, so these need
+   !important to win - the alternative is threading a variant prop through the
+   component, which is not worth it for a comparison build.
+   --------------------------------------------------------------------------- */
+
+html[data-rowdesign='c'] .fx-btn:not(.fx-primary) {
+	color: var(--fx-quiet, #98a0bd) !important;
+	border-color: rgba(255, 255, 255, 0.09) !important;
+	background-color: transparent !important;
+	font-weight: 400 !important;
+}
+
+html[data-rowdesign='c'] .fx-btn:not(.fx-primary):hover {
+	border-color: rgba(255, 255, 255, 0.18) !important;
+	background-color: rgba(255, 255, 255, 0.05) !important;
+}
+
+/* The primary earns a solid fill rather than the same 15% wash as everything
+   else, so "the thing you came here to do" is unambiguous. */
+html[data-rowdesign='c'] .fx-btn.fx-primary {
+	background-color: var(--accent-color) !important;
+	border-color: var(--accent-color) !important;
+	color: #16171f !important;
+	font-weight: 600 !important;
+}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -1291,3 +1291,77 @@ svg.wand-profiling-active path:nth-child(8) {
 .code-fence .shiki-host pre.shiki .line {
 	color: unset;
 }
+
+/* ============================================================================
+   GLOSS DEMO HARNESS (temporary; branch gloss-demo only)
+
+   Adds a light source to the app chrome so surfaces read as stacked layers
+   instead of one flat sheet of paint. Composes with the existing inline
+   `backgroundColor` on every chrome root because `box-shadow` and
+   `background-image` are different longhands than `background-color`, so no
+   theme token and no component style object has to change.
+
+   Intensity is driven by `html[data-gloss]` so the options can be compared
+   live in one running app:
+     off     - shipped behavior
+     sheen   - inset top highlight + short top-down wash
+     strong  - same, roughly 1.6x, plus a drop edge under each bar
+     max     - strong + accent glow on the active/selected surface (the ceiling)
+
+   Light themes are excluded: a white highlight on a white surface is invisible
+   at best and muddy at worst.
+   ============================================================================ */
+
+html[data-gloss='sheen'] .chrome-sheen {
+	box-shadow: inset 0 1px 0 color-mix(in srgb, currentColor 7%, transparent);
+	background-image: linear-gradient(
+		180deg,
+		color-mix(in srgb, currentColor 5%, transparent),
+		transparent 110px
+	);
+}
+
+html[data-gloss='strong'] .chrome-sheen,
+html[data-gloss='max'] .chrome-sheen {
+	box-shadow:
+		inset 0 1px 0 color-mix(in srgb, currentColor 11%, transparent),
+		0 1px 0 rgba(0, 0, 0, 0.45);
+	background-image: linear-gradient(
+		180deg,
+		color-mix(in srgb, currentColor 8%, transparent),
+		color-mix(in srgb, currentColor 2%, transparent) 34px,
+		transparent 130px
+	);
+}
+
+/* Cards and pills sit ON the chrome, so they get the highlight without the
+   wash - a gradient inside a small rounded box reads as a bad texture. */
+html[data-gloss='sheen'] .chrome-raised {
+	box-shadow:
+		inset 0 1px 0 color-mix(in srgb, currentColor 6%, transparent),
+		0 2px 10px rgba(0, 0, 0, 0.3);
+}
+
+html[data-gloss='strong'] .chrome-raised,
+html[data-gloss='max'] .chrome-raised {
+	box-shadow:
+		inset 0 1px 0 color-mix(in srgb, currentColor 9%, transparent),
+		0 3px 14px rgba(0, 0, 0, 0.42);
+}
+
+/* The ceiling. Included so the review has an upper bound to reject, not
+   because it is the recommendation. */
+html[data-gloss='max'] .chrome-raised-active {
+	box-shadow:
+		inset 0 1px 0 color-mix(in srgb, currentColor 14%, transparent),
+		0 0 0 1px color-mix(in srgb, var(--accent-color) 34%, transparent),
+		0 0 18px color-mix(in srgb, var(--accent-color) 22%, transparent);
+}
+
+/* Never on light themes. */
+html[data-theme-mode='light'] .chrome-sheen,
+html[data-theme-mode='light'] .chrome-raised,
+html[data-theme-mode='light'] .chrome-raised-active {
+	box-shadow: none;
+	background-image: none;
+}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -1449,12 +1449,18 @@ html[data-rowdesign='c'] .row-provider {
 	white-space: nowrap;
 }
 
+/* Width only. The chip sits beside the title and would otherwise hold its
+   natural width, so it is capped and given an ellipsis; that is layout.
+   An `opacity: .7` used to live here as well and it has been removed for the
+   same reason the provider dimming was: measured on the shipped palettes it
+   took the chip from 11.19:1 to 5.98:1 on Olive Nights and from 2.51:1 to
+   1.92:1 on Dracula, and at 9px it is never large text. This variant now
+   changes WHERE things sit and nothing about how legible they are. */
 html[data-rowdesign='c'] .row-group-chip {
 	max-width: 90px;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	opacity: 0.7;
 }
 
 html[data-rowdesign='b'] .row-name {

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -1296,12 +1296,8 @@ svg.wand-profiling-active path:nth-child(8) {
    SURFACE GLOSS
 
    Adds a light source to the app chrome so surfaces read as stacked layers
-   instead of one flat sheet of paint. Composes with the existing inline
-   `backgroundColor` on every chrome root because `box-shadow` and
-   `background-image` are different longhands than `background-color`, so no
-   theme token and no component style object has to change. That is the whole
-   reason this is CSS rather than a palette edit: it works identically on all
-   built-in themes and on a user's custom one, and it changes no colour value.
+   instead of one flat sheet of paint. It changes no theme colour: it only adds
+   highlights and shadows over the paint that is already there.
 
    Intensity comes from the `themeGloss` setting, published onto <html> as
    `data-gloss` by `useThemeStyles`. The vocabulary lives in
@@ -1309,54 +1305,75 @@ svg.wand-profiling-active path:nth-child(8) {
    Settings slider offers a stop that renders the same as the one before it.
 
      off     - shipped behaviour, no rules at all
-     sheen   - inset top highlight + short top-down wash
-     strong  - same, roughly 1.6x, plus a drop edge under each bar
+     sheen   - top highlight + short top-down wash
+     strong  - same, roughly 1.6x, plus a dark edge along the bottom of each bar
      max     - strong + accent glow on the active surface
 
    Light themes are excluded outright: a white highlight on a white surface is
    invisible at best and muddy at worst.
+
+   TWO CHOICES HERE ARE LOAD-BEARING, and both were made after the obvious
+   version turned out to be wrong.
+
+   1. THE BAR SHEEN IS BACKGROUND-IMAGE, NOT BOX-SHADOW. An inline style beats a
+      stylesheet class, and `SessionList` and `RightPanel` both set an inline
+      `boxShadow` for their focus ring. A `box-shadow` sheen therefore vanished
+      from whichever sidebar the user had focused and came back when they moved
+      away, which reads as the gloss flickering rather than as a focus ring.
+      `background-image` has no such collision: every chrome root paints itself
+      with `background-color`, which is a different longhand, so the layers
+      compose and neither side has to know about the other. The 1px highlight is
+      just a gradient with a hard stop. `.chrome-raised` keeps a real
+      `box-shadow` because it needs to cast OUTSIDE its box and nothing sets an
+      inline shadow there.
+
+   2. THE LIGHT SOURCE IS `--sheen-rgb`, NOT `currentColor`. currentColor is
+      whatever text colour happens to be inherited at each root, so a container
+      that sets a dim colour glosses weaker than one that does not, and the same
+      level renders at two strengths in one window for reasons nobody chose. The
+      variable is published from the theme's own `textMain`, so intensity is a
+      property of the level and the hue is a property of the theme. The fallback
+      is white because gloss is dark-theme only.
    ============================================================================ */
 
 html[data-gloss='sheen'] .chrome-sheen {
-	box-shadow: inset 0 1px 0 color-mix(in srgb, currentColor 7%, transparent);
-	background-image: linear-gradient(
-		180deg,
-		color-mix(in srgb, currentColor 5%, transparent),
-		transparent 110px
-	);
+	background-image:
+		linear-gradient(180deg, rgb(var(--sheen-rgb, 255 255 255) / 7%) 0 1px, transparent 1px),
+		linear-gradient(180deg, rgb(var(--sheen-rgb, 255 255 255) / 5%), transparent 110px);
 }
 
 html[data-gloss='strong'] .chrome-sheen,
 html[data-gloss='max'] .chrome-sheen {
-	box-shadow:
-		inset 0 1px 0 color-mix(in srgb, currentColor 11%, transparent),
-		0 1px 0 rgba(0, 0, 0, 0.45);
-	background-image: linear-gradient(
-		180deg,
-		color-mix(in srgb, currentColor 8%, transparent),
-		color-mix(in srgb, currentColor 2%, transparent) 34px,
-		transparent 130px
-	);
+	background-image:
+		linear-gradient(180deg, rgb(var(--sheen-rgb, 255 255 255) / 11%) 0 1px, transparent 1px),
+		linear-gradient(0deg, rgb(0 0 0 / 45%) 0 1px, transparent 1px),
+		linear-gradient(
+			180deg,
+			rgb(var(--sheen-rgb, 255 255 255) / 8%),
+			rgb(var(--sheen-rgb, 255 255 255) / 2%) 34px,
+			transparent 130px
+		);
 }
 
 /* Cards and pills sit ON the chrome, so they get the highlight without the
-   wash - a gradient inside a small rounded box reads as a bad texture. */
+   wash - a gradient inside a small rounded box reads as a bad texture - and a
+   real drop shadow, which is the whole point of calling them raised. */
 html[data-gloss='sheen'] .chrome-raised {
 	box-shadow:
-		inset 0 1px 0 color-mix(in srgb, currentColor 6%, transparent),
-		0 2px 10px rgba(0, 0, 0, 0.3);
+		inset 0 1px 0 rgb(var(--sheen-rgb, 255 255 255) / 6%),
+		0 2px 10px rgb(0 0 0 / 30%);
 }
 
 html[data-gloss='strong'] .chrome-raised,
 html[data-gloss='max'] .chrome-raised {
 	box-shadow:
-		inset 0 1px 0 color-mix(in srgb, currentColor 9%, transparent),
-		0 3px 14px rgba(0, 0, 0, 0.42);
+		inset 0 1px 0 rgb(var(--sheen-rgb, 255 255 255) / 9%),
+		0 3px 14px rgb(0 0 0 / 42%);
 }
 
 html[data-gloss='max'] .chrome-raised-active {
 	box-shadow:
-		inset 0 1px 0 color-mix(in srgb, currentColor 14%, transparent),
+		inset 0 1px 0 rgb(var(--sheen-rgb, 255 255 255) / 14%),
 		0 0 0 1px color-mix(in srgb, var(--accent-color) 34%, transparent),
 		0 0 18px color-mix(in srgb, var(--accent-color) 22%, transparent);
 }

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -46,6 +46,8 @@ import type { FileExplorerIconTheme } from '../utils/fileExplorerIcons/shared';
 import { isFileExplorerIconTheme } from '../utils/fileExplorerIcons/shared';
 import type { ToastWidth } from '../../shared/toastWidth';
 import { isToastWidth } from '../../shared/toastWidth';
+import type { GlossLevel } from '../../shared/themeGloss';
+import { DEFAULT_GLOSS_LEVEL, asGlossLevel } from '../../shared/themeGloss';
 import { normalizePlaybackRate } from '../../shared/mediaTypes';
 import {
 	MEDIA_FLOAT_SETTINGS_KEY,
@@ -393,6 +395,7 @@ export interface SettingsStoreState {
 	contextManagementSettings: ContextManagementSettings;
 	keyboardMasteryStats: KeyboardMasteryStats;
 	colorBlindMode: boolean;
+	themeGloss: GlossLevel;
 	showStarredInUnreadFilter: boolean;
 	showFilePreviewsInUnreadFilter: boolean;
 	showTerminalTabsInUnreadFilter: boolean;
@@ -545,6 +548,7 @@ export interface SettingsStoreActions {
 	setWebInterfaceUseCustomPort: (value: boolean) => void;
 	setWebInterfaceCustomPort: (value: number) => void;
 	setColorBlindMode: (value: boolean) => void;
+	setThemeGloss: (value: GlossLevel) => void;
 	setShowStarredInUnreadFilter: (value: boolean) => void;
 	setShowFilePreviewsInUnreadFilter: (value: boolean) => void;
 	setShowTerminalTabsInUnreadFilter: (value: boolean) => void;
@@ -778,6 +782,7 @@ export const useSettingsStore = create<SettingsStore>()((set, get) => {
 		contextManagementSettings: DEFAULT_CONTEXT_MANAGEMENT_SETTINGS,
 		keyboardMasteryStats: DEFAULT_KEYBOARD_MASTERY_STATS,
 		colorBlindMode: false,
+		themeGloss: DEFAULT_GLOSS_LEVEL,
 		showStarredInUnreadFilter: false,
 		showFilePreviewsInUnreadFilter: false,
 		showTerminalTabsInUnreadFilter: false,
@@ -1276,6 +1281,16 @@ export const useSettingsStore = create<SettingsStore>()((set, get) => {
 		setColorBlindMode: (value) => {
 			set({ colorBlindMode: value });
 			window.maestro.settings.set('colorBlindMode', value);
+		},
+
+		setThemeGloss: (value) => {
+			// Narrow even here. The Settings slider can only produce a valid
+			// level, but this setter is also the landing point for the value the
+			// CLI wrote, and an unrecognized string on <html data-gloss> matches
+			// no rule, so the user sees the control silently do nothing.
+			const level = asGlossLevel(value);
+			set({ themeGloss: level });
+			window.maestro.settings.set('themeGloss', level);
 		},
 
 		setShowStarredInUnreadFilter: (value) => {
@@ -2755,6 +2770,12 @@ export async function loadAllSettings(): Promise<void> {
 				(typeof raw === 'string' && raw !== 'none' && raw !== 'false' && raw !== '');
 		}
 
+		// Narrowed rather than cast: this value can arrive from an older build, a
+		// hand-edited settings file, or `maestro-cli settings set`, and an
+		// unrecognized level would render as permanently-off with no error.
+		if (allSettings['themeGloss'] !== undefined)
+			patch.themeGloss = asGlossLevel(allSettings['themeGloss']);
+
 		if (allSettings['showStarredInUnreadFilter'] !== undefined)
 			patch.showStarredInUnreadFilter = allSettings['showStarredInUnreadFilter'] as boolean;
 
@@ -3288,6 +3309,7 @@ export function getSettingsActions() {
 		acknowledgeKeyboardMasteryLevel: state.acknowledgeKeyboardMasteryLevel,
 		getUnacknowledgedKeyboardMasteryLevel: state.getUnacknowledgedKeyboardMasteryLevel,
 		setColorBlindMode: state.setColorBlindMode,
+		setThemeGloss: state.setThemeGloss,
 		setDocumentGraphShowExternalLinks: state.setDocumentGraphShowExternalLinks,
 		setDocumentGraphMaxNodes: state.setDocumentGraphMaxNodes,
 		setDocumentGraphPreviewCharLimit: state.setDocumentGraphPreviewCharLimit,

--- a/src/shared/settingsMetadata.ts
+++ b/src/shared/settingsMetadata.ts
@@ -79,6 +79,13 @@ export const SETTINGS_METADATA: Record<string, SettingMetadata> = {
 		default: 'dracula',
 		category: 'appearance',
 	},
+	themeGloss: {
+		description:
+			"How much light the app chrome catches: 'off' (flat, the shipped look), 'sheen', 'strong', or 'max'. Adds highlights and shadows only; it changes no theme color, and it has no effect on light themes.",
+		type: 'string',
+		default: 'off',
+		category: 'appearance',
+	},
 	customThemeColors: {
 		description: 'Custom color overrides when using a user-defined theme.',
 		type: 'object',

--- a/src/shared/themeGloss.ts
+++ b/src/shared/themeGloss.ts
@@ -1,0 +1,94 @@
+/**
+ * Surface Gloss
+ *
+ * One vocabulary for how much light the app chrome catches, shared by the
+ * renderer (which publishes the level onto `<html data-gloss>`), the Settings
+ * slider, and `maestro-cli gloss`. A click and a CLI call cannot disagree about
+ * what the levels are or what order they sit in, because there is only one
+ * list.
+ *
+ * The levels are a LADDER, ordered least to most. That ordering is what makes
+ * the Settings control a slider rather than four unrelated buttons, so index
+ * and value convert both ways and the control stays a plain numeric range
+ * input.
+ *
+ * Two traps, both of which have bitten this codebase before in other guises:
+ *
+ * 1. `'off'` is a truthy string. Never test a gloss value for truthiness.
+ *    Compare against the literals or call `isGlossOff()`.
+ * 2. Anything arriving from disk, the CLI, or the web bridge goes through
+ *    `asGlossLevel()` rather than a cast. An unrecognized value written
+ *    straight onto `<html>` matches no rule, so the user sees the setting
+ *    silently do nothing rather than get a rejected command.
+ *
+ * The CSS that consumes this lives in `src/renderer/index.css` under the
+ * "SURFACE GLOSS" banner; every level named here must have rules there, or the
+ * slider offers a stop that renders identically to the one before it.
+ */
+
+/** Every gloss level, ordered least to most intense. The order is the ladder. */
+export const GLOSS_LEVELS = ['off', 'sheen', 'strong', 'max'] as const;
+
+export type GlossLevel = (typeof GLOSS_LEVELS)[number];
+
+/** Shipped default. Gloss is opt-in: an install that never opens Settings looks exactly as it always has. */
+export const DEFAULT_GLOSS_LEVEL: GlossLevel = 'off';
+
+export interface GlossLevelMeta {
+	/** Short control label. Sentence case, no trailing period. */
+	label: string;
+	/** One sentence describing what the user will actually see. */
+	description: string;
+}
+
+/**
+ * Labels and descriptions for each level. Shared so the Settings slider and
+ * `maestro-cli gloss --list` describe the same thing in the same words.
+ */
+export const GLOSS_LEVEL_META: Record<GlossLevel, GlossLevelMeta> = {
+	off: {
+		label: 'Off',
+		description: 'Flat surfaces, exactly as Maestro has always rendered.',
+	},
+	sheen: {
+		label: 'Sheen',
+		description: 'A hairline highlight along the top of each bar and a short wash below it.',
+	},
+	strong: {
+		label: 'Strong',
+		description: 'A brighter highlight, a deeper wash, and a drop edge under every bar.',
+	},
+	max: {
+		label: 'Max',
+		description: 'Everything in Strong, plus an accent ring and glow around the active tab.',
+	},
+};
+
+/** True when the level is the shipped, unlit rendering. Use this instead of `!level`, which is always false. */
+export function isGlossOff(level: GlossLevel): boolean {
+	return level === 'off';
+}
+
+/**
+ * Narrow an untrusted value to a gloss level, falling back to the default.
+ *
+ * Use at every boundary: the settings hydration, the CLI, and the web bridge.
+ */
+export function asGlossLevel(value: unknown): GlossLevel {
+	return typeof value === 'string' && (GLOSS_LEVELS as readonly string[]).includes(value)
+		? (value as GlossLevel)
+		: DEFAULT_GLOSS_LEVEL;
+}
+
+/** Position of a level on the ladder, for a slider's numeric value. */
+export function glossLevelIndex(level: GlossLevel): number {
+	const index = GLOSS_LEVELS.indexOf(level);
+	return index === -1 ? GLOSS_LEVELS.indexOf(DEFAULT_GLOSS_LEVEL) : index;
+}
+
+/** The level at a ladder position, clamped. A range input cannot produce an out-of-range value, but a CLI or a test can. */
+export function glossLevelAtIndex(index: number): GlossLevel {
+	if (!Number.isFinite(index)) return DEFAULT_GLOSS_LEVEL;
+	const clamped = Math.min(GLOSS_LEVELS.length - 1, Math.max(0, Math.round(index)));
+	return GLOSS_LEVELS[clamped];
+}


### PR DESCRIPTION
Two changes that came out of the design review with Ron and Ryan Dawson, plus the fixes found while getting them into a shippable state.

## Surface Gloss

A light source on the app chrome so panels read as stacked layers instead of one flat sheet. **It changes no theme colour** - no palette edit, nothing Dracula- or Pedurple-specific. `box-shadow` and `background-image` are different longhands than `background-color`, so it composes over the existing inline paint on every chrome root and no theme token has to change.

Four levels, default **off**, so an install that never opens Settings looks exactly as it always has.

| Level | What it does |
|---|---|
| `off` | Shipped behaviour, no rules at all |
| `sheen` | Hairline top highlight and a short wash below it |
| `strong` | Brighter highlight, deeper wash, dark edge under each bar |
| `max` | Strong, plus an accent ring and glow on the active tab |

**Where it lives:** Settings -> Themes -> Surface Gloss, as a four-stop slider with each stop named and a live description of the level under the track. Disabled with an explanation on light themes, where the rules opt out anyway - an enabled control that changes nothing reads as a bug.

**CLI parity:** `maestro-cli gloss [level]`, routed through `set_setting` like `set-theme` so it applies live. `maestro-cli gloss` with no argument prints the current level and what each one does.

The vocabulary is a single shared module (`src/shared/themeGloss.ts`), so the slider, the renderer and the CLI cannot disagree about the levels or their order. Every boundary narrows through `asGlossLevel()` rather than casting: an unrecognized value on `<html data-gloss>` matches no rule and would render as off with no error anywhere.

## Left Bar row layout

The row used to spend its width on the constant and clip the variable. The agent name is the only thing that differs between rows and the only thing anyone scans for, yet it truncated around fourteen characters, while the provider label underneath reads the same string on nine rows out of ten and got a full uncontested line at almost the same weight.

The title now gets the entire first line and everything else drops to a second line. Always two lines, which is what the shipped row already was, at a cost of 0.5px of row height. Zero rows clip, measured in the DOM after render.

**It changes no text property.** An earlier draft also dimmed the provider label and the group chip, and that was reverted: CSS opacity nests, `.row-meta` already carries `opacity-70`, so the effective alpha was .35 rather than .5. On the shipped palettes that put the label at 1.46:1 on Dracula and 2.34:1 on Olive Nights, and at 9px none of it qualifies as large text. Moving text costs nothing and buys the fix; dimming it costs real legibility and buys an impression.

## Fixes found on the way

- **The sheen died under the focus ring.** `SessionList` and `RightPanel` each set an inline `boxShadow` for their focus ring, and an inline style outranks a stylesheet class, so the highlight vanished from whichever sidebar had focus and came back when focus left. Both sheen layers are now `background-image`, which nothing sets inline.
- **The light source was non-deterministic.** It derived from `currentColor`, so a container that sets a dim text colour glossed weaker than one that does not and the same level rendered at two strengths in one window. `useThemeStyles` now publishes `--sheen-rgb` from the theme's own `textMain`, with a white fallback.
- **An undefined level crashed the whole Settings modal.** `GLOSS_LEVEL_META[undefined]` throws, and the store hydrates asynchronously while any older settings blob has no `themeGloss` at all. `ThemeTab` narrows before reading.
- **Worktree child rows are excluded from the grid.** They render no meta row, so the two-line layout would have put their actions on an empty second line and turned a compact child row into a two-line one.

## Not in this PR

- **The Files toolbar hierarchy** (Find becomes primary, the other three drop to a quiet colour) is present but dormant behind its own `data-fx-toolbar` attribute, with the two blockers written down: the `!important` needs to become a real variant prop on `FileExplorerPanel`, and its hover rules hard-code white alphas that are wrong on a light theme.
- **The tonal floor** (four hex values). Its stated mechanism, a three percent brightness band, was disproven during the review: Olive Nights has the second narrowest band in the whole set and is the theme everyone likes. It also aimed at Dracula and Pedurple, which measured as the 2nd and 3rd most chromatic dark themes.
- **The three themes actually measured as ashy** - Gruvbox Dark, Monokai, Winamp, neutral gray lifted 14-16 L* off black - are untouched by any of this. Worth its own change.

## Verification

`tsc` clean on all four configs, ESLint clean, and the full suite green at **35,576 passed** via the pre-push hook. Nine new tests cover the shared vocabulary, the CLI verb, `--sheen-rgb`, and the undefined/unrecognized level regressions.

Claude ID: d629e36b-cea1-4297-82b9-a2a10406b79a
Maestro ID: b9bc0d08-5be2-4fdf-93cd-5618a8d53b35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Surface Gloss controls with Off, Sheen, Strong, and Max levels.
  - Gloss adjusts visual highlights and shadows across app chrome, including panels, headers, tabs, and composer.
  - Added live CLI controls to view, list, or change the gloss level, including JSON output.
  - Added labelled slider stops and searchable settings support.
  - Improved session sidebar row layout and toolbar styling.

- **Documentation**
  - Documented the Surface Gloss setting and CLI command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->