### PR TITLE
fix(terminal): spawn the PTY when the tab is created, not when it renders

### DIFF
--- a/src/__tests__/renderer/services/terminalSpawn.test.ts
+++ b/src/__tests__/renderer/services/terminalSpawn.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for terminalSpawn - the shared PTY spawn.
+ *
+ * The bug this module exists to fix: a terminal tab only ever got a shell if
+ * `TerminalView` rendered it, so `open-terminal --background` produced a tab
+ * with no PTY, `send-terminal` answered "has no running shell yet", and the only
+ * cure was clicking the tab. The spawn had to move off the view lifecycle.
+ *
+ * The guard is the sharp edge. It must key on the composed process id, because
+ * tab ids are only unique within an agent - keying on the bare tab id makes two
+ * different agents' terminals dedupe each other and the second silently never
+ * starts.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const spawnTerminalTab = vi.fn();
+const write = vi.fn().mockResolvedValue(undefined);
+
+vi.stubGlobal('window', {
+	maestro: { process: { spawnTerminalTab, write } },
+});
+
+import { spawnPtyForTab, isSpawnInFlight } from '../../../renderer/services/terminalSpawn';
+import { useSettingsStore } from '../../../renderer/stores/settingsStore';
+import type { Session, TerminalTab } from '../../../renderer/types';
+
+function session(overrides: Partial<Session> = {}): Session {
+	return { id: 'sess-1', cwd: '/repo', projectRoot: '/repo', ...overrides } as Session;
+}
+
+function tab(overrides: Partial<TerminalTab> = {}): TerminalTab {
+	return { id: 'tab-1', state: 'idle', pid: 0, ...overrides } as TerminalTab;
+}
+
+let onPid: (tabId: string, pid: number) => void;
+let onSpawnFailure: (tabId: string, isPersistent: boolean, message: string) => void;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	onPid = vi.fn();
+	onSpawnFailure = vi.fn();
+	spawnTerminalTab.mockResolvedValue({ success: true, pid: 4242 });
+	useSettingsStore.setState({ defaultShell: 'zsh', shellArgs: '', shellEnvVars: {} });
+});
+
+describe('spawnPtyForTab', () => {
+	it('spawns without any rendered terminal and reports the pid', async () => {
+		await spawnPtyForTab({ session: session(), tab: tab(), onPid, onSpawnFailure });
+
+		expect(spawnTerminalTab).toHaveBeenCalledTimes(1);
+		expect(spawnTerminalTab.mock.calls[0][0]).toMatchObject({
+			sessionId: 'sess-1-terminal-tab-1',
+			cwd: '/repo',
+			shell: 'zsh',
+		});
+		expect(onPid).toHaveBeenCalledWith('tab-1', 4242);
+		expect(onSpawnFailure).not.toHaveBeenCalled();
+	});
+
+	it('runs a startup command once the shell is up', async () => {
+		await spawnPtyForTab({
+			session: session(),
+			tab: tab({ startupCommand: 'npm run dev' }),
+			onPid,
+			onSpawnFailure,
+		});
+
+		expect(write).toHaveBeenCalledWith('sess-1-terminal-tab-1', 'npm run dev\n');
+	});
+
+	it('collapses concurrent spawns for the same tab into one', async () => {
+		let release: (v: unknown) => void = () => {};
+		spawnTerminalTab.mockReturnValue(new Promise((r) => (release = r)));
+
+		const a = spawnPtyForTab({ session: session(), tab: tab(), onPid, onSpawnFailure });
+		expect(isSpawnInFlight('sess-1', 'tab-1')).toBe(true);
+		const b = spawnPtyForTab({ session: session(), tab: tab(), onPid, onSpawnFailure });
+
+		release({ success: true, pid: 1 });
+		await Promise.all([a, b]);
+
+		// Two callers, one PTY. Without this a background spawn racing a user click
+		// starts two shells and orphans one with no error anywhere.
+		expect(spawnTerminalTab).toHaveBeenCalledTimes(1);
+		expect(isSpawnInFlight('sess-1', 'tab-1')).toBe(false);
+	});
+
+	// The guard keys on `${sessionId}-terminal-${tabId}`, not the bare tab id.
+	// Two agents can each own a tab called 'tab-1'; deduping those against each
+	// other would leave the second agent's terminal permanently dead.
+	it('does not dedupe the same tab id across two different agents', async () => {
+		let release: (v: unknown) => void = () => {};
+		spawnTerminalTab.mockReturnValue(new Promise((r) => (release = r)));
+
+		const a = spawnPtyForTab({
+			session: session({ id: 'sess-1' }),
+			tab: tab(),
+			onPid,
+			onSpawnFailure,
+		});
+		const b = spawnPtyForTab({
+			session: session({ id: 'sess-2' }),
+			tab: tab(),
+			onPid,
+			onSpawnFailure,
+		});
+
+		release({ success: true, pid: 1 });
+		await Promise.all([a, b]);
+
+		expect(spawnTerminalTab).toHaveBeenCalledTimes(2);
+		const ids = spawnTerminalTab.mock.calls.map((c) => c[0].sessionId).sort();
+		expect(ids).toEqual(['sess-1-terminal-tab-1', 'sess-2-terminal-tab-1']);
+	});
+
+	it('reports a failed spawn as non-persistent for a scratch tab', async () => {
+		spawnTerminalTab.mockResolvedValue({ success: false });
+
+		await spawnPtyForTab({ session: session(), tab: tab(), onPid, onSpawnFailure });
+
+		expect(onSpawnFailure).toHaveBeenCalledWith('tab-1', false, expect.stringContaining('shell'));
+		expect(onPid).not.toHaveBeenCalled();
+	});
+
+	it('treats a startup-command tab as persistent so it is kept, not closed', async () => {
+		spawnTerminalTab.mockResolvedValue({ success: false });
+
+		await spawnPtyForTab({
+			session: session(),
+			tab: tab({ startupCommand: 'npm run dev' }),
+			onPid,
+			onSpawnFailure,
+		});
+
+		expect(onSpawnFailure).toHaveBeenCalledWith('tab-1', true, expect.any(String));
+	});
+
+	it('treats an SSH session tab as persistent and names SSH in the message', async () => {
+		spawnTerminalTab.mockResolvedValue({ success: false });
+
+		await spawnPtyForTab({
+			session: session({ sessionSshRemoteConfig: { enabled: true, remoteId: 'r1' } as never }),
+			tab: tab(),
+			onPid,
+			onSpawnFailure,
+		});
+
+		expect(onSpawnFailure).toHaveBeenCalledWith('tab-1', true, expect.stringContaining('SSH'));
+	});
+
+	it('releases the in-flight guard when the spawn throws', async () => {
+		spawnTerminalTab.mockRejectedValue(new Error('boom'));
+
+		await spawnPtyForTab({ session: session(), tab: tab(), onPid, onSpawnFailure });
+
+		expect(onSpawnFailure).toHaveBeenCalledWith('tab-1', false, 'boom');
+		// A stuck guard would make the tab unspawnable for the rest of the session.
+		expect(isSpawnInFlight('sess-1', 'tab-1')).toBe(false);
+	});
+});

--- a/src/renderer/components/MainPanel/MainPanelContent.tsx
+++ b/src/renderer/components/MainPanel/MainPanelContent.tsx
@@ -430,7 +430,6 @@ export const MainPanelContent = React.memo(function MainPanelContent(props: Main
 
 	// Self-sourced from settingsStore
 	const fontFamily = useSettingsStore((s) => s.fontFamily);
-	const defaultShell = useSettingsStore((s) => s.defaultShell);
 	const fontSize = useSettingsStore((s) => s.fontSize);
 	const enterToSendAI = useSettingsStore((s) => s.enterToSendAI);
 	const chatRawTextMode = useSettingsStore((s) => s.chatRawTextMode);
@@ -847,7 +846,6 @@ export const MainPanelContent = React.memo(function MainPanelContent(props: Main
 							theme={theme}
 							fontFamily={fontFamily}
 							fontSize={Math.round(fontSize * 0.85)}
-							defaultShell={defaultShell}
 							onTabStateChange={createTabStateChangeHandler(sessionId)}
 							onTabPidChange={createTabPidChangeHandler(sessionId)}
 							searchOpen={isCurrentSession ? terminalSearchOpen : false}

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -10,7 +10,7 @@ import {
 } from '../utils/terminalTabHelpers';
 import { useSessionStore } from '../stores/sessionStore';
 import { useTabStore } from '../stores/tabStore';
-import { captureException } from '../utils/sentry';
+import { spawnPtyForTab as spawnPty } from '../services/terminalSpawn';
 import { notifyToast } from '../stores/notificationStore';
 import type { Session, TerminalTab } from '../types';
 import type { Theme } from '../../shared/theme-types';
@@ -35,9 +35,6 @@ interface TerminalViewProps {
 	theme: Theme;
 	fontFamily: string;
 	fontSize?: number;
-	defaultShell: string;
-	shellArgs?: string;
-	shellEnvVars?: Record<string, string>;
 	onTabStateChange: (tabId: string, state: TerminalTab['state'], exitCode?: number) => void;
 	onTabPidChange: (tabId: string, pid: number) => void;
 	searchOpen?: boolean;
@@ -62,9 +59,6 @@ export const TerminalView = memo(
 			theme,
 			fontFamily,
 			fontSize,
-			defaultShell,
-			shellArgs,
-			shellEnvVars,
 			onTabStateChange,
 			onTabPidChange,
 			searchOpen,
@@ -83,8 +77,6 @@ export const TerminalView = memo(
 		// ref rather than on the tab so it stays out of the persisted session snapshot;
 		// it is only needed for the keep-or-close decision on the very next render.
 		const exitSignalsRef = useRef<Map<string, number | undefined>>(new Map());
-		// In-flight spawn guard: set of tabIds currently waiting for a PTY PID
-		const spawnInFlightRef = useRef<Set<string>>(new Set());
 		// Track which tabs have already had the loading message written to avoid duplicates
 		const loadingWrittenRef = useRef<Set<string>>(new Set());
 		// Dedup spawn-failure toasts: batch rapid failures into a single notification
@@ -200,132 +192,19 @@ export const TerminalView = memo(
 			[activeTab]
 		);
 
-		// Shared spawn function - closes tab and shows error toast on failure
+		// Spawning lives in services/terminalSpawn so a tab this component never
+		// renders can still get a shell (see that module). The view supplies only the
+		// failure reporting, which is the one part that needs the live xterm buffer.
 		const spawnPtyForTab = useCallback(
 			(tab: TerminalTab) => {
-				const tabId = tab.id;
-				// Guard: skip if a spawn is already in flight for this tab
-				if (spawnInFlightRef.current.has(tabId)) return;
-				spawnInFlightRef.current.add(tabId);
-
-				// "Persistent" tabs carry user intent to keep running: a configured
-				// startup command, or any tab under an SSH/remote session (whose
-				// transport can drop for reasons unrelated to the user). We never
-				// silently discard these on failure - we keep them as a restartable
-				// exited husk instead of closing the tab and losing its config.
-				const isPersistent =
-					!!tab.startupCommand ||
-					!!(session.sessionSshRemoteConfig?.enabled || session.sshRemoteId);
-
-				const terminalSessionId = getTerminalSessionId(session.id, tabId);
-
-				// Build effective SSH config: prefer explicit sessionSshRemoteConfig, then fall back
-				// to sshRemoteId which is set after an AI agent connects. Without this fallback,
-				// terminal tabs under running SSH agents spawn locally instead of on the remote host.
-				//
-				// workingDirOverride must be a REMOTE path. Fallback chain:
-				//   1. sessionSshRemoteConfig.workingDirOverride - user-configured remote project root
-				//   2. session.remoteCwd - tracked remote cwd (set after agent reports cd)
-				//   3. session.cwd - the working directory from session creation; for SSH sessions
-				//      this IS a remote path (the user types a remote path when SSH is enabled)
-				const effectiveSshConfig = session.sessionSshRemoteConfig?.enabled
-					? {
-							...session.sessionSshRemoteConfig,
-							workingDirOverride:
-								session.sessionSshRemoteConfig.workingDirOverride ||
-								session.remoteCwd ||
-								session.cwd ||
-								undefined,
-						}
-					: session.sshRemoteId
-						? {
-								enabled: true,
-								remoteId: session.sshRemoteId,
-								workingDirOverride:
-									session.remoteCwd ||
-									session.sessionSshRemoteConfig?.workingDirOverride ||
-									session.cwd ||
-									undefined,
-							}
-						: undefined;
-
-				// When a startup command is configured, spawn the PTY in its configured cwd
-				// (if any) so the command runs in the right directory. Otherwise keep the
-				// existing fallback chain.
-				const spawnCwd =
-					(tab.startupCommand && tab.startupCommandCwd) ||
-					tab.cwd ||
-					session.cwd ||
-					session.projectRoot ||
-					'';
-
-				window.maestro.process
-					.spawnTerminalTab({
-						sessionId: terminalSessionId,
-						cwd: spawnCwd,
-						shell: defaultShell || undefined,
-						shellArgs,
-						shellEnvVars,
-						toolType: session.toolType,
-						sessionCustomEnvVars: session.customEnvVars,
-						sessionSshRemoteConfig: effectiveSshConfig,
-					})
-					.then((result) => {
-						if (result.success) {
-							onTabPidChangeRef.current(tabId, result.pid);
-							// Run the user-configured startup command. The PTY buffers stdin,
-							// so the shell will execute it once initialization (rc files, etc.)
-							// finishes.
-							if (tab.startupCommand) {
-								window.maestro.process
-									.write(terminalSessionId, tab.startupCommand + '\n')
-									.catch(() => {
-										// Write failures are surfaced by the process exit handler
-									});
-							}
-						} else {
-							// Spawn failed. Persistent tabs are kept (marked exited so the
-							// spawn effects stop retrying in a loop); scratch tabs are closed.
-							handleSpawnFailure(
-								tabId,
-								isPersistent,
-								effectiveSshConfig?.enabled
-									? 'SSH terminal could not be started. Check that the SSH remote is enabled and reachable.'
-									: 'The shell process could not be started. Check system PTY availability.'
-							);
-						}
-					})
-					.catch((err) => {
-						captureException(err, {
-							extra: {
-								tabId,
-								terminalSessionId,
-								operation: 'spawnTerminalTab',
-							},
-						});
-						// Spawn threw - same persistent-vs-scratch handling as a failed spawn.
-						handleSpawnFailure(
-							tabId,
-							isPersistent,
-							err instanceof Error ? err.message : 'An unexpected error occurred.'
-						);
-					})
-					.finally(() => {
-						spawnInFlightRef.current.delete(tabId);
-					});
+				void spawnPty({
+					session,
+					tab,
+					onPid: (id, pid) => onTabPidChangeRef.current(id, pid),
+					onSpawnFailure: handleSpawnFailure,
+				});
 			},
-			[
-				session.id,
-				session.cwd,
-				session.remoteCwd,
-				session.sessionSshRemoteConfig,
-				session.sshRemoteId,
-				defaultShell,
-				shellArgs,
-				shellEnvVars,
-				// onTabPidChange / onTabStateChange accessed via stable refs - not deps
-				handleSpawnFailure,
-			]
+			[session, handleSpawnFailure]
 		);
 
 		// Spawn PTY when active tab changes and has no PID yet

--- a/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
+++ b/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
@@ -25,6 +25,12 @@ import {
 } from '../../utils/terminalTabHelpers';
 import type { Session, AITab, ToolType, Group, BatchRunConfig, BrowserTab } from '../../types';
 import { logger } from '../../utils/logger';
+import { spawnPtyForTab } from '../../services/terminalSpawn';
+import { useTabStore } from '../../stores/tabStore';
+import {
+	createTabPidChangeHandler,
+	createTabStateChangeHandler,
+} from '../../components/TerminalView';
 import { captureException, captureMessage } from '../../utils/sentry';
 import { DEFAULT_BATCH_PROMPT } from '../batch/batchUtils';
 import { gitService } from '../../services/git';
@@ -315,6 +321,44 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 				return { ...addTerminalTabHelper(s, tab), inputMode: 'terminal' as const };
 			})
 		);
+
+		// Start the shell here rather than leaving it to TerminalView. That component
+		// only renders the agent the user is looking at, and only spawns for the ACTIVE
+		// tab (or a non-active one carrying a startup command), so a backgrounded
+		// terminal never got a PTY at all: the tab existed, `send-terminal` reported
+		// "has no running shell yet", and the only fix was to click it - which is the
+		// one thing `--background` exists to avoid. Spawning at creation makes the tab
+		// usable immediately no matter which agent is on screen.
+		//
+		// Safe to call unconditionally: the spawn dedupes in-flight calls by process
+		// id, and once the PID lands TerminalView's own `pid !== 0` check stops it
+		// spawning a second one when it later mounts.
+		const sessionForSpawn = selectSessionById(sessionId)(useSessionStore.getState());
+		if (sessionForSpawn) {
+			void spawnPtyForTab({
+				session: sessionForSpawn,
+				tab,
+				onPid: createTabPidChangeHandler(sessionId),
+				onSpawnFailure: (tabId, isPersistent, message) => {
+					// No xterm to write into from here, so report through the store and a
+					// toast. Persistent tabs stay as restartable husks exactly as they do
+					// on the view path; scratch tabs are closed.
+					logger.warn('Background terminal PTY spawn failed', 'RemoteEvents', {
+						sessionId,
+						tabId,
+						isPersistent,
+						message,
+					});
+					if (isPersistent) {
+						createTabStateChangeHandler(sessionId)(tabId, 'exited');
+					} else {
+						useTabStore.getState().closeTerminalTab(tabId, 'spawn-failure');
+					}
+					notifyToast({ type: 'error', title: 'Failed to start terminal', message });
+				},
+			});
+		}
+
 		ack(true, tab.id);
 	});
 

--- a/src/renderer/services/terminalSpawn.ts
+++ b/src/renderer/services/terminalSpawn.ts
@@ -1,0 +1,171 @@
+/**
+ * terminalSpawn.ts - the one place a terminal tab's PTY is started.
+ *
+ * This used to live inside `TerminalView`, which meant a tab only ever got a
+ * shell if that component rendered it. `TerminalView` mounts per agent and only
+ * for the agent that is (or has been) on screen, so a terminal opened into the
+ * background never spawned at all: the tab appeared in the tab bar, `send-terminal`
+ * answered "has no running shell yet", and the only cure was to click the tab -
+ * exactly what `open-terminal --background` exists to avoid.
+ *
+ * The spawn itself never needed the view. It touches no DOM, no xterm instance,
+ * and no cols/rows; it is an IPC call plus two store writes. So it lives here and
+ * both callers share it:
+ *
+ *   - `TerminalView`, when a tab it is rendering has no PID yet
+ *   - the `open-terminal` remote handler, the moment it creates the tab
+ *
+ * Callers differ only in how they REPORT failure: the view can write into the
+ * live xterm buffer, the handler cannot. That is the `onSpawnFailure` hook.
+ */
+
+import { getTerminalSessionId } from '../utils/terminalTabHelpers';
+import { useSettingsStore } from '../stores/settingsStore';
+import { captureException } from '../utils/sentry';
+import type { Session, TerminalTab } from '../types';
+
+/**
+ * Tabs with a spawn already in flight, keyed by the PROCESS id
+ * (`getTerminalSessionId(sessionId, tabId)`), never by the bare tab id.
+ *
+ * Module scope rather than a component ref, because the two callers live in
+ * different React subtrees and a per-mount guard cannot see the other's spawn -
+ * a background spawn racing a user clicking that tab would start two PTYs and
+ * orphan one with no error anywhere.
+ *
+ * The key must be the composed process id: tab ids are only unique within an
+ * agent, so guarding on the bare id would make two different agents' terminals
+ * dedupe each other and the second one would silently never start.
+ *
+ * This only covers the window before the PID lands in the store. Once it has,
+ * `pid !== 0` is the durable guard and survives remounting.
+ */
+const spawnInFlight = new Set<string>();
+
+/** Whether a spawn for this tab is already on its way. Exported for tests. */
+export function isSpawnInFlight(sessionId: string, tabId: string): boolean {
+	return spawnInFlight.has(getTerminalSessionId(sessionId, tabId));
+}
+
+export interface SpawnPtyForTabOptions {
+	session: Session;
+	tab: TerminalTab;
+	/** Called with the real PID once the shell is up. */
+	onPid: (tabId: string, pid: number) => void;
+	/**
+	 * Called when the shell could not be started. `isPersistent` means the tab
+	 * carries user intent worth keeping (a startup command, or an SSH session
+	 * whose transport can drop for unrelated reasons) - those become restartable
+	 * exited husks rather than being closed.
+	 */
+	onSpawnFailure: (tabId: string, isPersistent: boolean, message: string) => void;
+}
+
+/**
+ * Start the PTY for a terminal tab. Safe to call from anywhere in the renderer;
+ * concurrent calls for the same tab collapse to one spawn.
+ */
+export async function spawnPtyForTab(options: SpawnPtyForTabOptions): Promise<void> {
+	const { session, tab, onPid, onSpawnFailure } = options;
+	const tabId = tab.id;
+	const terminalSessionId = getTerminalSessionId(session.id, tabId);
+
+	if (spawnInFlight.has(terminalSessionId)) return;
+	spawnInFlight.add(terminalSessionId);
+
+	// "Persistent" tabs carry user intent to keep running: a configured startup
+	// command, or any tab under an SSH/remote session (whose transport can drop
+	// for reasons unrelated to the user). We never silently discard these on
+	// failure - we keep them as a restartable exited husk instead of closing the
+	// tab and losing its config.
+	const isPersistent =
+		!!tab.startupCommand || !!(session.sessionSshRemoteConfig?.enabled || session.sshRemoteId);
+
+	// Build effective SSH config: prefer explicit sessionSshRemoteConfig, then fall back
+	// to sshRemoteId which is set after an AI agent connects. Without this fallback,
+	// terminal tabs under running SSH agents spawn locally instead of on the remote host.
+	//
+	// workingDirOverride must be a REMOTE path. Fallback chain:
+	//   1. sessionSshRemoteConfig.workingDirOverride - user-configured remote project root
+	//   2. session.remoteCwd - tracked remote cwd (set after agent reports cd)
+	//   3. session.cwd - the working directory from session creation; for SSH sessions
+	//      this IS a remote path (the user types a remote path when SSH is enabled)
+	const effectiveSshConfig = session.sessionSshRemoteConfig?.enabled
+		? {
+				...session.sessionSshRemoteConfig,
+				workingDirOverride:
+					session.sessionSshRemoteConfig.workingDirOverride ||
+					session.remoteCwd ||
+					session.cwd ||
+					undefined,
+			}
+		: session.sshRemoteId
+			? {
+					enabled: true,
+					remoteId: session.sshRemoteId,
+					workingDirOverride:
+						session.remoteCwd ||
+						session.sessionSshRemoteConfig?.workingDirOverride ||
+						session.cwd ||
+						undefined,
+				}
+			: undefined;
+
+	// When a startup command is configured, spawn the PTY in its configured cwd
+	// (if any) so the command runs in the right directory. Otherwise keep the
+	// existing fallback chain.
+	const spawnCwd =
+		(tab.startupCommand && tab.startupCommandCwd) ||
+		tab.cwd ||
+		session.cwd ||
+		session.projectRoot ||
+		'';
+
+	// Read shell settings from the store rather than taking them as props: this
+	// runs outside React for the background path, and the settings are global.
+	const { defaultShell, shellArgs, shellEnvVars } = useSettingsStore.getState();
+
+	try {
+		const result = await window.maestro.process.spawnTerminalTab({
+			sessionId: terminalSessionId,
+			cwd: spawnCwd,
+			shell: defaultShell || undefined,
+			shellArgs,
+			shellEnvVars,
+			toolType: session.toolType,
+			sessionCustomEnvVars: session.customEnvVars,
+			sessionSshRemoteConfig: effectiveSshConfig,
+		});
+
+		if (result.success) {
+			onPid(tabId, result.pid);
+			// Run the user-configured startup command. The PTY buffers stdin, so the
+			// shell will execute it once initialization (rc files, etc.) finishes.
+			if (tab.startupCommand) {
+				window.maestro.process.write(terminalSessionId, tab.startupCommand + '\n').catch(() => {
+					// Write failures are surfaced by the process exit handler
+				});
+			}
+		} else {
+			onSpawnFailure(
+				tabId,
+				isPersistent,
+				effectiveSshConfig?.enabled
+					? 'SSH terminal could not be started. Check that the SSH remote is enabled and reachable.'
+					: 'The shell process could not be started. Check system PTY availability.'
+			);
+		}
+	} catch (err) {
+		captureException(err, {
+			extra: { tabId, terminalSessionId, operation: 'spawnTerminalTab' },
+		});
+		// Spawn threw - same persistent-vs-scratch handling as a failed spawn.
+		onSpawnFailure(
+			tabId,
+			isPersistent,
+			err instanceof Error ? err.message : 'An unexpected error occurred.'
+		);
+	} finally {
+		spawnInFlight.delete(terminalSessionId);
+	}
+}


### PR DESCRIPTION
## The bug

`open-terminal --background` produced a tab with **no shell**. `send-terminal` then answered:

> `Terminal "X" has no running shell yet. Select the tab in Maestro, or use open-terminal --command.`

Both remedies that error suggests are the things `--background` exists to avoid.

## Why

The spawn lived inside `TerminalView`, which has exactly two triggers: the tab is **active**, or it is non-active **and** carries a `startupCommand`. `TerminalView` is itself mounted only for a session that has been the active session at some point since launch (`useTerminalMounting` gates on `activeSession`).

That leaves three permanently-dead cases:

| # | scenario | why it stays dead |
|---|---|---|
| 1 | background tab, no `--command` | not active, no startup command |
| 2 | any tab in an agent never brought on screen | `TerminalView` never mounts |
| 3 | same, after an app restart | tab is persisted, the spawn is not |

## The fix

The spawn never needed the view — it is an IPC call plus two store writes, touching no DOM, no xterm instance, no cols/rows. It moves to `services/terminalSpawn.ts`, and the `open-terminal` handler calls it the moment it creates the tab, so the shell runs regardless of what is on screen. `TerminalView` calls the same function and supplies only the failure reporting, which is the one part that genuinely needs the live xterm buffer.

**No CLI contract change.** `--background` still means background; every verb keeps its current focus default. The four "the flag is ADDITIVE / no verb's default changed" assertions stay true, so none are touched.

## The guard, which is the sharp edge

`spawnInFlightRef` was a **per-mount ref keyed on the bare tab id**. Both properties had to change:

- **Per-mount** can't see a spawn started outside the component → a background spawn racing a user click starts **two PTYs**, one orphaned, no error.
- **Bare tab id** is unique only within an agent → two agents' terminals would **dedupe each other** and the second silently never starts.

Now module scope, keyed by `getTerminalSessionId(sessionId, tabId)`. It only covers the window before the PID lands; after that `TerminalView`'s existing `pid !== 0` check is the durable guard, so handler-spawns-then-view-mounts does not double spawn.

## Tests — proven to bite

8 new tests in `terminalSpawn.test.ts`. Re-keying the guard back to the bare tab id turns **"does not dedupe the same tab id across two different agents"** red — the exact silent trap. Restored, all 8 green.

Also covered: spawns with no rendered terminal, startup-command write, concurrent-call collapse, scratch vs persistent failure classification, SSH message, and guard release on throw (a stuck guard would make the tab unspawnable for the rest of the session).

## Validation

- **Full suite: 1314 files, 35,560 passed, 0 failed**
- `tsc` clean on all three configs, run directly
- `eslint src/` clean, prettier clean

## Dead code removed (direct consequence, listed rather than silently dropped)

- `defaultShell` / `shellArgs` / `shellEnvVars` props on `TerminalView` — settings now read from `settingsStore` inside the spawn
- the `defaultShell` selector in `MainPanelContent` that existed only to feed them
- an unused `captureException` import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal sessions now start immediately when opened, including in background tabs.
  * Startup commands continue to run automatically once the shell is ready.

* **Bug Fixes**
  * Prevented duplicate terminal processes from launching during concurrent startup.
  * Improved handling of terminal launch failures for persistent and temporary tabs.
  * Terminal processes now clean up correctly after failed launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->