### PR TITLE
test(cli): stop agent-spawner tests reading the developer's own shell env

### DIFF
--- a/docs/agent-guides/TEST-PATTERNS.md
+++ b/docs/agent-guides/TEST-PATTERNS.md
@@ -289,6 +289,42 @@ vi.mock('../../../cli/services/agent-spawner', () => ({
 }));
 ```
 
+### Isolating a Test From the Developer's Shell (`isolateAgentEnv`)
+
+Agent env defaults are **shell-wins by design**: `applyEnvLayers` in
+`src/cli/services/agent-spawner.ts` layers an agent's `defaultEnvVars` /
+`batchModeEnvVars` UNDER `process.env`, so a user who exported a value keeps it.
+That means any assertion about a DEFAULT value is really an assertion about
+whatever the test runner's shell happened to export, and it fails on that
+machine only.
+
+This has already bitten once: Claude Code exports
+`CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=0` into the shells it runs, so the two
+`agent-spawner.test.ts` tests asserting the `'1'` default failed for anyone
+running the suite from a Maestro terminal or an agent shell, passed in CI, and
+blocked the pre-push hook on a phantom failure.
+
+Call `isolateAgentEnv()` in the body of any `describe` that asserts a default
+env value. It registers its own `beforeEach` / `afterEach`, so it belongs at
+collection time, not inside another hook:
+
+```typescript
+import { isolateAgentEnv } from '../../helpers/agentEnvIsolation';
+
+describe('spawnAgent', () => {
+	isolateAgentEnv();
+	// ...
+});
+```
+
+A test that deliberately exercises the shell-wins path just sets the variable in
+its own body - that runs after the `beforeEach`, and the `afterEach` restores
+the real value, so no `try`/`finally` dance is needed. Do NOT hand-roll another
+save / delete / restore block; there were three near-identical copies in one
+file and only some of them were applied where they mattered. When an agent
+definition gains a new `defaultEnvVars` key, add it to
+`SHELL_OVERRIDABLE_AGENT_ENV_KEYS`.
+
 ### Mock Factories
 
 #### Mock Session

--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -126,6 +126,7 @@ import {
 	spawnAgent,
 	AgentResult,
 } from '../../../cli/services/agent-spawner';
+import { isolateAgentEnv } from '../../helpers/agentEnvIsolation';
 
 describe('agent-spawner', () => {
 	beforeEach(() => {
@@ -811,6 +812,12 @@ Some text with [x] in it that's not a checkbox
 	});
 
 	describe('spawnAgent', () => {
+		// Agent env defaults are shell-wins by design, so a value exported by the
+		// developer's own shell would otherwise be what the default assertions
+		// below actually measure. Tests that exercise the shell-wins path set the
+		// variable themselves, inside the test body, after this has run.
+		isolateAgentEnv();
+
 		beforeEach(() => {
 			mockSpawn.mockReturnValue(mockChild);
 		});
@@ -1579,26 +1586,18 @@ Some text with [x] in it that's not a checkbox
 		});
 
 		it('should let a pre-set CLAUDE_CODE_DISABLE_BACKGROUND_TASKS from shell env win', async () => {
-			const originalValue = process.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS;
+			// `isolateAgentEnv` restores the real value after the test.
 			process.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS = '0';
 
-			try {
-				const resultPromise = spawnAgent('claude-code', '/project', 'prompt');
-				await new Promise((resolve) => setTimeout(resolve, 0));
+			const resultPromise = spawnAgent('claude-code', '/project', 'prompt');
+			await new Promise((resolve) => setTimeout(resolve, 0));
 
-				const [, , options] = mockSpawn.mock.calls[0];
-				expect(options.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS).toBe('0');
+			const [, , options] = mockSpawn.mock.calls[0];
+			expect(options.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS).toBe('0');
 
-				mockStdout.emit('data', Buffer.from('{"type":"result","result":"Done"}\n'));
-				mockChild.emit('close', 0);
-				await resultPromise;
-			} finally {
-				if (originalValue === undefined) {
-					delete process.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS;
-				} else {
-					process.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS = originalValue;
-				}
-			}
+			mockStdout.emit('data', Buffer.from('{"type":"result","result":"Done"}\n'));
+			mockChild.emit('close', 0);
+			await resultPromise;
 		});
 	});
 
@@ -1836,6 +1835,10 @@ Some text with [x] in it that's not a checkbox
 	const CODEX_INIT = () => JSON.stringify({ type: 'task_started' }) + '\n';
 
 	describe('spawnAgent: local config overrides', () => {
+		// Same reason as the `spawnAgent` suite above: this one asserts what an
+		// agent's `defaultEnvVars` produce, which the ambient shell can override.
+		isolateAgentEnv();
+
 		beforeEach(() => {
 			mockSpawn.mockReturnValue(mockChild);
 		});
@@ -1924,36 +1927,25 @@ Some text with [x] in it that's not a checkbox
 			// the shell already exports. OpenCode has OPENCODE_CONFIG_CONTENT in
 			// its defaultEnvVars - if the shell sets it, that shell value should
 			// survive to the spawned process.
-			const prev = process.env.OPENCODE_CONFIG_CONTENT;
+			// `isolateAgentEnv` restores the real value after the test.
 			process.env.OPENCODE_CONFIG_CONTENT = 'shell-wins';
 
-			try {
-				const p = spawnAgent('opencode', '/p', 'hi');
-				await driveSpawnToCompletion(p, 0);
+			const p = spawnAgent('opencode', '/p', 'hi');
+			await driveSpawnToCompletion(p, 0);
 
-				const { options } = spawnCall();
-				expect(options.env.OPENCODE_CONFIG_CONTENT).toBe('shell-wins');
-			} finally {
-				if (prev === undefined) delete process.env.OPENCODE_CONFIG_CONTENT;
-				else process.env.OPENCODE_CONFIG_CONTENT = prev;
-			}
+			const { options } = spawnCall();
+			expect(options.env.OPENCODE_CONFIG_CONTENT).toBe('shell-wins');
 		});
 
 		it('agent defaultEnvVars is applied when the shell has not set it', async () => {
 			// Complements the "shell wins" test: when the shell does NOT export
 			// the key, the agent default must still reach the spawned process.
-			const prev = process.env.OPENCODE_CONFIG_CONTENT;
-			delete process.env.OPENCODE_CONFIG_CONTENT;
+			// `isolateAgentEnv` has already cleared the key for this test.
+			const p = spawnAgent('opencode', '/p', 'hi');
+			await driveSpawnToCompletion(p, 0);
 
-			try {
-				const p = spawnAgent('opencode', '/p', 'hi');
-				await driveSpawnToCompletion(p, 0);
-
-				const { options } = spawnCall();
-				expect(options.env.OPENCODE_CONFIG_CONTENT).toContain('"permission"');
-			} finally {
-				if (prev !== undefined) process.env.OPENCODE_CONFIG_CONTENT = prev;
-			}
+			const { options } = spawnCall();
+			expect(options.env.OPENCODE_CONFIG_CONTENT).toContain('"permission"');
 		});
 
 		it('applies customModel via configOptions argBuilder for Claude', async () => {

--- a/src/__tests__/helpers/agentEnvIsolation.ts
+++ b/src/__tests__/helpers/agentEnvIsolation.ts
@@ -1,0 +1,71 @@
+/**
+ * Isolate a test suite from agent env vars the developer's own shell exports.
+ *
+ * Every agent default in `definitions.ts` (`defaultEnvVars`, `batchModeEnvVars`)
+ * is deliberately SHELL-WINS: `applyEnvLayers` in `agent-spawner.ts` layers the
+ * defaults UNDER `process.env`, so a user who exported a value keeps it. That is
+ * correct behavior with an unpleasant consequence for tests - an assertion about
+ * the DEFAULT silently becomes an assertion about whatever the runner's shell
+ * happened to export, and it fails on that machine only.
+ *
+ * This is not hypothetical. Claude Code exports
+ * `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=0` into the shells it runs, so the two
+ * tests asserting the `'1'` default fail for anyone running the suite from a
+ * Maestro terminal or an agent shell, and pass in CI. That reads as a real
+ * regression and blocks the pre-push hook on a phantom failure.
+ *
+ * Call `isolateAgentEnv()` in the body of any `describe` that asserts a DEFAULT
+ * env value - it registers its own `beforeEach` / `afterEach`, so it must run at
+ * collection time rather than inside another hook. A test that deliberately
+ * exercises the shell-wins path sets the variable inside its own body, after the
+ * `beforeEach` has run, so it is unaffected.
+ *
+ * Usage:
+ *
+ *   import { isolateAgentEnv } from '../../helpers/agentEnvIsolation';
+ *
+ *   describe('spawnAgent', () => {
+ *     isolateAgentEnv();
+ *     ...
+ *   });
+ */
+
+import { beforeEach, afterEach } from 'vitest';
+
+/**
+ * Env vars an agent definition supplies a default for, and which the spawner
+ * therefore lets the ambient shell override. Keep in sync with `defaultEnvVars`
+ * / `batchModeEnvVars` / `readOnlyEnvOverrides` in `src/main/agents/definitions.ts`.
+ */
+export const SHELL_OVERRIDABLE_AGENT_ENV_KEYS = [
+	'CLAUDE_CODE_DISABLE_BACKGROUND_TASKS',
+	'OPENCODE_CONFIG_CONTENT',
+] as const;
+
+/**
+ * Delete every shell-overridable agent env var before each test in the enclosing
+ * suite, so assertions see the agent definition's own default rather than the
+ * developer's shell, and restore the real values afterwards.
+ */
+export function isolateAgentEnv(keys: readonly string[] = SHELL_OVERRIDABLE_AGENT_ENV_KEYS): void {
+	const saved = new Map<string, string | undefined>();
+
+	beforeEach(() => {
+		saved.clear();
+		for (const key of keys) {
+			saved.set(key, process.env[key]);
+			delete process.env[key];
+		}
+	});
+
+	afterEach(() => {
+		for (const [key, value] of saved) {
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+		saved.clear();
+	});
+}

--- a/src/__tests__/helpers/index.ts
+++ b/src/__tests__/helpers/index.ts
@@ -5,6 +5,7 @@
  * across many test files.
  */
 
+export { isolateAgentEnv, SHELL_OVERRIDABLE_AGENT_ENV_KEYS } from './agentEnvIsolation';
 export { createMockAITab, createMockFileTab } from './mockTab';
 export { createMockSession } from './mockSession';
 export { installLocalStorageMock } from './mockLocalStorage';


### PR DESCRIPTION
## The bug

Agent env defaults are **shell-wins by design**: `applyEnvLayers` in `src/cli/services/agent-spawner.ts` layers an agent's `defaultEnvVars` UNDER `process.env`, so a value the user exported survives to the spawned process. There is a test asserting exactly that behavior, so it is intended, not incidental.

Two tests in `src/__tests__/cli/services/agent-spawner.test.ts` assert the `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS='1'` **default** without clearing the ambient value first. They therefore measure whatever the runner's shell exported rather than the agent definition.

Claude Code exports that variable as `0` into the shells it runs. So the suite fails for anyone running it from a Maestro terminal or an agent shell, and passes in CI. Because the pre-push hook runs the full suite, this presents as a real regression that blocks every push from those shells, on a change that never touched the spawner.

```
CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=0  vitest  ->  2 failed | 125 passed
env -u CLAUDE_CODE_DISABLE_BACKGROUND_TASKS vitest  ->  127 passed
```

## The fix

`isolateAgentEnv()` in `src/__tests__/helpers/agentEnvIsolation.ts` clears every shell-overridable agent env key before each test in the enclosing suite and restores the real values afterwards. Applied to the two suites that assert env defaults.

Three hand-rolled save/delete/restore blocks in that file collapse into it. Notably one of them was already doing this correctly, which is why the OpenCode default test never broke while the Claude ones did: the pattern existed, it just wasn't applied where it mattered.

`SHELL_OVERRIDABLE_AGENT_ENV_KEYS` lists the keys agent definitions supply defaults for (`CLAUDE_CODE_DISABLE_BACKGROUND_TASKS`, `OPENCODE_CONFIG_CONTENT`), so a future `defaultEnvVars` entry has one place to be registered.

No production code changes. The shell-wins behavior is untouched, and the test that pins it now sets the variable in its own body and relies on the helper to restore it.

## Verification

| Condition | Before | After |
|---|---|---|
| `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=0` (agent shell) | 2 failed / 127 | **127 passed** |
| `OPENCODE_CONFIG_CONTENT=junk` + the above | 2 failed / 127 | **127 passed** |
| variable unset (CI) | 127 passed | **127 passed** |

Full `src/__tests__/cli/` directory: 1029 passed, 1 skipped. `tsc --noEmit` and ESLint clean. The pre-push hook ran the full suite green.

Documented in `docs/agent-guides/TEST-PATTERNS.md` under a new "Isolating a Test From the Developer's Shell" section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability when developer shell environment variables could affect agent configuration checks.
  * Ensured environment settings are properly isolated and restored between tests.

* **Documentation**
  * Added guidance for isolating agent environment variables in tests.
  * Documented how shell-provided values interact with agent defaults and how to test both behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->