### PR TITLE
fix: stop a passive tab-inventory sync from stealing the active agent

### DIFF
--- a/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
@@ -1004,6 +1004,59 @@ describe('useRemoteIntegration', () => {
 				{ type: 'ai', id: 'tab-2' },
 			]);
 		});
+
+		// Issue #1496: the `tabs_changed` broadcast fires on any agent's tab hash
+		// change (which includes `state` and `hasUnread`), so a background agent
+		// starting a turn used to drag the reader onto it.
+		it('does not switch agents for a passive tab inventory sync', () => {
+			const session = createMockSession({
+				id: 'session-1',
+				aiTabs: [createMockTab({ id: 'tab-1' }), createMockTab({ id: 'tab-2' })],
+				activeTabId: 'tab-1',
+			});
+			const deps = createDeps({ sessions: [session], activeSessionId: 'other-session' });
+
+			renderHook(() => useRemoteIntegration(deps));
+
+			act(() => {
+				onRemoteSelectTabHandler?.('session-1', 'tab-2', [
+					{
+						id: 'tab-2',
+						agentSessionId: null,
+						name: 'Busy background tab',
+						starred: false,
+						inputValue: '',
+						createdAt: 1700000001000,
+						state: 'busy',
+					},
+				]);
+			});
+
+			expect(deps.setActiveSessionId).not.toHaveBeenCalled();
+			// The inventory still reconciles - it is only the view that stays put.
+			const updated = useSessionStore.getState().sessions.find((s) => s.id === 'session-1');
+			expect(updated?.aiTabs.map((tab) => tab.id)).toEqual(['tab-2']);
+			expect(updated?.activeTabId).toBe('tab-1');
+		});
+
+		it('still follows an explicit tab selection with no inventory attached', () => {
+			const session = createMockSession({
+				id: 'session-1',
+				aiTabs: [createMockTab({ id: 'tab-1' }), createMockTab({ id: 'tab-2' })],
+				activeTabId: 'tab-1',
+			});
+			const deps = createDeps({ sessions: [session], activeSessionId: 'other-session' });
+
+			renderHook(() => useRemoteIntegration(deps));
+
+			act(() => {
+				onRemoteSelectTabHandler?.('session-1', 'tab-2');
+			});
+
+			expect(deps.setActiveSessionId).toHaveBeenCalledWith('session-1');
+			const updated = useSessionStore.getState().sessions.find((s) => s.id === 'session-1');
+			expect(updated?.activeTabId).toBe('tab-2');
+		});
 	});
 
 	describe('remote new tab', () => {

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -459,19 +459,37 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 		);
 
 		// Handle remote tab selection from web interface
-		// This also switches to the session if not already active
+		//
+		// This channel carries TWO different asks and they must not be treated
+		// alike (see `src/shared/focusPlacement.ts` for the rule):
+		//
+		//   - an explicit `select_tab` (no third argument) is a human tapping a
+		//     tab in a remote client, so it moves the view: switch agent, then
+		//     activate the tab.
+		//   - the legacy `tabs_changed` packet (third argument present) is a
+		//     PASSIVE inventory broadcast. The desktop re-broadcasts it whenever
+		//     any agent's tab hash changes, and that hash includes `state` and
+		//     `hasUnread` - so a background agent merely starting a turn or
+		//     picking up an unread emits one. Treating it as a selection is what
+		//     let background activity yank the reader onto whichever of ninety
+		//     agents happened to move (issue #1496).
+		//
+		// A passive sync therefore reconciles data only. It never changes the
+		// active agent, and it only follows the desktop's active tab for the
+		// agent the user is already looking at, where doing so cannot pull them
+		// away from anything.
 		const unsubscribeSelectTab = window.maestro.process.onRemoteSelectTab(
 			(sessionId, tabId, remoteTabs) => {
-				// First, switch to the session if not already active
+				const isInventorySync = remoteTabs !== undefined;
 				const currentActiveId = activeSessionIdRef.current;
-				if (currentActiveId !== sessionId) {
+				if (!isInventorySync && currentActiveId !== sessionId) {
 					setActiveSessionId(sessionId);
 				}
+				const mayFollowTab = !isInventorySync || currentActiveId === sessionId;
 
-				// The legacy `tabs_changed` web packet carries the complete desktop tab
-				// inventory as its third argument. Reconcile that snapshot here so the
-				// browser adds and removes tabs instead of only following an ID it may not
-				// have. Existing tabs retain renderer-only data such as logs and drafts.
+				// Reconcile the snapshot so the browser adds and removes tabs instead of
+				// only following an ID it may not have. Existing tabs retain
+				// renderer-only data such as logs and drafts.
 				updateSessionWith(sessionId, (s) => {
 					let updatedSession = s;
 					if (remoteTabs) {
@@ -510,7 +528,7 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 						};
 					}
 
-					if (!updatedSession.aiTabs.some((tab) => tab.id === tabId)) {
+					if (!mayFollowTab || !updatedSession.aiTabs.some((tab) => tab.id === tabId)) {
 						return updatedSession;
 					}
 					return { ...updatedSession, ...aiTabFocusFields(tabId) };

--- a/src/web-desktop/electron-shim.ts
+++ b/src/web-desktop/electron-shim.ts
@@ -139,10 +139,15 @@ class BridgeClient {
 			} else if (
 				msg.type === 'tabs_changed' &&
 				typeof msg.sessionId === 'string' &&
-				typeof msg.activeTabId === 'string'
+				typeof msg.activeTabId === 'string' &&
+				// The tab inventory is what marks this as a passive sync rather than a
+				// human selecting a tab, and the listener tells the two apart by its
+				// presence. A `tabs_changed` without one would arrive looking like a
+				// selection and move the view, so drop it instead of routing it.
+				Array.isArray(msg.aiTabs)
 			) {
 				channel = 'remote:selectTab';
-				args = [msg.sessionId, msg.activeTabId, Array.isArray(msg.aiTabs) ? msg.aiTabs : undefined];
+				args = [msg.sessionId, msg.activeTabId, msg.aiTabs];
 			}
 			if (channel) {
 				const set = this.listeners.get(channel);


### PR DESCRIPTION
closes #1496

## The path

`remote:selectTab` carries two different asks on one channel, and the listener in `useRemoteIntegration.ts` handled them alike:

- an explicit `select_tab` (no third argument) is a human tapping a tab in a remote client, and moving the view is the whole point;
- the legacy `tabs_changed` packet (third argument present) is a **passive** broadcast. `useRemoteIntegration`'s 500ms sweep re-emits it for *any* agent whose tab hash changes, and that hash is built from `state` and `hasUnread` - so a background agent merely starting a turn or picking up an unread fires one.

Both landed on `setActiveSessionId(sessionId)` + `aiTabFocusFields(tabId)`. That is exactly the reported symptom: background agent activity switches the visible agent and the tab inside it, with no way to tell which of ninety agents took the view.

This is also the call site the reporter fingerprinted out of the shipped bundle (`if (currentActiveId !== sessionId) { setActiveSessionId(sessionId); }` followed by a comment starting "The leg...").

## The fix

A passive sync reconciles data only, per the rule already written down in `src/shared/focusPlacement.ts`:

- it never changes the active agent;
- it follows the desktop's active tab only for the agent that is *already* on screen, where doing so cannot pull the user away from anything;
- the tab inventory still reconciles exactly as before, so nothing is lost from the remote client's tab list.

An explicit `select_tab` is untouched and still switches agent and activates the tab.

`src/web-desktop/electron-shim.ts` now drops a `tabs_changed` that carries no inventory instead of routing it onward. The inventory's presence is what the listener tells the two asks apart by, so an inventory-less `tabs_changed` would arrive looking like a selection and move the view.

## Branch base

Based on `rc`, not `main`: `src/web-desktop/` and the three-argument `onRemoteSelectTab` are both rc-only, so the defect does not exist on `main` and the fix cannot be expressed there.

## Not covered here

`maestro:refreshAutoRunDocs` in `useAppRemoteEventListeners.ts` switches the active agent purely to trigger a refresh effect, which is the same class of defect. It is **already fixed on `main`** (with a `background` field threaded through the verb) and will arrive on `rc` with the next merge, so it is deliberately left alone here to avoid a conflicting second fix.

## Validation

- `npm run lint` (all three tsconfigs) clean
- `npx eslint` clean, `prettier --check` clean
- `npx vitest run src/__tests__/renderer/hooks/ src/__tests__/main/preload/process/tabRemote.test.ts src/__tests__/integration/remote-control.integration.test.ts` - 243 files, 5620 passed
- two new tests in `useRemoteIntegration.test.ts`: a passive inventory sync for a non-active agent reconciles tabs without calling `setActiveSessionId` or moving `activeTabId`; an explicit selection with no inventory still switches both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved remote tab synchronization so background tab updates no longer switch the currently viewed session or active tab.
  - Explicit remote tab selections now correctly switch to the selected session and tab.
  - Prevented incomplete tab synchronization messages from being treated as user selections.
  - Improved tab focus behavior to avoid applying focus changes when following a remote tab is not permitted.

- **Tests**
  - Added coverage for passive tab inventory updates and explicit remote tab selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->