### PR TITLE
fix(web-desktop): restore running agent status after a page reload

### DIFF
--- a/src/__tests__/renderer/hooks/session/useSessionRestoration.reattach.test.tsx
+++ b/src/__tests__/renderer/hooks/session/useSessionRestoration.reattach.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Issue #1464 - after a web-desktop page reload the main process is still
+ * running the agent, but restoreSession resets every agent to idle. These tests
+ * pin the reconcile that puts the busy indicators back from main's live turn
+ * table, and pin that it never invents busy state it wasn't told about.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useSessionRestoration } from '../../../../renderer/hooks/session/useSessionRestoration';
+import { useSessionStore } from '../../../../renderer/stores/sessionStore';
+import { createMockSession } from '../../../helpers/mockSession';
+import { createMockAITab } from '../../../helpers/mockTab';
+
+const RUNNING_AGENT = createMockSession({
+	id: 'agent-1',
+	state: 'busy',
+	aiTabs: [createMockAITab({ id: 'tab-1', state: 'busy' })],
+	activeTabId: 'tab-1',
+});
+
+function mockMaestro(activeProcesses: unknown[]) {
+	const maestro = (window as any).maestro;
+	maestro.sessions = {
+		...maestro.sessions,
+		getAll: vi.fn().mockResolvedValue([RUNNING_AGENT]),
+		getActiveSessionId: vi.fn().mockResolvedValue('agent-1'),
+		setActiveSessionId: vi.fn().mockResolvedValue(undefined),
+	};
+	maestro.groups = { ...maestro.groups, getAll: vi.fn().mockResolvedValue([]) };
+	maestro.groupChat = { ...maestro.groupChat, list: vi.fn().mockResolvedValue([]) };
+	maestro.agents = { ...maestro.agents, get: vi.fn().mockResolvedValue({ id: 'claude-code' }) };
+	maestro.process = {
+		...maestro.process,
+		getActiveProcesses: vi.fn().mockResolvedValue(activeProcesses),
+	};
+}
+
+const agentState = () => useSessionStore.getState().sessions.find((s) => s.id === 'agent-1');
+
+beforeEach(() => {
+	useSessionStore.setState({ sessions: [], initialLoadComplete: false, sessionsLoaded: false });
+});
+
+describe('useSessionRestoration - live turn reattach (#1464)', () => {
+	it('restores busy state for an agent main is still running', async () => {
+		mockMaestro([
+			{
+				sessionId: 'agent-1-ai-tab-1',
+				toolType: 'claude-code',
+				pid: 4242,
+				cwd: '/test/project',
+				isTerminal: false,
+				startTime: 1000,
+			},
+		]);
+
+		renderHook(() => useSessionRestoration());
+
+		await waitFor(() => expect(agentState()?.state).toBe('busy'));
+		expect(agentState()).toMatchObject({ busySource: 'ai', thinkingStartTime: 1000, aiPid: 4242 });
+		expect(agentState()?.aiTabs[0]).toMatchObject({ state: 'busy', thinkingStartTime: 1000 });
+	});
+
+	it('leaves the agent idle when main is running nothing for it', async () => {
+		mockMaestro([]);
+
+		renderHook(() => useSessionRestoration());
+
+		await waitFor(() => expect(useSessionStore.getState().sessionsLoaded).toBe(true));
+		expect(agentState()?.state).toBe('idle');
+		expect(agentState()?.aiTabs[0].state).toBe('idle');
+	});
+
+	it('leaves the agent idle when the probe itself fails', async () => {
+		mockMaestro([]);
+		(window as any).maestro.process.getActiveProcesses = vi
+			.fn()
+			.mockRejectedValue(new Error('bridge down'));
+
+		renderHook(() => useSessionRestoration());
+
+		await waitFor(() => expect(useSessionStore.getState().sessionsLoaded).toBe(true));
+		expect(agentState()?.state).toBe('idle');
+	});
+});

--- a/src/__tests__/renderer/services/process.test.ts
+++ b/src/__tests__/renderer/services/process.test.ts
@@ -8,6 +8,7 @@ import { logger } from '../../../renderer/utils/logger';
 import {
 	processService,
 	probeSessionAiProcesses,
+	fetchLiveAiTurns,
 	ProcessConfig,
 	ProcessDataHandler,
 	ProcessExitHandler,
@@ -589,5 +590,45 @@ describe('probeSessionAiProcesses', () => {
 		const state = await probeSessionAiProcesses(SESSION, 'tab-1');
 
 		expect(state).toEqual({ anyActive: true, targetTabActive: true, probeFailed: true });
+	});
+});
+
+describe('fetchLiveAiTurns', () => {
+	function proc(sessionId: string, overrides: Record<string, unknown> = {}) {
+		return {
+			sessionId,
+			toolType: 'claude-code',
+			pid: 7,
+			cwd: '/x',
+			isTerminal: false,
+			startTime: 1000,
+			...overrides,
+		};
+	}
+
+	test('resolves every live AI turn across all agents in one round trip', async () => {
+		mockProcess.getActiveProcesses.mockResolvedValue([
+			proc('agent-a-ai-tab-1'),
+			proc('agent-b-ai-tab-9', { pid: 8 }),
+			proc('agent-a-terminal', { isTerminal: true }),
+		]);
+
+		await expect(fetchLiveAiTurns()).resolves.toEqual([
+			{ sessionId: 'agent-a', tabId: 'tab-1', pid: 7, startTime: 1000 },
+			{ sessionId: 'agent-b', tabId: 'tab-9', pid: 8, startTime: 1000 },
+		]);
+		expect(mockProcess.getActiveProcesses).toHaveBeenCalledWith({ includeChildProcesses: false });
+	});
+
+	test('returns null when the probe fails, so callers can tell it apart from "nothing running"', async () => {
+		mockProcess.getActiveProcesses.mockRejectedValue(new Error('bridge down'));
+
+		await expect(fetchLiveAiTurns()).resolves.toBeNull();
+	});
+
+	test('returns an empty array when main owns no AI turns', async () => {
+		mockProcess.getActiveProcesses.mockResolvedValue([]);
+
+		await expect(fetchLiveAiTurns()).resolves.toEqual([]);
 	});
 });

--- a/src/__tests__/renderer/utils/liveTurnReattach.test.ts
+++ b/src/__tests__/renderer/utils/liveTurnReattach.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for liveTurnReattach - re-deriving busy state from the main process's
+ * live turn table after a web-desktop page reload (issue #1464).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveLiveAiTurns, applyLiveAiTurns } from '../../../renderer/utils/liveTurnReattach';
+import { createMockSession } from '../../helpers/mockSession';
+import { createMockAITab } from '../../helpers/mockTab';
+
+const proc = (overrides: Partial<Parameters<typeof resolveLiveAiTurns>[0][number]>) => ({
+	sessionId: 'agent-1-ai-tab-1',
+	pid: 100,
+	isTerminal: false,
+	startTime: 1000,
+	...overrides,
+});
+
+describe('resolveLiveAiTurns', () => {
+	it('resolves an AI tab process into its agent and tab', () => {
+		expect(resolveLiveAiTurns([proc({})])).toEqual([
+			{ sessionId: 'agent-1', tabId: 'tab-1', pid: 100, startTime: 1000 },
+		]);
+	});
+
+	it('resolves a forced-parallel turn onto its originating tab', () => {
+		expect(resolveLiveAiTurns([proc({ sessionId: 'agent-1-ai-tab-1-fp-2' })])[0]).toMatchObject({
+			sessionId: 'agent-1',
+			tabId: 'tab-1',
+		});
+	});
+
+	it('skips terminals, Cue runs, and non-AI-tab ids', () => {
+		const resolved = resolveLiveAiTurns([
+			proc({ sessionId: 'agent-1-terminal', isTerminal: true }),
+			proc({ sessionId: 'agent-1-ai-tab-9', isCueRun: true }),
+			proc({ sessionId: 'agent-1-batch-1700000000' }),
+			proc({ sessionId: 'agent-1' }),
+		]);
+		expect(resolved).toEqual([]);
+	});
+});
+
+describe('applyLiveAiTurns', () => {
+	const idleSession = (id = 'agent-1') =>
+		createMockSession({
+			id,
+			state: 'idle',
+			aiTabs: [createMockAITab({ id: 'tab-1' }), createMockAITab({ id: 'tab-2' })],
+			activeTabId: 'tab-1',
+		});
+
+	it('marks the agent and the running tab busy', () => {
+		const [session] = applyLiveAiTurns(
+			[idleSession()],
+			[{ sessionId: 'agent-1', tabId: 'tab-1', pid: 42, startTime: 1000 }]
+		);
+
+		expect(session.state).toBe('busy');
+		expect(session.busySource).toBe('ai');
+		expect(session.thinkingStartTime).toBe(1000);
+		expect(session.aiPid).toBe(42);
+		expect(session.aiTabs[0]).toMatchObject({ state: 'busy', thinkingStartTime: 1000 });
+		// A tab with no live turn stays idle.
+		expect(session.aiTabs[1].state).toBe('idle');
+	});
+
+	it('uses the earliest start time when an agent has several live turns', () => {
+		const [session] = applyLiveAiTurns(
+			[idleSession()],
+			[
+				{ sessionId: 'agent-1', tabId: 'tab-2', pid: 43, startTime: 5000 },
+				{ sessionId: 'agent-1', tabId: 'tab-1', pid: 42, startTime: 1000 },
+			]
+		);
+
+		expect(session.thinkingStartTime).toBe(1000);
+		expect(session.aiTabs[0].thinkingStartTime).toBe(1000);
+		expect(session.aiTabs[1].thinkingStartTime).toBe(5000);
+	});
+
+	it('marks the agent busy even when its tab is gone', () => {
+		const [session] = applyLiveAiTurns(
+			[createMockSession({ id: 'agent-1', state: 'idle', aiTabs: [] })],
+			[{ sessionId: 'agent-1', tabId: 'closed-tab', pid: 42, startTime: 1000 }]
+		);
+
+		expect(session.state).toBe('busy');
+	});
+
+	it('leaves agents with no live turn untouched', () => {
+		const sessions = [idleSession('agent-1'), idleSession('agent-2')];
+		const next = applyLiveAiTurns(sessions, [
+			{ sessionId: 'agent-1', tabId: 'tab-1', pid: 42, startTime: 1000 },
+		]);
+
+		expect(next[1]).toBe(sessions[1]);
+		expect(next[1].state).toBe('idle');
+	});
+
+	it('returns the same array when there is nothing running', () => {
+		const sessions = [idleSession()];
+		expect(applyLiveAiTurns(sessions, [])).toBe(sessions);
+	});
+
+	it('does not overwrite a restored limit pause', () => {
+		const paused = createMockSession({
+			id: 'agent-1',
+			state: 'error',
+			agentErrorPaused: true,
+			aiTabs: [createMockAITab({ id: 'tab-1' })],
+		});
+		const [session] = applyLiveAiTurns(
+			[paused],
+			[{ sessionId: 'agent-1', tabId: 'tab-1', pid: 42, startTime: 1000 }]
+		);
+
+		expect(session.state).toBe('error');
+		expect(session.agentErrorPaused).toBe(true);
+	});
+
+	it('falls back to now when main reports no start time', () => {
+		const [session] = applyLiveAiTurns(
+			[idleSession()],
+			[{ sessionId: 'agent-1', tabId: 'tab-1', pid: 42 }],
+			7777
+		);
+
+		expect(session.thinkingStartTime).toBe(7777);
+		expect(session.aiTabs[0].thinkingStartTime).toBe(7777);
+	});
+});

--- a/src/renderer/hooks/session/useSessionRestoration.ts
+++ b/src/renderer/hooks/session/useSessionRestoration.ts
@@ -10,6 +10,7 @@
  *
  * Effects:
  *   - Session & group loading on mount (with React Strict Mode guard)
+ *   - Re-derives busy state from the main process's live turns after load
  *   - Sets initialLoadComplete + sessionsLoaded flags for splash coordination
  */
 
@@ -21,6 +22,9 @@ import { useGroupChatStore } from '../../stores/groupChatStore';
 import { gitService } from '../../services/git';
 import { generateId } from '../../utils/ids';
 import { isEphemeralBrowserTab, rehydrateBrowserTab } from '../../utils/browserTabPersistence';
+import { applyLiveAiTurns } from '../../utils/liveTurnReattach';
+import { fetchLiveAiTurns } from '../../services/process';
+import { useOwnedSessionGate } from '../agent/internal/useOwnedSessionGate';
 import { getRepairedUnifiedTabOrder } from '../../utils/tabHelpers';
 import { collectLeafTabRefs, normalizeTabGroups } from '../../utils/panelLayout';
 import { migrateLegacySnoozedTabs } from '../../utils/snoozeHelpers';
@@ -111,6 +115,12 @@ export function useSessionRestoration(): SessionRestorationReturn {
 		});
 	}, []) as React.MutableRefObject<boolean>;
 
+	// Window scoping for the live-turn reconcile below. A secondary window must
+	// not light up an agent the primary owns, and the gate is the one place that
+	// answers that (web-desktop's is a permit-all, which is what makes the
+	// reconcile work there at all).
+	const ownedGate = useOwnedSessionGate();
+
 	// --- validateAgentInBackground ---
 	// Checks agent availability without blocking session restoration.
 	// If the agent is unavailable, marks the session with error state.
@@ -146,6 +156,27 @@ export function useSessionRestoration(): SessionRestorationReturn {
 		},
 		[]
 	);
+
+	// --- reattachLiveAiTurns ---
+	// restoreSession resets every agent to idle because in the Electron app no
+	// spawned process survives a restart. The web-desktop bundle breaks that
+	// assumption: the page is a client of a main process that keeps running, so a
+	// browser reload (or a reconnect after the tab was suspended) drops the
+	// renderer's busy bookkeeping while the agent keeps working - the Left Bar
+	// draws the idle dot and the thinking pill never appears, even as the
+	// transcript fills in, because the output listeners route by process id and
+	// never needed that bookkeeping. Ask main what it is actually running and put
+	// the indicators back. On a cold Electron start the process table is empty, so
+	// this costs one round trip and changes nothing.
+	const reattachLiveAiTurns = useCallback(async () => {
+		const turns = await fetchLiveAiTurns();
+		// null means the probe failed, which is not the same answer as "nothing is
+		// running" - leave the restored state alone rather than guessing.
+		if (!turns || turns.length === 0) return;
+		const owned = turns.filter((turn) => ownedGate.current?.(`${turn.sessionId}-ai-${turn.tabId}`));
+		if (owned.length === 0) return;
+		setSessions((prev) => applyLiveAiTurns(prev, owned));
+	}, [ownedGate]);
 
 	// --- fetchGitInfoInBackground ---
 	const fetchGitInfoInBackground = useCallback(
@@ -630,6 +661,12 @@ export function useSessionRestoration(): SessionRestorationReturn {
 						// doesn't retry the invalid ID on next launch
 						setActiveSessionId(restoredSessions[0].id);
 					}
+
+					// Put back the busy indicators for agents main is still running.
+					// Deliberately not awaited: it must not hold the splash, and a page
+					// that paints an agent idle for one frame before correcting itself is
+					// far better than one that waits on an IPC round trip to paint at all.
+					void reattachLiveAiTurns();
 
 					// Background tasks: agent validation + SSH git info.
 					// These run after splash hides so they never block startup.

--- a/src/renderer/services/process.ts
+++ b/src/renderer/services/process.ts
@@ -4,6 +4,7 @@
  */
 
 import { createIpcMethod } from './ipcWrapper';
+import { resolveLiveAiTurns, type LiveAiTurn } from '../utils/liveTurnReattach';
 import type { ProcessConfig } from '../types';
 
 export type { ProcessConfig } from '../types';
@@ -177,5 +178,27 @@ export async function probeSessionAiProcesses(
 		// Preserve the input when ownership is unknown: treating an IPC failure as
 		// idle can retry a live process id and lose its response.
 		return { anyActive: true, targetTabActive: true, probeFailed: true };
+	}
+}
+
+/**
+ * Every AI turn the MAIN process is running right now, across all agents.
+ *
+ * The whole-table counterpart to {@link probeSessionAiProcesses}, which asks
+ * about one agent: startup reconciliation needs the answer for every restored
+ * agent at once, and one round trip beats one per session.
+ *
+ * Returns `null` when the probe itself fails. Callers reconcile idle state
+ * against this, so an empty array would read as "nothing is running" and is the
+ * wrong shape for "I could not find out" - the two must stay distinguishable.
+ */
+export async function fetchLiveAiTurns(): Promise<LiveAiTurn[] | null> {
+	try {
+		const active = await window.maestro.process.getActiveProcesses({
+			includeChildProcesses: false,
+		});
+		return resolveLiveAiTurns(active);
+	} catch {
+		return null;
 	}
 }

--- a/src/renderer/utils/liveTurnReattach.ts
+++ b/src/renderer/utils/liveTurnReattach.ts
@@ -1,0 +1,149 @@
+/**
+ * Re-deriving "this agent is busy" from the processes MAIN still owns.
+ *
+ * `restoreSession` resets every agent and AI tab to idle on load, because in the
+ * Electron app the main process dies with the window and no spawned agent
+ * survives a restart. That assumption does not hold for the web-desktop bundle:
+ * the browser page is a client of a main process that keeps running, so a page
+ * reload (or a reconnect after the browser suspended the tab) throws away the
+ * renderer's in-memory busy state while the agent keeps working. The result is
+ * an agent drawn with the idle dot, no thinking pill, and no elapsed timer,
+ * while its output streams into the transcript - the listeners route by
+ * `{agentId}-ai-{tabId}` and never needed the renderer's bookkeeping.
+ *
+ * Busy state is therefore not something to remember across a reload, it is
+ * something to ASK for: the process table in main is the only authority on what
+ * is running right now. These helpers turn that table back into session state.
+ *
+ * The pass is a no-op on a cold Electron start (the process manager is empty),
+ * so it costs one IPC round trip and changes nothing there.
+ */
+
+import type { Session, SessionState, AITab } from '../types';
+import { parseSessionId } from './sessionIdParser';
+
+/**
+ * One live AI turn main still owns, resolved back to the agent and tab it
+ * belongs to. Forced-parallel turns (`-fp-<n>`) resolve to their originating
+ * tab, which is the tab whose indicator should read busy.
+ */
+export interface LiveAiTurn {
+	/** The agent (`Session.id`) the turn belongs to. */
+	sessionId: string;
+	/** The AI tab the turn was spawned on. */
+	tabId: string;
+	/** OS pid of the agent process. */
+	pid: number;
+	/** When main started the process, for the elapsed-time pill. */
+	startTime?: number;
+}
+
+/**
+ * Resolve raw active-process entries into the AI turns they represent.
+ *
+ * Terminal PTYs and Cue runs are excluded: neither occupies an agent's
+ * sequential AI turn, so neither should make its dot go yellow. Anything whose
+ * id is not an `{agentId}-ai-{tabId}` shape (batch runs, synopsis runs, bare
+ * agent ids) is skipped for the same reason.
+ */
+export function resolveLiveAiTurns(
+	processes: Array<{
+		sessionId: string;
+		pid: number;
+		isTerminal: boolean;
+		isCueRun?: boolean;
+		startTime?: number;
+	}>
+): LiveAiTurn[] {
+	const turns: LiveAiTurn[] = [];
+	for (const process of processes) {
+		if (process.isTerminal || process.isCueRun) continue;
+		const parsed = parseSessionId(process.sessionId);
+		if (parsed.type !== 'ai-tab' || !parsed.tabId) continue;
+		turns.push({
+			sessionId: parsed.actualSessionId,
+			tabId: parsed.tabId,
+			pid: process.pid,
+			startTime: process.startTime,
+		});
+	}
+	return turns;
+}
+
+/** The earliest start time among a set of turns, falling back to `now`. */
+function earliestStart(turns: LiveAiTurn[], now: number): number {
+	let earliest: number | undefined;
+	for (const turn of turns) {
+		if (turn.startTime === undefined) continue;
+		earliest = earliest === undefined ? turn.startTime : Math.min(earliest, turn.startTime);
+	}
+	return earliest ?? now;
+}
+
+/**
+ * Mark the agents and tabs named by `turns` busy again.
+ *
+ * Only ever moves state in one direction - a session with no live turn is
+ * returned untouched rather than forced idle. Reconciling the other way is the
+ * exit listener's job, and it already verifies against this same process table
+ * before clearing anything; doing it here as well would race a turn spawned
+ * between the probe and the store write and cancel its indicator.
+ *
+ * A turn whose tab is gone (closed before the reload, or pruned by restoration)
+ * still marks the AGENT busy. The Left Bar dot is the symptom the user reads
+ * first, and an agent that is demonstrably working must not be drawn idle just
+ * because the pane it was working in is no longer open.
+ *
+ * `state === 'error'` is left alone: a limit pause is deliberately restored as
+ * a live error so auto-resume re-finds it, and overwriting that with 'busy'
+ * would hide the pause the coordinator is waiting on.
+ */
+export function applyLiveAiTurns(
+	sessions: Session[],
+	turns: LiveAiTurn[],
+	now: number = Date.now()
+): Session[] {
+	if (turns.length === 0) return sessions;
+
+	const bySession = new Map<string, LiveAiTurn[]>();
+	for (const turn of turns) {
+		const existing = bySession.get(turn.sessionId);
+		if (existing) existing.push(turn);
+		else bySession.set(turn.sessionId, [turn]);
+	}
+	if (bySession.size === 0) return sessions;
+
+	let changed = false;
+	const next = sessions.map((session) => {
+		const sessionTurns = bySession.get(session.id);
+		if (!sessionTurns || session.state === 'error') return session;
+
+		const startTimeByTab = new Map<string, number>();
+		for (const turn of sessionTurns) {
+			const start = turn.startTime ?? now;
+			const known = startTimeByTab.get(turn.tabId);
+			startTimeByTab.set(turn.tabId, known === undefined ? start : Math.min(known, start));
+		}
+
+		const markTab = (tab: AITab): AITab => {
+			const start = startTimeByTab.get(tab.id);
+			if (start === undefined || tab.state === 'busy') return tab;
+			return { ...tab, state: 'busy', thinkingStartTime: start };
+		};
+
+		changed = true;
+		return {
+			...session,
+			state: 'busy' as SessionState,
+			busySource: 'ai' as const,
+			thinkingStartTime: earliestStart(sessionTurns, now),
+			aiPid: sessionTurns[0].pid,
+			aiTabs: session.aiTabs.map(markTab),
+			...(session.orphanedThinkingTabs && {
+				orphanedThinkingTabs: session.orphanedThinkingTabs.map(markTab),
+			}),
+		};
+	});
+
+	return changed ? next : sessions;
+}


### PR DESCRIPTION
Closes #1464

## The bug

`restoreSession` resets every agent and AI tab to idle on load, on the grounds that no spawned process survives a restart. That holds for the Electron app, where the main process dies with the window. It does not hold for web-desktop, where the page is a client of a main process that keeps running.

So a browser reload throws away the renderer's busy bookkeeping while the agent keeps working. This also covers the reporter's "disconnect and reconnect" path: the bridge handles a reconnect by reloading the page (`electron-shim.ts`), and its own comment already flags "busy pills ... stale beyond repair" as a known consequence.

That explains both symptoms in the issue, including the one that reads as contradictory:

- **(a) the agent shows the idle dot.** `restoreSession` wrote `state: 'idle'` over a live agent and nothing re-derived it.
- **(b) output streams but the indicator still never turns busy.** The `process:*` listeners route by `{agentId}-ai-{tabId}` and never needed the renderer's bookkeeping, so the transcript keeps filling in correctly. Only the indicators were lost, and only the renderer that originally spawned the turn ever set them.

## The fix

Busy state is not something to remember across a reload, it is something to *ask for*. The process table in main is the only authority on what is running right now, so after sessions load we probe it and re-derive the indicators.

- `resolveLiveAiTurns` / `applyLiveAiTurns` (`utils/liveTurnReattach.ts`) turn the process table back into session state. Terminals and Cue runs are excluded, since neither occupies an agent's sequential AI turn; forced-parallel `-fp-<n>` turns resolve back to their originating tab.
- `fetchLiveAiTurns` (`services/process.ts`) is the whole-table counterpart to the existing `probeSessionAiProcesses`, which asks about a single agent. One round trip beats one per session. It returns `null` on probe failure so "I could not find out" stays distinguishable from "nothing is running" - an empty array would read as the latter and wrongly force everything idle.

### Invariants worth calling out

- **The reconcile only ever moves state toward busy.** Clearing stays with the exit listener, which already verifies against this same process table. Doing it here as well would race a turn spawned between the probe and the store write and cancel its indicator.
- **A restored limit pause (`state: 'error'`) is left alone**, so the auto-resume coordinator still finds it.
- **A turn whose tab is gone still marks the agent busy.** The Left Bar dot is the symptom the user reads first, and an agent that is demonstrably working should not be drawn idle just because the pane is closed.
- **Window scoping is honored** via the existing `useOwnedSessionGate`, so a secondary Electron window can't light up an agent the primary owns. Web-desktop's gate is a permit-all by design, which is what makes the reconcile work there.
- **The probe is not awaited.** It must not hold the splash; painting idle for one frame and correcting beats waiting on IPC to paint at all.

On a cold Electron start the process table is empty, so this costs one IPC round trip and changes nothing there.

## Testing

- `src/__tests__/renderer/utils/liveTurnReattach.test.ts` - 10 tests over the pure resolve/apply logic (forced-parallel, terminal/Cue exclusion, earliest start time, closed tab, limit pause, no-op identity).
- `src/__tests__/renderer/services/process.test.ts` - 3 tests for `fetchLiveAiTurns`, including the null-on-failure contract.
- `src/__tests__/renderer/hooks/session/useSessionRestoration.reattach.test.tsx` - 3 tests pinning the wiring end to end. The idle-case test feeds the same `busy` fixture and asserts it lands idle, which is the control proving the busy-case test exercises the reattach rather than leftover fixture state.

`npm run lint` clean; `npx eslint src/` shows the same 5 pre-existing warnings as the base tree. Full suite: 40,243 passed. `src/__tests__/main/cue/cue-engine.test.ts` is flaky under full-suite parallelism and fails on the **base tree too** (verified by stashing); it passes in isolation both with and without this change.

## Note on the base branch

Branched off `rc`, not `main`. `src/web-desktop/` does not exist on `main` (0.17.4), and the report is against 0.18.5-RC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored active AI session indicators after page reloads.
  * Running agents and tabs now correctly display as busy, including AI status, process ID, and start time.
  * Sessions without active processes remain idle, while existing pause states and unrelated sessions are preserved.
  * Improved handling when live-process status checks are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->