### PR TITLE
fix(preload): stop dropping --background on open-terminal

### DIFF
--- a/src/__tests__/main/preload/process/browserTabRemote.test.ts
+++ b/src/__tests__/main/preload/process/browserTabRemote.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for process/browserTabRemote preload API.
+ *
+ * These exercise the registered IPC handler itself rather than the callback
+ * signature, because the signature is exactly what cannot be trusted here:
+ * TypeScript accepts a 3-parameter function where a 4-parameter callback type
+ * is declared, so a bridge that quietly drops its last argument type-checks
+ * clean and ships a dead flag. `--background` on `open-terminal` was inert for
+ * that reason - the main process sent the option, the preload handler never
+ * declared it, and the renderer read `undefined`. Every tab focused.
+ *
+ * So the assertion has to be end-to-end across the bridge: emit what the main
+ * process actually sends, and check what the renderer actually receives.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockOn = vi.fn();
+const mockRemoveListener = vi.fn();
+const mockSend = vi.fn();
+
+vi.mock('electron', () => ({
+	ipcRenderer: {
+		on: (...args: unknown[]) => mockOn(...args),
+		removeListener: (...args: unknown[]) => mockRemoveListener(...args),
+		send: (...args: unknown[]) => mockSend(...args),
+	},
+}));
+
+import { createBrowserTabRemoteApi } from '../../../../main/preload/process/browserTabRemote';
+
+/** Pull the handler the API registered for a channel, so we can drive it. */
+function registeredHandler(channel: string): (...args: unknown[]) => void {
+	const entry = mockOn.mock.calls.find((call) => call[0] === channel);
+	if (!entry) throw new Error(`no handler registered for ${channel}`);
+	return entry[1] as (...args: unknown[]) => void;
+}
+
+describe('Process BrowserTabRemote Preload API', () => {
+	let api: ReturnType<typeof createBrowserTabRemoteApi>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		api = createBrowserTabRemoteApi();
+	});
+
+	describe('onRemoteOpenTerminalTab - background must survive the bridge', () => {
+		const config = { name: 'Dev server' };
+
+		it('forwards background:true to the renderer callback', () => {
+			const callback = vi.fn();
+			api.onRemoteOpenTerminalTab(callback);
+
+			// Exactly what browserTabCallbacks.ts sends over the wire.
+			registeredHandler('remote:openTerminalTab')(null, 'session-1', config, 'chan-1', {
+				background: true,
+			});
+
+			expect(callback).toHaveBeenCalledWith('session-1', config, 'chan-1', { background: true });
+		});
+
+		it('forwards background:false when the verb should focus', () => {
+			const callback = vi.fn();
+			api.onRemoteOpenTerminalTab(callback);
+
+			registeredHandler('remote:openTerminalTab')(null, 'session-1', config, 'chan-1', {
+				background: false,
+			});
+
+			expect(callback).toHaveBeenCalledWith('session-1', config, 'chan-1', { background: false });
+		});
+
+		it('treats a missing options argument as foreground, not undefined', () => {
+			const callback = vi.fn();
+			api.onRemoteOpenTerminalTab(callback);
+
+			// An older main process that predates the flag sends only three args.
+			registeredHandler('remote:openTerminalTab')(null, 'session-1', config, 'chan-1');
+
+			expect(callback).toHaveBeenCalledWith('session-1', config, 'chan-1', { background: false });
+		});
+
+		it('only a literal true opts in', () => {
+			const callback = vi.fn();
+			api.onRemoteOpenTerminalTab(callback);
+
+			registeredHandler('remote:openTerminalTab')(null, 'session-1', config, 'chan-1', {
+				background: 'yes' as unknown as boolean,
+			});
+
+			expect(callback).toHaveBeenCalledWith('session-1', config, 'chan-1', { background: false });
+		});
+
+		it('acks false on the response channel when the callback throws', () => {
+			const callback = vi.fn(() => {
+				throw new Error('renderer blew up');
+			});
+			api.onRemoteOpenTerminalTab(callback);
+
+			expect(() =>
+				registeredHandler('remote:openTerminalTab')(null, 'session-1', config, 'chan-1', {
+					background: true,
+				})
+			).toThrow('renderer blew up');
+			expect(mockSend).toHaveBeenCalledWith('chan-1', false);
+		});
+	});
+
+	describe('onRemoteOpenBrowserTab - the sibling that was already correct', () => {
+		it('forwards its options object through the bridge', () => {
+			const callback = vi.fn();
+			api.onRemoteOpenBrowserTab(callback);
+
+			registeredHandler('remote:openBrowserTab')(
+				null,
+				'session-1',
+				'https://example.com',
+				'chan-2',
+				{
+					background: true,
+				}
+			);
+
+			expect(callback).toHaveBeenCalledWith('session-1', 'https://example.com', 'chan-2', {
+				background: true,
+			});
+		});
+	});
+});

--- a/src/main/preload/process/browserTabRemote.ts
+++ b/src/main/preload/process/browserTabRemote.ts
@@ -82,17 +82,21 @@ export function createBrowserTabRemoteApi() {
 			callback: (
 				sessionId: string,
 				config: { cwd?: string; shell?: string; name?: string | null; command?: string },
-				responseChannel: string
+				responseChannel: string,
+				options: { background?: boolean }
 			) => void
 		): (() => void) => {
 			const handler = (
 				_: unknown,
 				sessionId: string,
 				config: { cwd?: string; shell?: string; name?: string | null; command?: string },
-				responseChannel: string
+				responseChannel: string,
+				options?: { background?: boolean }
 			) => {
 				try {
-					callback(sessionId, config, responseChannel);
+					callback(sessionId, config, responseChannel, {
+						background: options?.background === true,
+					});
 				} catch (error) {
 					ipcRenderer.send(responseChannel, false);
 					throw error;


### PR DESCRIPTION
**This is the focus theft.** Every terminal an agent opened stole the screen, even when it passed `--background`.

## The break

The flag is resolved by the CLI, read by the web-server handler, and sent over IPC - then dropped one layer short of the renderer.

| stage | verdict |
|---|---|
| CLI `resolveBackgroundFlag` | sends it |
| `browserTabCallbacks.ts:145` | sends a 4th arg `{ background }` |
| **`browserTabRemote.ts` `onRemoteOpenTerminalTab`** | **declares 3 params, forwards 3** |
| `useRemoteIntegration.ts` renderer | reads a 4th arg |

The renderer got `undefined`, `undefined?.background === true` was `false`, and the handler took the foreground branch every time: `setActiveSessionId` fired and the tab was added with `activate: true`.

Reproducible in two commands on a packaged build - open two background terminals and watch `activeTerminalTabId` move to each one.

## Why it only affects `rc`

`9656c12d4` added `--background` by patching `main`'s monolithic preload. `rc` **contains that commit**, but had already split the preload into `src/main/preload/process/*`, so the hunk landed in a file that no longer defines the handler. `main` is correct at `process.ts:731-757`.

Same shape as the `process-listeners-wiring` split trap, one layer down.

## It is not systemic - I checked rather than assumed

Audited every sibling bridge in the split:

| bridge | forwards? |
|---|---|
| `onRemoteOpenBrowserTab` | yes - `options ?? {}` |
| `onRemoteOpenFileTab` | yes - normalizes `background` and `switchToAgent` |
| `onRemoteSwitchMode` | yes - `background === true` |
| `onRemoteNewTab` | yes - `background === true` |
| **`onRemoteOpenTerminalTab`** | **no** |

One defect, not a suspect surface.

## The test drives the bridge, not the signature

`tsc` structurally cannot catch this: TypeScript accepts a 3-arity function where a 4-arity callback type is declared, so the defect type-checks clean and ships a dead flag. The test therefore emits exactly what `browserTabCallbacks.ts` sends and asserts what the renderer receives.

**Reverting the forward turns 4 of the 6 cases red.** Verified, not assumed.

Also covered: an absent options argument normalizes to `{ background: false }` rather than handing the renderer `undefined` (so an older main process degrades to today's behaviour), and only a literal `true` opts in - matching `readBackgroundField` in `shared/focusPlacement.ts`.

## Verification

- Full suite: **40,196 passed, 0 failed** (1,699 files)
- `tsc` clean - the only errors are the 5 pre-existing `TS6133` on `rc`'s tip, in files this doesn't touch
- No CLI, IPC-payload, or default-behaviour change. `open-terminal` still focuses when the flag is absent.

## What this supersedes

The dead-tab theory - that background terminals get no PTY - was real in code but **unreachable**, because no tab was ever actually backgrounded through this path. Background tabs got shells precisely *because* backgrounding failed and they were activated. Fixing the spawn lifecycle or flipping the focus default would both have changed nothing while the flag could not reach the renderer.

**Not merged** - landing on the release branch is Pedram's call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Terminal tabs can now be opened in the background when requested.
  - Background-opening options are consistently forwarded between the application processes.

- **Bug Fixes**
  - Invalid or missing background settings now safely default to foreground behavior.
  - Failed tab-opening callbacks correctly acknowledge the request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->