### PR TITLE
Gate native OMP client on public protocol conformance

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
 		"lint": "tsc -p tsconfig.lint.json && tsc -p tsconfig.main.json --noEmit && tsc -p tsconfig.cli.json --noEmit",
 		"lint:eslint": "eslint src/ && eslint -c eslint.dashes.config.mjs src/__tests__ scripts",
 		"lint:doc-refs": "node scripts/check-doc-refs.mjs",
+		"test:omp-protocol": "node --test scripts/omp-rpc-protocol.test.mjs scripts/omp-rpc-conformance.test.mjs",
+		"probe:omp-protocol": "node scripts/omp-rpc-conformance.mjs",
 		"format": "prettier --write \"src/**/*.{ts,tsx}\"",
 		"format:all": "prettier --write .",
 		"format:check": "prettier --check \"src/**/*.{ts,tsx}\"",

--- a/scripts/fixtures/omp-rpc-18.1.6-baseline.json
+++ b/scripts/fixtures/omp-rpc-18.1.6-baseline.json
@@ -1,0 +1,111 @@
+{
+	"schemaVersion": 1,
+	"omp": {
+		"version": "18.1.6",
+		"sha256": "99a824d60aa93f28a4d3e863acc7d47ffb5be51a1653f0d12aec1af4806b4b76",
+		"protocol": "rpc",
+		"startupProtocolVersion": 1,
+		"supportedProtocolVersions": [1, 2]
+	},
+	"transport": {
+		"serverMaxFrameBytes": 1048576,
+		"serverMaxReassembledFrameBytes": 67108864,
+		"maestroMaxFrameBytes": 1048576,
+		"maestroMaxReassembledFrameBytes": 8388608
+	},
+	"requiredCommandTypes": [
+		"prompt",
+		"steer",
+		"follow_up",
+		"abort",
+		"abort_and_prompt",
+		"new_session",
+		"negotiate_protocol",
+		"get_state",
+		"set_fast_mode",
+		"get_available_commands",
+		"set_todos",
+		"set_host_tools",
+		"set_host_uri_schemes",
+		"set_subagent_subscription",
+		"get_subagents",
+		"get_subagent_messages",
+		"set_model",
+		"cycle_model",
+		"get_available_models",
+		"set_thinking_level",
+		"cycle_thinking_level",
+		"set_steering_mode",
+		"set_follow_up_mode",
+		"set_interrupt_mode",
+		"compact",
+		"set_auto_compaction",
+		"set_auto_retry",
+		"abort_retry",
+		"bash",
+		"abort_bash",
+		"get_session_stats",
+		"export_html",
+		"switch_session",
+		"branch",
+		"get_branch_messages",
+		"get_last_assistant_text",
+		"set_session_name",
+		"handoff",
+		"get_messages",
+		"get_messages_page",
+		"get_login_providers",
+		"login"
+	],
+	"requiredEventTypes": [
+		"agent_start",
+		"agent_end",
+		"turn_start",
+		"turn_end",
+		"message_start",
+		"message_update",
+		"message_end",
+		"tool_execution_start",
+		"tool_execution_update",
+		"tool_execution_end",
+		"model_changed",
+		"thinking_level_changed",
+		"goal_updated",
+		"available_commands_update",
+		"prompt_result",
+		"extension_ui_request",
+		"host_tool_call",
+		"host_tool_cancel"
+	],
+	"requiredCases": ["A01", "A02", "A03", "A04", "A05", "A06", "A07", "A08", "A09", "A10", "A11"],
+	"powerUserCapabilities": [
+		{
+			"id": "G1",
+			"name": "host-created workers",
+			"required": true,
+			"expected": "unsupported",
+			"missingProtocolPrimitive": "create_worker"
+		},
+		{
+			"id": "G2",
+			"name": "direct worker steering and messaging",
+			"required": true,
+			"expected": "unsupported",
+			"missingProtocolPrimitive": "command_worker"
+		},
+		{
+			"id": "G3",
+			"name": "completed worker transcript visibility",
+			"required": true,
+			"expected": "supported",
+			"requiredSignal": "get_subagent_messages contains completed worker message after terminal root completion"
+		},
+		{
+			"id": "G5",
+			"name": "deterministic abort-and-prompt completion",
+			"required": true,
+			"expected": "supported",
+			"requiredSignal": "response.data.agentInvoked or prompt_result"
+		}
+	]
+}

--- a/scripts/fixtures/omp-rpc-18.1.6-observed.json
+++ b/scripts/fixtures/omp-rpc-18.1.6-observed.json
@@ -1,0 +1,333 @@
+{
+	"schemaVersion": 1,
+	"startedAt": "2026-09-04T01:57:05.415Z",
+	"finishedAt": "2026-09-04T01:58:51.000Z",
+	"executable": "<explicit-omp-executable>",
+	"workspace": "<isolated-workspace>",
+	"harnessSha256": "244e633cad7485595118b6109c1c97d813b25a61a495458390d41c69126129ba",
+	"sourceRevision": "8893b9a97bac6dc84754b50ccf9735465fe6ce5c",
+	"fixtureRevision": 1,
+	"maestro": {
+		"version": "0.18.5-RC",
+		"hostContract": "run-fleet/v1-placeholder"
+	},
+	"adapter": {
+		"id": "official.omp",
+		"version": "unreleased-placeholder"
+	},
+	"host": {
+		"platform": "win32",
+		"architecture": "x64",
+		"release": "10.0.26200"
+	},
+	"omp": {
+		"version": "18.1.6",
+		"sha256": "99a824d60aa93f28a4d3e863acc7d47ffb5be51a1653f0d12aec1af4806b4b76",
+		"identityStatus": "pass",
+		"identityReasons": []
+	},
+	"protocol": {
+		"name": "rpc",
+		"requestedVersion": 2,
+		"ready": {
+			"protocolVersion": 1,
+			"supportedProtocolVersions": [1, 2],
+			"maxFrameBytes": 1048576,
+			"maxReassembledFrameBytes": 67108864
+		},
+		"documentationSha256": "42b1744f652601efd6bc8c8f0ea4c14bda49499fca2c9782882389447d09b230"
+	},
+	"sourcePolicy": {
+		"allowed": ["OMP --help", "OMP --version", "omp://rpc.md", "RPC stdio", "ACP stdio"],
+		"forbidden": ["private OMP session files", "private OMP settings", "OMP implementation modules"]
+	},
+	"options": {
+		"live": true
+	},
+	"cases": [
+		{
+			"id": "A01",
+			"title": "RPC identity, negotiation, framing, and limits",
+			"required": true,
+			"status": "pass",
+			"durationMs": 1560,
+			"evidence": {
+				"version": "18.1.6",
+				"sha256": "99a824d60aa93f28a4d3e863acc7d47ffb5be51a1653f0d12aec1af4806b4b76",
+				"protocolVersions": [1, 2],
+				"serverLimits": {
+					"maxFrameBytes": 1048576,
+					"maxReassembledFrameBytes": 67108864
+				},
+				"maestroLogicalLimit": 8388608,
+				"documentedCommandCount": 42,
+				"documentedEventCount": 18,
+				"helpAdvertisesNoSession": true,
+				"transportComparison": {
+					"selected": "rpc",
+					"rpc": {
+						"advertised": true,
+						"liveStateRead": true
+					},
+					"rpcUi": {
+						"advertised": true,
+						"liveStateRead": true,
+						"protocolVersions": [1, 2]
+					},
+					"acp": {
+						"advertised": true,
+						"selected": false,
+						"reason": "Standard client compatibility surface; RPC exposes the OMP-specific host-control contract."
+					}
+				}
+			}
+		},
+		{
+			"id": "A02",
+			"title": "Session identity and public reattachment",
+			"required": true,
+			"status": "pass",
+			"durationMs": 6158,
+			"evidence": {
+				"stableSessionId": true,
+				"stableSessionFile": true,
+				"createAndResumeUsedPublicRpcStateOnly": true
+			}
+		},
+		{
+			"id": "A03",
+			"title": "Root stream, snapshot, paging, and replay",
+			"required": true,
+			"status": "pass",
+			"durationMs": 18167,
+			"evidence": {
+				"frameCounts": {
+					"agent_end": 1,
+					"agent_start": 1,
+					"extension_ui_request": 1,
+					"message_end": 2,
+					"message_start": 2,
+					"message_update": 481,
+					"response": 2,
+					"turn_end": 1,
+					"turn_start": 1
+				},
+				"messageCount": 2,
+				"snapshotSha256": "a4e59621d68577f18d85082f6e4c8a45b2eb0699b787324e927771de559f2a4a",
+				"terminalAgentEnd": true,
+				"busyErrorCode": "session_busy",
+				"staleCursorCode": "stale_cursor"
+			}
+		},
+		{
+			"id": "A04",
+			"title": "Worker registry, hierarchy, and transcript surface",
+			"required": true,
+			"status": "fail",
+			"durationMs": 45463,
+			"error": "public Worker transcript did not expose the completed worker message"
+		},
+		{
+			"id": "A05",
+			"title": "Steering, cancellation, and abort-and-prompt",
+			"required": true,
+			"status": "fail",
+			"durationMs": 2442,
+			"error": "abort_and_prompt was accepted without a correlated completion signal; responseKeys=id,type,command,success; dataKeys=; promptResultCount=0; promptResultIds="
+		},
+		{
+			"id": "A06",
+			"title": "Approval callback and restrictive launch policy",
+			"required": true,
+			"status": "pass",
+			"durationMs": 12892,
+			"evidence": {
+				"requestCount": 1,
+				"methods": ["select"],
+				"rejectedByHost": true,
+				"restrictiveLaunch": true,
+				"acpPermissionSurface": "documented-standard; RPC is the selected adapter transport"
+			}
+		},
+		{
+			"id": "A07",
+			"title": "Dynamic models, providers, thinking, and effective state",
+			"required": true,
+			"status": "pass",
+			"durationMs": 248,
+			"evidence": {
+				"modelCount": 766,
+				"providerCount": 14,
+				"modelChangeRoundTrip": true,
+				"thinkingChangeRoundTrip": true,
+				"fastModeReadbackFields": ["active", "enabled"],
+				"loginProviderCount": 70
+			}
+		},
+		{
+			"id": "A08",
+			"title": "Todos, commands, host tools, stats, and compaction surface",
+			"required": true,
+			"status": "pass",
+			"durationMs": 15224,
+			"evidence": {
+				"todoRoundTrip": true,
+				"hostToolNames": ["maestro_probe"],
+				"hostToolCallbackCount": 1,
+				"hostToolCallFields": ["arguments", "id", "toolCallId", "toolName", "type"],
+				"hostUriSchemes": ["maestroprobe"],
+				"commandCount": 43,
+				"statsFields": [
+					"assistantMessages",
+					"contextUsage",
+					"cost",
+					"premiumRequests",
+					"sessionId",
+					"tokens",
+					"toolCalls",
+					"toolResults",
+					"totalMessages",
+					"userMessages"
+				],
+				"contextUsageFields": ["contextWindow", "percent", "tokens"]
+			}
+		},
+		{
+			"id": "A09",
+			"title": "Evidence, artifact, process, worktree, and export surface",
+			"required": true,
+			"status": "pass",
+			"durationMs": 163,
+			"evidence": {
+				"bashResponseFields": [
+					"cancelled",
+					"exitCode",
+					"output",
+					"outputBytes",
+					"outputLines",
+					"totalBytes",
+					"totalLines",
+					"truncated",
+					"workingDir"
+				],
+				"bashEffectObserved": true,
+				"exportStatus": "unavailable: export_html failed: Cannot export in-memory session to HTML",
+				"discoveredToolSurfaces": {
+					"file": false,
+					"browser": false,
+					"worktree": false,
+					"process": false,
+					"pty": false,
+					"artifact": false
+				},
+				"providerOwnedToolEvents": true
+			}
+		},
+		{
+			"id": "A10",
+			"title": "Typed errors and fail-closed capability changes",
+			"required": true,
+			"status": "pass",
+			"durationMs": 133,
+			"evidence": {
+				"parseFailure": {
+					"type": "response",
+					"idPresent": false,
+					"command": "parse",
+					"success": false,
+					"keys": ["command", "error", "success", "type"]
+				},
+				"unknownCommand": {
+					"type": "response",
+					"idPresent": false,
+					"command": "maestro_unknown_command",
+					"success": false,
+					"keys": ["command", "error", "success", "type"]
+				},
+				"staleCursorCode": "stale_cursor",
+				"busyCodeObservedDuringLiveRun": "session_busy",
+				"providerFailure": {
+					"type": "response",
+					"idPresent": true,
+					"command": "set_model",
+					"success": false,
+					"keys": ["command", "error", "id", "success", "type"]
+				},
+				"stateUnchangedAfterRejectedMutation": true
+			}
+		},
+		{
+			"id": "A11",
+			"title": "Stable power-user protocol gaps",
+			"required": false,
+			"status": "fail",
+			"durationMs": 0,
+			"evidence": {
+				"requirements": [
+					{
+						"id": "G1",
+						"name": "host-created workers",
+						"status": "unsupported",
+						"reason": "RPC has observation APIs but no create_worker command."
+					},
+					{
+						"id": "G2",
+						"name": "direct worker steering and messaging",
+						"status": "unsupported",
+						"reason": "RPC steering targets the root session and exposes no command_worker command."
+					},
+					{
+						"id": "G3",
+						"name": "completed worker transcript visibility",
+						"status": "unsupported",
+						"reason": "get_subagent_messages returned no completed worker message after terminal root completion."
+					},
+					{
+						"id": "G5",
+						"name": "deterministic abort-and-prompt completion",
+						"status": "ambiguous",
+						"reason": "Command acceptance alone does not prove terminal abort-and-prompt completion."
+					}
+				]
+			}
+		}
+	],
+	"capabilities": [
+		{
+			"id": "G1",
+			"name": "host-created workers",
+			"status": "unsupported",
+			"reason": "RPC has observation APIs but no create_worker command."
+		},
+		{
+			"id": "G2",
+			"name": "direct worker steering and messaging",
+			"status": "unsupported",
+			"reason": "RPC steering targets the root session and exposes no command_worker command."
+		},
+		{
+			"id": "G3",
+			"name": "completed worker transcript visibility",
+			"status": "unsupported",
+			"reason": "get_subagent_messages returned no completed worker message after terminal root completion."
+		},
+		{
+			"id": "G5",
+			"name": "deterministic abort-and-prompt completion",
+			"status": "ambiguous",
+			"reason": "Command acceptance alone does not prove terminal abort-and-prompt completion."
+		}
+	],
+	"deviations": [
+		{
+			"id": "A09_RESOURCE_SURFACE",
+			"detail": "Dedicated artifact, browser, worktree, background-process, and PTY lifecycle APIs are not part of RPC v2; available agent tools remain provider-owned structured events."
+		}
+	],
+	"verdict": {
+		"adapterProtocol": "fail",
+		"workloadParity": "blocked",
+		"blockingCaseIds": ["A04", "A05"],
+		"blockingCapabilityIds": ["G1", "G2", "G3", "G5"]
+	}
+}

--- a/scripts/fixtures/omp-rpc-upstream-requirements.json
+++ b/scripts/fixtures/omp-rpc-upstream-requirements.json
@@ -1,0 +1,144 @@
+{
+	"schemaVersion": 1,
+	"protocol": "OMP RPC v2",
+	"authority": "OMP owns Worker identity, hierarchy, lifecycle, command ordering, acknowledgement, effect, and terminal state",
+	"requirements": [
+		{
+			"id": "G1",
+			"name": "host-created workers",
+			"statusIn18.1.6": "missing",
+			"request": {
+				"type": "create_worker",
+				"required": ["id", "task"],
+				"optional": ["parentWorkerId", "model", "thinkingLevel", "tools"]
+			},
+			"response": {
+				"command": "create_worker",
+				"successDataRequired": [
+					"commandId",
+					"workerId",
+					"providerWorkerId",
+					"parentWorkerId",
+					"status"
+				]
+			},
+			"events": [
+				{
+					"type": "worker_created",
+					"required": ["commandId", "workerId", "providerWorkerId", "parentWorkerId", "sequence"]
+				},
+				{
+					"type": "worker_lifecycle_changed",
+					"required": ["workerId", "status", "sequence", "isTerminal"]
+				}
+			],
+			"invariants": [
+				"Response acknowledgement is not creation effect.",
+				"worker_created is the effect observation for the correlated commandId.",
+				"Worker identity and parent lineage are stable for the Session.",
+				"Duplicate commandId is idempotent or returns a typed duplicate-command error without creating another Worker.",
+				"An unknown parent fails before acknowledgement."
+			]
+		},
+		{
+			"id": "G2",
+			"name": "direct worker steering and messaging",
+			"statusIn18.1.6": "missing",
+			"request": {
+				"type": "command_worker",
+				"required": ["id", "workerId", "action"],
+				"optional": ["message", "images", "expectedWorkerRevision"],
+				"actionEnum": ["message", "steer", "follow_up", "interrupt", "resume", "cancel", "kill"]
+			},
+			"response": {
+				"command": "command_worker",
+				"successDataRequired": ["commandId", "workerId", "action", "acknowledged"]
+			},
+			"events": [
+				{
+					"type": "worker_command_effect",
+					"required": ["commandId", "workerId", "action", "outcome", "sequence"],
+					"outcomeEnum": [
+						"effectObserved",
+						"rejected",
+						"failed",
+						"ambiguous",
+						"cancelled",
+						"stopped"
+					]
+				}
+			],
+			"errors": [
+				"unknown_worker",
+				"stale_worker_revision",
+				"unsupported_action",
+				"worker_not_mutable",
+				"session_busy"
+			],
+			"invariants": [
+				"The addressed Worker, not its root Session, receives the action.",
+				"Acknowledgement never implies effect.",
+				"Late completion after cancel remains separately observable and ordered.",
+				"A stale or terminal Worker fails closed.",
+				"Every mutation carries a host-provided id and provider-correlated commandId."
+			]
+		},
+		{
+			"id": "G3",
+			"name": "completed worker transcript visibility",
+			"statusIn18.1.6": "documented-but-not-observed",
+			"request": {
+				"type": "get_subagent_messages",
+				"required": ["id"],
+				"optional": ["subagentId", "sessionFile", "fromByte"]
+			},
+			"response": {
+				"command": "get_subagent_messages",
+				"successDataRequired": ["workerId", "messages", "entries", "nextByte", "workerRevision"]
+			},
+			"events": [
+				{
+					"type": "worker_transcript_updated",
+					"required": ["workerId", "workerRevision", "nextByte", "sequence"]
+				}
+			],
+			"errors": ["unknown_worker", "stale_worker_revision", "transcript_unavailable"],
+			"invariants": [
+				"Exactly one of subagentId or sessionFile selects the Worker transcript.",
+				"After terminal Worker lifecycle and root completion, the correlated completed Worker message is observable.",
+				"workerRevision and nextByte provide monotonic incremental reads without private file access.",
+				"A response acknowledgement is correlated to the selected Worker and workerRevision."
+			]
+		},
+		{
+			"id": "G5",
+			"name": "deterministic abort-and-prompt completion",
+			"statusIn18.1.6": "requires-live-proof",
+			"request": {
+				"type": "abort_and_prompt",
+				"required": ["id", "message"],
+				"optional": ["images"]
+			},
+			"response": {
+				"command": "abort_and_prompt",
+				"successDataRequired": ["agentInvoked", "abortedTurnId", "replacementTurnId"]
+			},
+			"events": [
+				{
+					"type": "prompt_result",
+					"required": ["id", "agentInvoked", "replacementTurnId"]
+				},
+				{
+					"type": "agent_end",
+					"required": ["turnId", "isTerminal"]
+				}
+			],
+			"invariants": [
+				"The response or prompt_result always identifies whether replacement execution began.",
+				"The aborted and replacement turns have distinct stable identities.",
+				"Terminal completion is correlated to replacementTurnId, never inferred from the next unscoped agent_end.",
+				"A consume-before-ack disconnect returns an authoritative status or explicit ambiguous outcome; hosts never retry blindly."
+			]
+		}
+	]
+}

--- a/scripts/omp-rpc-conformance-lib.mjs
+++ b/scripts/omp-rpc-conformance-lib.mjs
@@ -1,0 +1,219 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+const CASE_STATUSES = new Set(['pass', 'fail', 'ambiguous', 'not-run']);
+const CAPABILITY_STATUSES = new Set(['supported', 'unsupported', 'ambiguous']);
+
+function isRecord(value) {
+	return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function requireUniqueStrings(value, label) {
+	if (
+		!Array.isArray(value) ||
+		value.length === 0 ||
+		value.some((item) => typeof item !== 'string' || item.length === 0)
+	) {
+		throw new Error(`${label} must be a non-empty string array`);
+	}
+	if (new Set(value).size !== value.length) throw new Error(`${label} contains duplicates`);
+}
+
+export function validateBaseline(baseline) {
+	if (!isRecord(baseline) || baseline.schemaVersion !== 1) {
+		throw new Error('baseline.schemaVersion must be 1');
+	}
+	if (!isRecord(baseline.omp) || !/^\d+\.\d+\.\d+$/.test(baseline.omp.version)) {
+		throw new Error('baseline.omp.version must be an exact semantic version');
+	}
+	if (!/^[a-f0-9]{64}$/i.test(baseline.omp.sha256 ?? '')) {
+		throw new Error('baseline.omp.sha256 must be a SHA-256 digest');
+	}
+	requireUniqueStrings(baseline.requiredCommandTypes, 'baseline.requiredCommandTypes');
+	requireUniqueStrings(baseline.requiredEventTypes, 'baseline.requiredEventTypes');
+	requireUniqueStrings(baseline.requiredCases, 'baseline.requiredCases');
+	if (!Array.isArray(baseline.powerUserCapabilities)) {
+		throw new Error('baseline.powerUserCapabilities must be an array');
+	}
+	return baseline;
+}
+
+export function parseConformanceArgs(argv) {
+	const parsed = { executable: null, baselinePath: null, outputPath: null, live: false };
+	for (let index = 0; index < argv.length; index += 1) {
+		const argument = argv[index];
+		if (argument === '--live') {
+			parsed.live = true;
+			continue;
+		}
+		if (!['--executable', '--baseline', '--output'].includes(argument)) {
+			throw new Error(`unknown argument: ${argument}`);
+		}
+		const value = argv[index + 1];
+		if (!value || value.startsWith('--')) throw new Error(`${argument} requires a value`);
+		index += 1;
+		if (argument === '--executable') parsed.executable = value;
+		if (argument === '--baseline') parsed.baselinePath = value;
+		if (argument === '--output') parsed.outputPath = value;
+	}
+	if (!parsed.executable) throw new Error('--executable is required');
+	if (!path.isAbsolute(parsed.executable)) {
+		throw new Error('--executable must be an absolute path to the user-installed OMP binary');
+	}
+	const executable = path.resolve(parsed.executable);
+	const baselinePath = path.resolve(
+		parsed.baselinePath ??
+			path.join(
+				path.dirname(fileURLToPath(import.meta.url)),
+				'fixtures',
+				'omp-rpc-18.1.6-baseline.json'
+			)
+	);
+	const outputPath = parsed.outputPath ? path.resolve(parsed.outputPath) : null;
+	return { executable, baselinePath, outputPath, live: parsed.live };
+}
+export function parseOmpVersionOutput(output) {
+	const match = String(output)
+		.trim()
+		.match(/^omp\/(\d+\.\d+\.\d+)$/);
+	if (!match) throw new Error('unable to parse exact OMP version from --version');
+	return match[1];
+}
+
+function optionText(option) {
+	if (typeof option === 'string') return option;
+	if (!isRecord(option)) return '';
+	return [option.label, option.title, option.value, option.id]
+		.filter((value) => typeof value === 'string')
+		.join(' ');
+}
+
+function optionValue(option) {
+	if (typeof option === 'string') return option;
+	if (!isRecord(option)) return undefined;
+	return option.value ?? option.id ?? option.label;
+}
+
+export function buildExtensionUiResponse(request, decision) {
+	if (!isRecord(request) || typeof request.id !== 'string' || typeof request.method !== 'string') {
+		throw new Error('extension UI request requires string id and method');
+	}
+	if (!['approve', 'reject'].includes(decision)) {
+		throw new Error('extension UI decision must be approve or reject');
+	}
+	const response = { type: 'extension_ui_response', id: request.id };
+	if (request.method !== 'select') {
+		return { ...response, confirmed: decision === 'approve' };
+	}
+
+	const options = Array.isArray(request.options) ? request.options : [];
+	const selected = options.find((option) => {
+		const text = optionText(option);
+		return decision === 'approve'
+			? /(?:allow|approve|yes)/i.test(text) && !/(?:always|permanent)/i.test(text)
+			: /(?:deny|reject|cancel|no)/i.test(text);
+	});
+	const value = optionValue(selected);
+	if (value === undefined) return { ...response, cancelled: true };
+	return { ...response, value };
+}
+
+export function comparePinnedIdentity(identity, baseline) {
+	validateBaseline(baseline);
+	const reasons = [];
+	if (identity.version !== baseline.omp.version) {
+		reasons.push(`expected OMP ${baseline.omp.version}, observed ${String(identity.version)}`);
+	}
+	if (identity.sha256?.toLowerCase() !== baseline.omp.sha256.toLowerCase()) {
+		reasons.push(`expected SHA-256 ${baseline.omp.sha256}, observed ${String(identity.sha256)}`);
+	}
+	return { status: reasons.length === 0 ? 'pass' : 'fail', reasons };
+}
+
+export function assertSuccessfulResponse(response, expectedCommand) {
+	if (!isRecord(response) || response.type !== 'response') {
+		throw new Error(`expected ${expectedCommand} RPC response`);
+	}
+	if (response.command !== expectedCommand) {
+		throw new Error(`expected ${expectedCommand} response, received ${String(response.command)}`);
+	}
+	if (response.success !== true) {
+		const detail = response.code ?? response.error ?? 'unknown RPC failure';
+		throw new Error(`${expectedCommand} failed: ${detail}`);
+	}
+	return response.data;
+}
+
+export function classifyPowerUserCapabilities({
+	commandTypes,
+	workerTranscriptObserved,
+	abortAndPromptCompletionObserved,
+}) {
+	const commands = new Set(commandTypes);
+	const g1Supported = commands.has('create_worker');
+	const g2Supported = commands.has('command_worker');
+	return [
+		{
+			id: 'G1',
+			name: 'host-created workers',
+			status: g1Supported ? 'supported' : 'unsupported',
+			reason: g1Supported
+				? 'RPC exposes a create_worker command.'
+				: 'RPC has observation APIs but no create_worker command.',
+		},
+		{
+			id: 'G2',
+			name: 'direct worker steering and messaging',
+			status: g2Supported ? 'supported' : 'unsupported',
+			reason: g2Supported
+				? 'RPC exposes a command_worker command.'
+				: 'RPC steering targets the root session and exposes no command_worker command.',
+		},
+		{
+			id: 'G3',
+			name: 'completed worker transcript visibility',
+			status: workerTranscriptObserved ? 'supported' : 'unsupported',
+			reason: workerTranscriptObserved
+				? 'get_subagent_messages exposed the completed worker message.'
+				: 'get_subagent_messages returned no completed worker message after terminal root completion.',
+		},
+		{
+			id: 'G5',
+			name: 'deterministic abort-and-prompt completion',
+			status: abortAndPromptCompletionObserved ? 'supported' : 'ambiguous',
+			reason: abortAndPromptCompletionObserved
+				? 'Observed response.data.agentInvoked or prompt_result completion correlation.'
+				: 'Command acceptance alone does not prove terminal abort-and-prompt completion.',
+		},
+	];
+}
+
+export function computeConformanceVerdict({ cases, capabilities }) {
+	if (!Array.isArray(cases) || !Array.isArray(capabilities)) {
+		throw new TypeError('cases and capabilities must be arrays');
+	}
+	for (const testCase of cases) {
+		if (!CASE_STATUSES.has(testCase.status))
+			throw new Error(`invalid case status: ${testCase.status}`);
+	}
+	for (const capability of capabilities) {
+		if (!CAPABILITY_STATUSES.has(capability.status)) {
+			throw new Error(`invalid capability status: ${capability.status}`);
+		}
+	}
+	const blockingCaseIds = cases
+		.filter((testCase) => testCase.required && testCase.status !== 'pass')
+		.map((testCase) => testCase.id);
+	const blockingCapabilityIds = capabilities
+		.filter(
+			(capability) =>
+				['G1', 'G2', 'G3', 'G5'].includes(capability.id) && capability.status !== 'supported'
+		)
+		.map((capability) => capability.id);
+	return {
+		adapterProtocol: blockingCaseIds.length === 0 ? 'pass' : 'fail',
+		workloadParity:
+			blockingCapabilityIds.length === 0 && blockingCaseIds.length === 0 ? 'pass' : 'blocked',
+		blockingCaseIds,
+		blockingCapabilityIds,
+	};
+}

--- a/scripts/omp-rpc-conformance.mjs
+++ b/scripts/omp-rpc-conformance.mjs
@@ -1,0 +1,1072 @@
+#!/usr/bin/env node
+
+import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { promisify } from 'node:util';
+
+import {
+	assertSuccessfulResponse,
+	buildExtensionUiResponse,
+	classifyPowerUserCapabilities,
+	comparePinnedIdentity,
+	computeConformanceVerdict,
+	parseConformanceArgs,
+	parseOmpVersionOutput,
+	validateBaseline,
+} from './omp-rpc-conformance-lib.mjs';
+import {
+	JsonLineDecoder,
+	MAESTRO_RPC_MAX_REASSEMBLED_BYTES,
+	RpcProcessPeer,
+	RpcV2FrameDecoder,
+	redactConformanceReport,
+	summarizeProtocolFrame,
+	validateReadyFrame,
+} from './omp-rpc-protocol.mjs';
+
+const execFileAsync = promisify(execFile);
+const TIMEOUT_MS = 120_000;
+const LIVE_TIMEOUT_MS = 300_000;
+const MAX_CAPTURED_FRAMES = 20_000;
+const SOURCE_POLICY = Object.freeze({
+	allowed: ['OMP --help', 'OMP --version', 'omp://rpc.md', 'RPC stdio', 'ACP stdio'],
+	forbidden: ['private OMP session files', 'private OMP settings', 'OMP implementation modules'],
+});
+
+const CASE_TITLES = Object.freeze({
+	A01: 'RPC identity, negotiation, framing, and limits',
+	A02: 'Session identity and public reattachment',
+	A03: 'Root stream, snapshot, paging, and replay',
+	A04: 'Worker registry, hierarchy, and transcript surface',
+	A05: 'Steering, cancellation, and abort-and-prompt',
+	A06: 'Approval callback and restrictive launch policy',
+	A07: 'Dynamic models, providers, thinking, and effective state',
+	A08: 'Todos, commands, host tools, stats, and compaction surface',
+	A09: 'Evidence, artifact, process, worktree, and export surface',
+	A10: 'Typed errors and fail-closed capability changes',
+	A11: 'Stable power-user protocol gaps',
+});
+
+class NotRunError extends Error {}
+
+const options = parseConformanceArgs(process.argv.slice(2));
+const baseline = validateBaseline(JSON.parse(await readFile(options.baselinePath, 'utf8')));
+const temporaryWorkspace = await mkdtemp(path.join(os.tmpdir(), 'maestro-omp-conformance-'));
+const caseResults = [];
+const deviations = [];
+const shared = {
+	commandTypes: [],
+	eventTypes: [],
+	workerTranscriptObserved: false,
+	abortAndPromptCompletionObserved: false,
+	busyErrorCode: null,
+};
+let baseHandle;
+
+const report = {
+	schemaVersion: 1,
+	startedAt: new Date().toISOString(),
+	finishedAt: null,
+	executable: options.executable,
+	workspace: temporaryWorkspace,
+	harnessSha256: null,
+	sourceRevision: null,
+	fixtureRevision: baseline.schemaVersion,
+	maestro: { version: null, hostContract: 'run-fleet/v1-placeholder' },
+	adapter: { id: 'official.omp', version: 'unreleased-placeholder' },
+	host: { platform: process.platform, architecture: process.arch, release: os.release() },
+	omp: null,
+	protocol: { name: 'rpc', requestedVersion: 2, ready: null, documentationSha256: null },
+	sourcePolicy: SOURCE_POLICY,
+	options: { live: options.live },
+	cases: caseResults,
+	capabilities: [],
+	deviations,
+	verdict: null,
+};
+
+try {
+	await populateBuildIdentity(report);
+	const identity = await readOmpIdentity(options.executable);
+	const identityComparison = comparePinnedIdentity(identity, baseline);
+	report.omp = {
+		version: identity.version,
+		sha256: identity.sha256,
+		identityStatus: identityComparison.status,
+		identityReasons: identityComparison.reasons,
+	};
+
+	if (identityComparison.status === 'pass') {
+		const publicHelp = await runPublicCommand(['--help']);
+		const publicAcpHelp = await runPublicCommand(['acp', '--help']);
+		const publicRpcDocumentation = await runPublicCommand(['read', 'omp://rpc.md']);
+		report.protocol.documentationSha256 = sha256(Buffer.from(publicRpcDocumentation, 'utf8'));
+		shared.commandTypes = baseline.requiredCommandTypes.filter((type) =>
+			publicRpcDocumentation.includes(`\"${type}\"`)
+		);
+		shared.eventTypes = baseline.requiredEventTypes.filter(
+			(type) =>
+				publicRpcDocumentation.includes(`\"${type}\"`) ||
+				publicRpcDocumentation.includes(`\`${type}\``)
+		);
+
+		baseHandle = createRpcHandle({
+			args: deterministicRpcArgs({ noSession: true, tools: [] }),
+			approvalDecision: 'approve',
+			hostToolResultText: 'MAESTRO_HOST_TOOL_OK',
+		});
+		const ready = await withTimeout(baseHandle.peer.ready, TIMEOUT_MS, 'base RPC ready frame');
+		report.protocol.ready = validateReadyFrame(ready);
+
+		await runCase('A01', true, async () => {
+			if (identityComparison.status !== 'pass')
+				throw new Error(identityComparison.reasons.join('; '));
+			const readyData = validateReadyFrame(ready);
+			if (!readyData.supportedProtocolVersions.includes(2)) {
+				throw new Error('RPC v2 is not advertised');
+			}
+			const negotiated = assertSuccessfulResponse(
+				await baseHandle.peer.request('negotiate_protocol', { protocolVersion: 2 }, TIMEOUT_MS),
+				'negotiate_protocol'
+			);
+			if (negotiated?.protocolVersion !== 2)
+				throw new Error('RPC v2 negotiation did not read back v2');
+			if (readyData.maxFrameBytes !== baseline.transport.serverMaxFrameBytes) {
+				throw new Error(`unexpected physical-frame limit ${readyData.maxFrameBytes}`);
+			}
+			if (
+				readyData.maxReassembledFrameBytes !== baseline.transport.serverMaxReassembledFrameBytes
+			) {
+				throw new Error(
+					`unexpected server logical-frame limit ${readyData.maxReassembledFrameBytes}`
+				);
+			}
+			runCodecSelfCheck();
+			const undocumentedCommands = baseline.requiredCommandTypes.filter(
+				(type) => !shared.commandTypes.includes(type)
+			);
+			const undocumentedEvents = baseline.requiredEventTypes.filter(
+				(type) => !shared.eventTypes.includes(type)
+			);
+			if (undocumentedCommands.length > 0 || undocumentedEvents.length > 0) {
+				throw new Error(
+					`public RPC documentation omissions: commands=${undocumentedCommands.join(',')}; events=${undocumentedEvents.join(',')}`
+				);
+			}
+			const rpcUiHandle = createRpcHandle({
+				args: deterministicRpcArgs({ mode: 'rpc-ui', noSession: true, tools: [] }),
+				approvalDecision: 'reject',
+			});
+			let rpcUiReady;
+			try {
+				rpcUiReady = validateReadyFrame(
+					await withTimeout(rpcUiHandle.peer.ready, TIMEOUT_MS, 'RPC-UI ready frame')
+				);
+				assertSuccessfulResponse(
+					await rpcUiHandle.peer.request('get_state', {}, TIMEOUT_MS),
+					'get_state'
+				);
+			} finally {
+				await rpcUiHandle.peer.close();
+			}
+			return {
+				evidence: {
+					version: identity.version,
+					sha256: identity.sha256,
+					protocolVersions: readyData.supportedProtocolVersions,
+					serverLimits: {
+						maxFrameBytes: readyData.maxFrameBytes,
+						maxReassembledFrameBytes: readyData.maxReassembledFrameBytes,
+					},
+					maestroLogicalLimit: MAESTRO_RPC_MAX_REASSEMBLED_BYTES,
+					documentedCommandCount: shared.commandTypes.length,
+					documentedEventCount: shared.eventTypes.length,
+					helpAdvertisesNoSession: publicHelp.includes('--no-session'),
+					transportComparison: {
+						selected: 'rpc',
+						rpc: { advertised: publicHelp.includes('rpc'), liveStateRead: true },
+						rpcUi: {
+							advertised: publicHelp.includes('rpc-ui'),
+							liveStateRead: true,
+							protocolVersions: rpcUiReady.supportedProtocolVersions,
+						},
+						acp: {
+							advertised: publicAcpHelp.includes('Agent Client Protocol'),
+							selected: false,
+							reason:
+								'Standard client compatibility surface; RPC exposes the OMP-specific host-control contract.',
+						},
+					},
+				},
+			};
+		});
+
+		await runCase('A02', true, async () => probeSessionIdentity());
+		await runCase('A03', true, async () => probeRootStream());
+		await runCase('A04', true, async () => probeWorkerSurface());
+		await runCase('A05', true, async () => probeSteeringAndAbort());
+		await runCase('A06', true, async () => probeApprovalRoundTrip());
+		await runCase('A07', true, async () => probeDynamicConfiguration());
+		await runCase('A08', true, async () => probeOperationalSurface());
+		await runCase('A09', true, async () => probeEvidenceAndProcessSurface());
+		await runCase('A10', true, async () => probeTypedErrors());
+	} else {
+		await runCase('A01', true, async () => {
+			throw new Error(identityComparison.reasons.join('; '));
+		});
+		for (const id of ['A02', 'A03', 'A04', 'A05', 'A06', 'A07', 'A08', 'A09', 'A10']) {
+			await runCase(id, true, async () => {
+				throw new NotRunError('pinned OMP identity did not match');
+			});
+		}
+	}
+	report.capabilities = classifyPowerUserCapabilities(shared);
+	await runCase('A11', false, async () => ({
+		status: report.capabilities.every((capability) => capability.status === 'supported')
+			? 'pass'
+			: 'fail',
+		evidence: { requirements: report.capabilities },
+	}));
+
+	report.verdict = computeConformanceVerdict({
+		cases: report.cases,
+		capabilities: report.capabilities,
+	});
+} catch (error) {
+	deviations.push({ id: 'HARNESS_FATAL', detail: errorMessage(error) });
+	report.verdict = {
+		adapterProtocol: 'fail',
+		workloadParity: 'blocked',
+		blockingCaseIds: baseline.requiredCases,
+		blockingCapabilityIds: ['G1', 'G2', 'G5'],
+	};
+} finally {
+	if (baseHandle) await baseHandle.peer.close();
+	report.finishedAt = new Date().toISOString();
+	const sanitized = redactConformanceReport(report);
+	const serialized = `${JSON.stringify(sanitized, null, '\t')}\n`;
+	if (options.outputPath) await writeFile(options.outputPath, serialized, 'utf8');
+	process.stdout.write(serialized);
+	await rm(temporaryWorkspace, { recursive: true, force: true });
+	if (report.verdict?.adapterProtocol !== 'pass') process.exitCode = 1;
+}
+
+async function runCase(id, required, operation) {
+	const startedAt = Date.now();
+	try {
+		const outcome = (await operation()) ?? {};
+		caseResults.push({
+			id,
+			title: CASE_TITLES[id],
+			required,
+			status: outcome.status ?? 'pass',
+			durationMs: Date.now() - startedAt,
+			evidence: outcome.evidence ?? {},
+		});
+	} catch (error) {
+		caseResults.push({
+			id,
+			title: CASE_TITLES[id],
+			required,
+			status: error instanceof NotRunError ? 'not-run' : 'fail',
+			durationMs: Date.now() - startedAt,
+			error: errorMessage(error),
+		});
+	}
+}
+
+function requireLive(caseId) {
+	if (!options.live) throw new NotRunError(`${caseId} requires --live`);
+}
+
+function deterministicRpcArgs({ mode = 'rpc', noSession, tools, resume, sessionDirectory } = {}) {
+	const args = [
+		'--mode',
+		mode,
+		'--no-extensions',
+		'--no-skills',
+		'--no-rules',
+		'--no-lsp',
+		'--no-title',
+		'--approval-mode',
+		'always-ask',
+		'--system-prompt',
+		'You are an isolated protocol-conformance probe. Follow the synthetic request exactly. Do not inspect the workspace or any external resource.',
+	];
+	if (noSession) args.push('--no-session');
+	if (sessionDirectory) args.push('--session-dir', sessionDirectory);
+	if (resume) args.push('--resume', resume);
+	if (Array.isArray(tools) && tools.length === 0) args.push('--no-tools');
+	else if (Array.isArray(tools)) args.push('--tools', tools.join(','));
+	return args;
+}
+
+function createRpcHandle({ args, approvalDecision, hostToolResultText }) {
+	const frames = [];
+	const approvalRequests = [];
+	const uiRequests = [];
+	const hostToolCalls = [];
+	const peer = new RpcProcessPeer({
+		executable: options.executable,
+		args,
+		cwd: temporaryWorkspace,
+		env: process.env,
+		onFrame(frame, activePeer) {
+			if (frames.length < MAX_CAPTURED_FRAMES) frames.push(frame);
+			if (frame.type === 'extension_ui_request') {
+				uiRequests.push(frame);
+				if (['confirm', 'input', 'editor', 'select'].includes(frame.method)) {
+					approvalRequests.push(frame);
+				}
+				activePeer.send(buildExtensionUiResponse(frame, approvalDecision));
+			}
+			if (frame.type === 'host_tool_call' && typeof hostToolResultText === 'string') {
+				hostToolCalls.push(frame);
+				activePeer.send({
+					type: 'host_tool_update',
+					id: frame.id,
+					partialResult: { content: [{ type: 'text', text: 'working' }] },
+				});
+				activePeer.send({
+					type: 'host_tool_result',
+					id: frame.id,
+					result: { content: [{ type: 'text', text: hostToolResultText }] },
+				});
+			}
+		},
+	});
+	return { peer, frames, approvalRequests, uiRequests, hostToolCalls };
+}
+
+async function probeSessionIdentity() {
+	requireLive('A02');
+	const sessionDirectory = path.join(temporaryWorkspace, 'sessions');
+	const created = createRpcHandle({
+		args: deterministicRpcArgs({ noSession: false, tools: [], sessionDirectory }),
+		approvalDecision: 'reject',
+	});
+	let firstState;
+	try {
+		await withTimeout(created.peer.ready, TIMEOUT_MS, 'saved-session ready frame');
+		await negotiate(created.peer);
+		firstState = await requestData(created.peer, 'get_state');
+		if (!firstState?.sessionId || !firstState?.sessionFile) {
+			throw new Error('public state omitted sessionId or sessionFile');
+		}
+		const terminal = created.peer.waitForFrame(
+			(frame) => frame.type === 'agent_end' && frame.isTerminal !== false,
+			LIVE_TIMEOUT_MS,
+			'terminal saved-session turn'
+		);
+		assertSuccessfulResponse(
+			await created.peer.request(
+				'prompt',
+				{ message: 'Reply with exactly MAESTRO_SESSION_OK.' },
+				TIMEOUT_MS
+			),
+			'prompt'
+		);
+		await terminal;
+	} finally {
+		await created.peer.close();
+	}
+
+	const resumed = createRpcHandle({
+		args: deterministicRpcArgs({
+			noSession: false,
+			tools: [],
+			sessionDirectory,
+			resume: firstState.sessionFile,
+		}),
+		approvalDecision: 'reject',
+	});
+	try {
+		await withTimeout(resumed.peer.ready, TIMEOUT_MS, 'resumed-session ready frame');
+		await negotiate(resumed.peer);
+		const secondState = await requestData(resumed.peer, 'get_state');
+		const stableSessionId = secondState.sessionId === firstState.sessionId;
+		const stableSessionFile =
+			path.resolve(secondState.sessionFile) === path.resolve(firstState.sessionFile);
+		if (!stableSessionId || !stableSessionFile) {
+			throw new Error(
+				`public resume identity mismatch: stableSessionId=${stableSessionId}, stableSessionFile=${stableSessionFile}`
+			);
+		}
+		return {
+			evidence: {
+				stableSessionId,
+				stableSessionFile,
+				createAndResumeUsedPublicRpcStateOnly: true,
+			},
+		};
+	} finally {
+		await resumed.peer.close();
+	}
+}
+
+async function probeRootStream() {
+	requireLive('A03');
+	const handle = createRpcHandle({
+		args: deterministicRpcArgs({ noSession: true, tools: [] }),
+		approvalDecision: 'reject',
+	});
+	try {
+		await withTimeout(handle.peer.ready, TIMEOUT_MS, 'root live ready frame');
+		await negotiate(handle.peer);
+		const start = handle.frames.length;
+		const agentStarted = handle.peer.waitForFrame(
+			(frame) => frame.type === 'agent_start',
+			LIVE_TIMEOUT_MS,
+			'root agent_start'
+		);
+		const terminal = handle.peer.waitForFrame(
+			(frame) => frame.type === 'agent_end' && frame.isTerminal !== false,
+			LIVE_TIMEOUT_MS,
+			'terminal root agent_end'
+		);
+		const promptResponse = await handle.peer.request(
+			'prompt',
+			{ message: 'Write the integers 1 through 200 on one line, then write MAESTRO_ROOT_OK.' },
+			TIMEOUT_MS
+		);
+		assertSuccessfulResponse(promptResponse, 'prompt');
+		await agentStarted;
+		const busy = await handle.peer.request('get_messages_page', { limit: 1 }, TIMEOUT_MS);
+		if (busy.success === false) shared.busyErrorCode = busy.code ?? null;
+		await terminal;
+		const liveFrames = handle.frames.slice(start);
+		const kinds = countFrameTypes(liveFrames);
+		for (const required of [
+			'agent_start',
+			'turn_start',
+			'message_start',
+			'message_update',
+			'message_end',
+			'turn_end',
+			'agent_end',
+		]) {
+			if (!kinds[required]) throw new Error(`missing live event ${required}`);
+		}
+		const paged = await requestData(handle.peer, 'get_messages_page', { limit: 256 });
+		const legacy = await requestData(handle.peer, 'get_messages');
+		const pagedMessages = paged?.messages ?? [];
+		const legacyMessages = Array.isArray(legacy) ? legacy : (legacy?.messages ?? []);
+		if (pagedMessages.length === 0 || legacyMessages.length === 0) {
+			throw new Error('public message snapshots were empty after a live root turn');
+		}
+		const pagedHash = hashJson(pagedMessages);
+		const legacyHash = hashJson(legacyMessages);
+		if (pagedHash !== legacyHash) throw new Error('paged and legacy snapshots differ');
+
+		const firstPage = await requestData(handle.peer, 'get_messages_page', { limit: 1 });
+		if (firstPage.nextCursor) {
+			await requestData(handle.peer, 'bash', {
+				command: 'node -e "process.stdout.write(\'CURSOR_MUTATION\')"',
+			});
+			const stale = await handle.peer.request(
+				'get_messages_page',
+				{ cursor: firstPage.nextCursor, limit: 1 },
+				TIMEOUT_MS
+			);
+			if (stale.success === false) shared.staleErrorCode = stale.code ?? null;
+		}
+		return {
+			evidence: {
+				frameCounts: kinds,
+				messageCount: pagedMessages.length,
+				snapshotSha256: pagedHash,
+				terminalAgentEnd: true,
+				busyErrorCode: shared.busyErrorCode,
+				staleCursorCode: shared.staleErrorCode,
+			},
+		};
+	} finally {
+		await handle.peer.close();
+	}
+}
+
+async function probeWorkerSurface() {
+	requireLive('A04');
+	const handle = createRpcHandle({
+		args: deterministicRpcArgs({ noSession: true, tools: ['task'] }),
+		approvalDecision: 'approve',
+	});
+	try {
+		await withTimeout(handle.peer.ready, TIMEOUT_MS, 'worker live ready frame');
+		await negotiate(handle.peer);
+		await requestData(handle.peer, 'set_subagent_subscription', { level: 'events' });
+		const terminal = handle.peer.waitForFrame(
+			(frame) => frame.type === 'agent_end' && frame.isTerminal !== false,
+			LIVE_TIMEOUT_MS,
+			'terminal worker-probe agent_end'
+		);
+		const firstLifecycle = handle.peer.waitForFrame(
+			(frame) => frame.type === 'subagent_lifecycle',
+			LIVE_TIMEOUT_MS,
+			'first Worker lifecycle frame'
+		);
+		assertSuccessfulResponse(
+			await handle.peer.request(
+				'prompt',
+				{
+					message:
+						'Call the task tool exactly once. Ask that worker to reply exactly MAESTRO_WORKER_OK without tools. Wait for it, then reply exactly MAESTRO_ROOT_OK.',
+				},
+				TIMEOUT_MS
+			),
+			'prompt'
+		);
+		await firstLifecycle;
+		const snapshot = await requestData(handle.peer, 'get_subagents');
+		await terminal;
+		const workers = snapshot?.subagents ?? snapshot ?? [];
+		if (!Array.isArray(workers) || workers.length === 0) {
+			const lifecycle = handle.frames.find((frame) => frame.type === 'subagent_lifecycle');
+			throw new Error(
+				`no active Worker appeared in the public subagent registry; snapshotKeys=${Object.keys(snapshot ?? {}).join(',')}; lifecycleKeys=${Object.keys(lifecycle ?? {}).join(',')}; frames=${JSON.stringify(countFrameTypes(handle.frames))}; uiMethods=${handle.uiRequests.map((request) => request.method).join(',')}`
+			);
+		}
+		const worker = workers[0];
+		const workerId = worker.id ?? worker.subagentId;
+		if (!workerId) throw new Error('public Worker record omitted an id');
+		const selectors = [
+			{ subagentId: workerId, fromByte: 0 },
+			typeof worker.sessionFile === 'string'
+				? { sessionFile: worker.sessionFile, fromByte: 0 }
+				: null,
+		].filter(Boolean);
+		let transcript = null;
+		for (let attempt = 0; attempt < 5; attempt += 1) {
+			for (const selector of selectors) {
+				const candidate = await requestData(handle.peer, 'get_subagent_messages', selector);
+				if (
+					Array.isArray(candidate?.messages) &&
+					candidate.messages.length > 0 &&
+					JSON.stringify(candidate.messages).includes('MAESTRO_WORKER_OK')
+				) {
+					transcript = candidate;
+					break;
+				}
+			}
+			if (transcript) break;
+			await new Promise((resolve) => setTimeout(resolve, 200));
+		}
+		if (!transcript) {
+			throw new Error('public Worker transcript did not expose the completed worker message');
+		}
+		shared.workerTranscriptObserved = true;
+		return {
+			evidence: {
+				workerCount: workers.length,
+				workerFields: Object.keys(worker).sort(),
+				workerMessageCount: transcript.messages.length,
+				workerTranscriptSha256: hashJson(transcript.messages),
+				forwardedFrameCounts: countFrameTypes(handle.frames),
+			},
+		};
+	} finally {
+		await handle.peer.close();
+	}
+}
+
+async function probeSteeringAndAbort() {
+	requireLive('A05');
+	const handle = createRpcHandle({
+		args: deterministicRpcArgs({ noSession: true, tools: [] }),
+		approvalDecision: 'reject',
+	});
+	try {
+		await withTimeout(handle.peer.ready, TIMEOUT_MS, 'steering live ready frame');
+		await negotiate(handle.peer);
+		await requestData(handle.peer, 'set_steering_mode', { mode: 'one-at-a-time' });
+		await requestData(handle.peer, 'set_follow_up_mode', { mode: 'one-at-a-time' });
+		await requestData(handle.peer, 'set_interrupt_mode', { mode: 'immediate' });
+
+		const started = handle.peer.waitForFrame(
+			(frame) => frame.type === 'agent_start',
+			LIVE_TIMEOUT_MS,
+			'agent_start before steering'
+		);
+		assertSuccessfulResponse(
+			await handle.peer.request(
+				'prompt',
+				{ message: 'Write a long numbered list from 1 through 500, one item at a time.' },
+				TIMEOUT_MS
+			),
+			'prompt'
+		);
+		await started;
+		assertSuccessfulResponse(
+			await handle.peer.request(
+				'steer',
+				{ message: 'Stop the list and reply STEERED.' },
+				TIMEOUT_MS
+			),
+			'steer'
+		);
+
+		const terminal = handle.peer.waitForFrame(
+			(frame) => frame.type === 'agent_end' && frame.isTerminal !== false,
+			LIVE_TIMEOUT_MS,
+			'terminal agent_end after abort_and_prompt'
+		);
+		const abortAndPrompt = await handle.peer.request(
+			'abort_and_prompt',
+			{ message: 'Reply with exactly ABORT_PROMPT_OK.' },
+			TIMEOUT_MS
+		);
+		assertSuccessfulResponse(abortAndPrompt, 'abort_and_prompt');
+		await terminal;
+		const completionSignal =
+			typeof abortAndPrompt.data?.agentInvoked === 'boolean' ||
+			handle.frames.some(
+				(frame) => frame.type === 'prompt_result' && frame.id === abortAndPrompt.id
+			);
+		assertSuccessfulResponse(await handle.peer.request('abort', {}, TIMEOUT_MS), 'abort');
+		shared.abortAndPromptCompletionObserved = completionSignal;
+		if (!completionSignal) {
+			const promptResults = handle.frames.filter((frame) => frame.type === 'prompt_result');
+			throw new Error(
+				`abort_and_prompt was accepted without a correlated completion signal; responseKeys=${Object.keys(abortAndPrompt).join(',')}; dataKeys=${Object.keys(abortAndPrompt.data ?? {}).join(',')}; promptResultCount=${promptResults.length}; promptResultIds=${promptResults.map((frame) => String(frame.id)).join(',')}`
+			);
+		}
+		return {
+			evidence: {
+				steerAccepted: true,
+				abortAndPromptCompletionSignal: true,
+				idleAbortAccepted: true,
+				frameCounts: countFrameTypes(handle.frames),
+			},
+		};
+	} finally {
+		await handle.peer.close();
+	}
+}
+
+async function probeApprovalRoundTrip() {
+	requireLive('A06');
+	const handle = createRpcHandle({
+		args: deterministicRpcArgs({ noSession: true, tools: ['write'] }),
+		approvalDecision: 'reject',
+	});
+	try {
+		await withTimeout(handle.peer.ready, TIMEOUT_MS, 'approval live ready frame');
+		await negotiate(handle.peer);
+		const terminal = handle.peer.waitForFrame(
+			(frame) => frame.type === 'agent_end' && frame.isTerminal !== false,
+			LIVE_TIMEOUT_MS,
+			'terminal approval-probe agent_end'
+		);
+		assertSuccessfulResponse(
+			await handle.peer.request(
+				'prompt',
+				{
+					message:
+						'Use the write tool to create approval-probe.txt in the current directory containing APPROVAL_PROBE. If denied, reply DENIED.',
+				},
+				TIMEOUT_MS
+			),
+			'prompt'
+		);
+		await terminal;
+		if (handle.approvalRequests.length === 0) {
+			throw new Error('restrictive RPC launch produced no extension_ui_request approval callback');
+		}
+		const request = handle.approvalRequests[0];
+		const rejectedTarget = path.join(temporaryWorkspace, 'approval-probe.txt');
+		try {
+			await readFile(rejectedTarget);
+			throw new Error('host-rejected write still created approval-probe.txt');
+		} catch (error) {
+			if (error?.code !== 'ENOENT') throw error;
+		}
+		if (!request.id || !request.method) throw new Error('approval callback omitted id or method');
+		return {
+			evidence: {
+				requestCount: handle.approvalRequests.length,
+				methods: [...new Set(handle.approvalRequests.map((item) => item.method))].sort(),
+				rejectedByHost: true,
+				restrictiveLaunch: true,
+				acpPermissionSurface: 'documented-standard; RPC is the selected adapter transport',
+			},
+		};
+	} finally {
+		await handle.peer.close();
+	}
+}
+
+async function probeDynamicConfiguration() {
+	const stateBefore = await requestData(baseHandle.peer, 'get_state');
+	const modelCatalog = await requestData(baseHandle.peer, 'get_available_models');
+	const models = modelCatalog?.models ?? modelCatalog ?? [];
+	if (!Array.isArray(models) || models.length === 0) throw new Error('model catalog is empty');
+	const original = stateBefore.model;
+	const alternate = models.find(
+		(model) => model.provider !== original?.provider || (model.id ?? model.modelId) !== original?.id
+	);
+	let changedModel = false;
+	if (alternate) {
+		await requestData(baseHandle.peer, 'set_model', {
+			provider: alternate.provider,
+			modelId: alternate.id ?? alternate.modelId,
+		});
+		const changed = await requestData(baseHandle.peer, 'get_state');
+		changedModel =
+			changed.model?.provider === alternate.provider &&
+			changed.model?.id === (alternate.id ?? alternate.modelId);
+		if (!changedModel) throw new Error('set_model acknowledgement did not match effective state');
+		await requestData(baseHandle.peer, 'set_model', {
+			provider: original.provider,
+			modelId: original.id,
+		});
+	}
+	const thinkingLevels = ['off', 'minimal', 'low', 'medium', 'high'];
+	const alternateThinking = thinkingLevels.find((level) => level !== stateBefore.thinkingLevel);
+	await requestData(baseHandle.peer, 'set_thinking_level', { level: alternateThinking });
+	const thinkingChanged = await requestData(baseHandle.peer, 'get_state');
+	if (thinkingChanged.thinkingLevel !== alternateThinking) {
+		throw new Error('set_thinking_level acknowledgement did not match effective state');
+	}
+	await requestData(baseHandle.peer, 'set_thinking_level', { level: stateBefore.thinkingLevel });
+	const fastMode = await requestData(baseHandle.peer, 'set_fast_mode', { enabled: false });
+	const loginProviders = await requestData(baseHandle.peer, 'get_login_providers');
+	return {
+		evidence: {
+			modelCount: models.length,
+			providerCount: new Set(models.map((model) => model.provider)).size,
+			modelChangeRoundTrip: alternate ? changedModel : 'single-model-catalog',
+			thinkingChangeRoundTrip: true,
+			fastModeReadbackFields: Object.keys(fastMode ?? {}).sort(),
+			loginProviderCount: (loginProviders?.providers ?? loginProviders ?? []).length,
+		},
+	};
+}
+
+async function probeOperationalSurface() {
+	requireLive('A08');
+	const phase = {
+		id: 'maestro-conformance',
+		name: 'Conformance',
+		tasks: [{ id: 'round-trip', content: 'Round-trip public todo state', status: 'pending' }],
+	};
+	const setTodos = await requestData(baseHandle.peer, 'set_todos', { phases: [phase] });
+	const returnedPhases = Array.isArray(setTodos)
+		? setTodos
+		: (setTodos?.phases ?? setTodos?.todoPhases ?? []);
+	const state = await requestData(baseHandle.peer, 'get_state');
+	if (
+		returnedPhases.length !== 1 ||
+		state.todoPhases?.length !== 1 ||
+		hashJson(returnedPhases) !== hashJson(state.todoPhases)
+	) {
+		throw new Error(
+			`normalized todo state did not round-trip: responseCount=${returnedPhases.length}, stateCount=${state.todoPhases?.length ?? 0}`
+		);
+	}
+	const hostTools = await requestData(baseHandle.peer, 'set_host_tools', {
+		tools: [
+			{
+				name: 'maestro_probe',
+				label: 'Maestro Probe',
+				description: 'Conformance-only no-op tool',
+				parameters: { type: 'object', properties: {}, additionalProperties: false },
+				loadMode: 'essential',
+			},
+		],
+	});
+	const uriSchemes = await requestData(baseHandle.peer, 'set_host_uri_schemes', {
+		schemes: [
+			{
+				scheme: 'maestroprobe',
+				description: 'Conformance-only immutable resource',
+				writable: false,
+				immutable: true,
+			},
+		],
+	});
+	const hostCallStart = baseHandle.hostToolCalls.length;
+	const hostToolTerminal = baseHandle.peer.waitForFrame(
+		(frame) => frame.type === 'agent_end' && frame.isTerminal !== false,
+		LIVE_TIMEOUT_MS,
+		'terminal host-tool probe agent_end'
+	);
+	assertSuccessfulResponse(
+		await baseHandle.peer.request(
+			'prompt',
+			{
+				message:
+					'Call the maestro_probe tool exactly once with no arguments. After its result, reply exactly HOST_TOOL_COMPLETE.',
+			},
+			TIMEOUT_MS
+		),
+		'prompt'
+	);
+	await hostToolTerminal;
+	const hostToolCalls = baseHandle.hostToolCalls.slice(hostCallStart);
+	if (hostToolCalls.length !== 1 || hostToolCalls[0].toolName !== 'maestro_probe') {
+		throw new Error(
+			`host tool callback mismatch: count=${hostToolCalls.length}; names=${hostToolCalls.map((call) => call.toolName).join(',')}`
+		);
+	}
+	const commands = await requestData(baseHandle.peer, 'get_available_commands');
+	const stats = await requestData(baseHandle.peer, 'get_session_stats');
+	await requestData(baseHandle.peer, 'set_auto_compaction', { enabled: false });
+	await requestData(baseHandle.peer, 'set_auto_compaction', { enabled: true });
+	await requestData(baseHandle.peer, 'set_auto_retry', { enabled: false });
+	await requestData(baseHandle.peer, 'set_todos', { phases: [] });
+	await requestData(baseHandle.peer, 'set_host_tools', { tools: [] });
+	await requestData(baseHandle.peer, 'set_host_uri_schemes', { schemes: [] });
+	return {
+		evidence: {
+			todoRoundTrip: true,
+			hostToolNames: hostTools?.toolNames ?? [],
+			hostToolCallbackCount: hostToolCalls.length,
+			hostToolCallFields: Object.keys(hostToolCalls[0]).sort(),
+			hostUriSchemes: uriSchemes?.schemes ?? [],
+			commandCount: (commands?.commands ?? commands ?? []).length,
+			statsFields: Object.keys(stats ?? {}).sort(),
+			contextUsageFields: Object.keys(state.contextUsage ?? {}).sort(),
+		},
+	};
+}
+async function probeEvidenceAndProcessSurface() {
+	const evidencePath = path.join(temporaryWorkspace, 'rpc-evidence.txt');
+	const command = `node -e \"require('node:fs').writeFileSync('rpc-evidence.txt', 'EVIDENCE_OK'); process.stdout.write('PROCESS_OK')\"`;
+	const bashResult = await requestData(baseHandle.peer, 'bash', { command }, TIMEOUT_MS);
+	const evidenceContents = await readFile(evidencePath, 'utf8');
+	if (
+		bashResult?.exitCode !== 0 ||
+		bashResult?.output !== 'PROCESS_OK' ||
+		evidenceContents !== 'EVIDENCE_OK'
+	) {
+		throw new Error(
+			`bash evidence mismatch: exitCode=${String(bashResult?.exitCode)}; outputMatch=${bashResult?.output === 'PROCESS_OK'}; fileMatch=${evidenceContents === 'EVIDENCE_OK'}`
+		);
+	}
+	const exportPath = path.join(temporaryWorkspace, 'session-export.html');
+	let exportStatus = 'supported';
+	try {
+		await requestData(baseHandle.peer, 'export_html', { outputPath: exportPath }, TIMEOUT_MS);
+	} catch (error) {
+		exportStatus = `unavailable: ${errorMessage(error)}`;
+	}
+	const state = await requestData(baseHandle.peer, 'get_state');
+	const toolNames = (state.dumpTools ?? []).map((tool) => tool.name);
+	const surfaces = {
+		file: toolNames.some((name) => ['read', 'write', 'edit'].includes(name)),
+		browser: toolNames.some((name) => /browser/i.test(name)),
+		worktree: toolNames.some((name) => /worktree/i.test(name)),
+		process: toolNames.some((name) => /process|^ps$/i.test(name)),
+		pty: toolNames.some((name) => /pty|terminal/i.test(name)),
+		artifact: toolNames.some((name) => /artifact/i.test(name)),
+	};
+	deviations.push({
+		id: 'A09_RESOURCE_SURFACE',
+		detail:
+			'Dedicated artifact, browser, worktree, background-process, and PTY lifecycle APIs are not part of RPC v2; available agent tools remain provider-owned structured events.',
+	});
+	return {
+		evidence: {
+			bashResponseFields: Object.keys(bashResult ?? {}).sort(),
+			bashEffectObserved: true,
+			exportStatus,
+			discoveredToolSurfaces: surfaces,
+			providerOwnedToolEvents: true,
+		},
+	};
+}
+
+async function probeTypedErrors() {
+	requireLive('A10');
+	const parseWait = baseHandle.peer.waitForFrame(
+		(frame) => frame.type === 'response' && frame.success === false && frame.command === 'parse',
+		TIMEOUT_MS,
+		'typed malformed-JSON response'
+	);
+	baseHandle.peer.sendRaw('{malformed-json');
+	const parseFailure = await parseWait;
+
+	const unknownWait = baseHandle.peer.waitForFrame(
+		(frame) => frame.type === 'response' && frame.success === false && frame.command !== 'parse',
+		5_000,
+		'typed unknown-command response'
+	);
+	baseHandle.peer.send({ id: 'maestro-unknown', type: 'maestro_unknown_command' });
+	const unknown = await unknownWait;
+	if (unknown.success !== false) throw new Error('unknown command did not fail');
+	if (shared.staleErrorCode !== 'stale_cursor') {
+		throw new Error(
+			`mutated paged snapshot did not return stale_cursor (received ${String(shared.staleErrorCode)})`
+		);
+	}
+	if (shared.busyErrorCode !== 'session_busy') {
+		throw new Error(
+			`streaming page request did not return session_busy (received ${String(shared.busyErrorCode)})`
+		);
+	}
+
+	const before = await requestData(baseHandle.peer, 'get_state');
+	const unavailable = await baseHandle.peer.request(
+		'set_model',
+		{ provider: 'maestro-invalid-provider', modelId: 'maestro-invalid-model' },
+		TIMEOUT_MS
+	);
+	if (unavailable.success !== false) throw new Error('unavailable provider/model did not fail');
+	const after = await requestData(baseHandle.peer, 'get_state');
+	if (hashJson(before.model) !== hashJson(after.model)) {
+		throw new Error('failed model change mutated effective model state');
+	}
+	return {
+		evidence: {
+			parseFailure: summarizeProtocolFrame(parseFailure),
+			unknownCommand: summarizeProtocolFrame(unknown),
+			staleCursorCode: shared.staleErrorCode,
+			busyCodeObservedDuringLiveRun: shared.busyErrorCode,
+			providerFailure: summarizeProtocolFrame(unavailable),
+			stateUnchangedAfterRejectedMutation: true,
+		},
+	};
+}
+async function requestData(peer, type, params = {}, timeoutMs = TIMEOUT_MS) {
+	return assertSuccessfulResponse(await peer.request(type, params, timeoutMs), type);
+}
+
+async function negotiate(peer) {
+	const response = await peer.request('negotiate_protocol', { protocolVersion: 2 }, TIMEOUT_MS);
+	const data = assertSuccessfulResponse(response, 'negotiate_protocol');
+	if (data?.protocolVersion !== 2)
+		throw new Error('RPC v2 negotiation did not return protocolVersion 2');
+}
+
+async function runPublicCommand(args) {
+	const { stdout } = await execFileAsync(options.executable, args, {
+		cwd: temporaryWorkspace,
+		windowsHide: true,
+		timeout: TIMEOUT_MS,
+		maxBuffer: 8 * 1024 * 1024,
+	});
+	return stdout;
+}
+
+async function readOmpIdentity(executable) {
+	const { stdout } = await execFileAsync(executable, ['--version'], {
+		cwd: temporaryWorkspace,
+		windowsHide: true,
+		timeout: 30_000,
+	});
+	return { version: parseOmpVersionOutput(stdout), sha256: await hashFile(executable) };
+}
+
+async function populateBuildIdentity(target) {
+	const packageJson = JSON.parse(await readFile(path.join(process.cwd(), 'package.json'), 'utf8'));
+	target.maestro.version = packageJson.version;
+	const harnessDigest = createHash('sha256');
+	for (const relativePath of [
+		'scripts/omp-rpc-protocol.mjs',
+		'scripts/omp-rpc-conformance-lib.mjs',
+		'scripts/omp-rpc-conformance.mjs',
+		'scripts/fixtures/omp-rpc-18.1.6-baseline.json',
+		'scripts/fixtures/omp-rpc-upstream-requirements.json',
+	]) {
+		harnessDigest.update(relativePath);
+		harnessDigest.update(await readFile(path.join(process.cwd(), relativePath)));
+	}
+	target.harnessSha256 = harnessDigest.digest('hex');
+	try {
+		const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], {
+			cwd: process.cwd(),
+			windowsHide: true,
+			timeout: 30_000,
+		});
+		target.sourceRevision = stdout.trim();
+	} catch {
+		target.sourceRevision = 'unavailable';
+	}
+}
+
+function runCodecSelfCheck() {
+	const physical = new JsonLineDecoder({ maxFrameBytes: 256 });
+	const snowman = '\u2603';
+	const frame = Buffer.from(`${JSON.stringify({ type: 'notice', value: snowman })}\n`, 'utf8');
+	const boundary = frame.indexOf(Buffer.from(snowman)) + 1;
+	if (physical.push(frame.subarray(0, boundary)).length !== 0) {
+		throw new Error('UTF-8 split unexpectedly emitted a physical frame');
+	}
+	const decoded = physical.push(frame.subarray(boundary));
+	if (decoded[0]?.value !== snowman) throw new Error('UTF-8 split did not round-trip');
+
+	const logical = { type: 'response', id: 'self-check', data: { value: snowman.repeat(16) } };
+	const bytes = Buffer.from(JSON.stringify(logical), 'utf8');
+	const split = Math.floor(bytes.length / 2);
+	const chunks = [bytes.subarray(0, split), bytes.subarray(split)];
+	const reassembler = new RpcV2FrameDecoder({ maxReassembledFrameBytes: 1024 });
+	let value = null;
+	for (let index = 0; index < chunks.length; index += 1) {
+		value = reassembler.push({
+			type: 'rpc_chunk',
+			chunkId: 'rpc-self-check',
+			index,
+			count: chunks.length,
+			byteLength: bytes.length,
+			data: chunks[index].toString('base64'),
+		});
+	}
+	if (hashJson(value) !== hashJson(logical)) throw new Error('RPC v2 chunk self-check failed');
+}
+
+function countFrameTypes(frames) {
+	const counts = {};
+	for (const frame of frames) {
+		const key = typeof frame.type === 'string' ? frame.type : 'unknown';
+		counts[key] = (counts[key] ?? 0) + 1;
+	}
+	return Object.fromEntries(
+		Object.entries(counts).sort(([left], [right]) => left.localeCompare(right))
+	);
+}
+
+function stableJson(value) {
+	if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+	if (value && typeof value === 'object') {
+		return `{${Object.keys(value)
+			.sort()
+			.map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`)
+			.join(',')}}`;
+	}
+	return JSON.stringify(value);
+}
+
+function hashJson(value) {
+	return sha256(Buffer.from(stableJson(value), 'utf8'));
+}
+
+function sha256(bytes) {
+	return createHash('sha256').update(bytes).digest('hex');
+}
+
+async function hashFile(filePath) {
+	const digest = createHash('sha256');
+	for await (const chunk of createReadStream(filePath)) digest.update(chunk);
+	return digest.digest('hex');
+}
+
+async function withTimeout(promise, timeoutMs, description) {
+	let timer;
+	const timeout = new Promise((_, reject) => {
+		timer = setTimeout(() => reject(new Error(`timed out waiting for ${description}`)), timeoutMs);
+	});
+	try {
+		return await Promise.race([promise, timeout]);
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+function errorMessage(error) {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/scripts/omp-rpc-conformance.test.mjs
+++ b/scripts/omp-rpc-conformance.test.mjs
@@ -1,0 +1,273 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+	assertSuccessfulResponse,
+	buildExtensionUiResponse,
+	classifyPowerUserCapabilities,
+	comparePinnedIdentity,
+	computeConformanceVerdict,
+	parseConformanceArgs,
+	parseOmpVersionOutput,
+	validateBaseline,
+} from './omp-rpc-conformance-lib.mjs';
+
+const scriptsDirectory = path.dirname(fileURLToPath(import.meta.url));
+const baselinePath = path.join(scriptsDirectory, 'fixtures', 'omp-rpc-18.1.6-baseline.json');
+const baseline = JSON.parse(await readFile(baselinePath, 'utf8'));
+const upstreamRequirements = JSON.parse(
+	await readFile(
+		path.join(scriptsDirectory, 'fixtures', 'omp-rpc-upstream-requirements.json'),
+		'utf8'
+	)
+);
+
+test('upstream G1 G2 G3 G5 contracts are explicit and correlation-bearing', () => {
+	assert.equal(upstreamRequirements.schemaVersion, 1);
+	assert.deepEqual(
+		upstreamRequirements.requirements.map((requirement) => requirement.id),
+		['G1', 'G2', 'G3', 'G5']
+	);
+	for (const requirement of upstreamRequirements.requirements) {
+		assert.match(
+			requirement.request.type,
+			/^(create_worker|command_worker|get_subagent_messages|abort_and_prompt)$/
+		);
+		assert.ok(requirement.request.required.includes('id'));
+		assert.ok(requirement.response.successDataRequired.length > 0);
+		assert.ok(requirement.events.length > 0);
+		assert.ok(
+			requirement.invariants.some((invariant) => /acknowledgement|correlat/i.test(invariant))
+		);
+	}
+});
+
+test('extension UI responses select one-time approval and explicit rejection values', () => {
+	const request = {
+		type: 'extension_ui_request',
+		id: 'approval-1',
+		method: 'select',
+		options: [
+			{ label: 'Always allow', value: 'always' },
+			{ label: 'Allow once', value: 'once' },
+			{ label: 'Reject', value: 'reject' },
+		],
+	};
+	assert.deepEqual(buildExtensionUiResponse(request, 'approve'), {
+		type: 'extension_ui_response',
+		id: 'approval-1',
+		value: 'once',
+	});
+	assert.deepEqual(buildExtensionUiResponse(request, 'reject'), {
+		type: 'extension_ui_response',
+		id: 'approval-1',
+		value: 'reject',
+	});
+});
+
+test('extension UI responses cancel unknown selects and confirm boolean prompts', () => {
+	assert.deepEqual(
+		buildExtensionUiResponse({ id: 'select-1', method: 'select', options: [] }, 'reject'),
+		{ type: 'extension_ui_response', id: 'select-1', cancelled: true }
+	);
+	assert.deepEqual(buildExtensionUiResponse({ id: 'confirm-1', method: 'confirm' }, 'approve'), {
+		type: 'extension_ui_response',
+		id: 'confirm-1',
+		confirmed: true,
+	});
+});
+test('OMP version parser accepts the public slash form only', () => {
+	assert.equal(parseOmpVersionOutput('omp/18.1.6\n'), '18.1.6');
+	assert.throws(() => parseOmpVersionOutput('omp v18.1.6'), /exact OMP version/);
+	assert.throws(() => parseOmpVersionOutput('18.1'), /exact OMP version/);
+});
+
+test('the pinned baseline is internally complete and unique', () => {
+	assert.equal(validateBaseline(baseline), baseline);
+	assert.equal(new Set(baseline.requiredCommandTypes).size, baseline.requiredCommandTypes.length);
+	assert.equal(new Set(baseline.requiredEventTypes).size, baseline.requiredEventTypes.length);
+	assert.deepEqual(baseline.requiredCases, [
+		'A01',
+		'A02',
+		'A03',
+		'A04',
+		'A05',
+		'A06',
+		'A07',
+		'A08',
+		'A09',
+		'A10',
+		'A11',
+	]);
+});
+
+test('parseConformanceArgs requires an explicit absolute OMP executable', () => {
+	assert.throws(() => parseConformanceArgs([]), /--executable/);
+	assert.throws(() => parseConformanceArgs(['--executable', 'omp']), /absolute path/);
+	assert.deepEqual(
+		parseConformanceArgs([
+			'--executable',
+			'C:\\Tools\\omp.exe',
+			'--baseline',
+			baselinePath,
+			'--output',
+			'C:\\Temp\\report.json',
+			'--live',
+		]),
+		{
+			executable: path.resolve('C:\\Tools\\omp.exe'),
+			baselinePath: path.resolve(baselinePath),
+			outputPath: path.resolve('C:\\Temp\\report.json'),
+			live: true,
+		}
+	);
+});
+
+test('parseConformanceArgs rejects unknown flags and missing values', () => {
+	assert.throws(() => parseConformanceArgs(['--executable']), /requires a value/);
+	assert.throws(
+		() => parseConformanceArgs(['--executable', 'C:\\Tools\\omp.exe', '--surprise']),
+		/unknown argument/
+	);
+});
+
+test('comparePinnedIdentity requires exact semantic version and SHA-256 digest', () => {
+	assert.deepEqual(
+		comparePinnedIdentity({ version: '18.1.6', sha256: baseline.omp.sha256 }, baseline),
+		{ status: 'pass', reasons: [] }
+	);
+	assert.deepEqual(comparePinnedIdentity({ version: '18.1.7', sha256: '0'.repeat(64) }, baseline), {
+		status: 'fail',
+		reasons: [
+			'expected OMP 18.1.6, observed 18.1.7',
+			`expected SHA-256 ${baseline.omp.sha256}, observed ${'0'.repeat(64)}`,
+		],
+	});
+});
+
+test('assertSuccessfulResponse returns data and rejects failed or mismatched responses', () => {
+	assert.deepEqual(
+		assertSuccessfulResponse(
+			{ type: 'response', command: 'get_state', success: true, data: { value: 1 } },
+			'get_state'
+		),
+		{ value: 1 }
+	);
+	assert.throws(
+		() =>
+			assertSuccessfulResponse(
+				{ type: 'response', command: 'get_state', success: false, code: 'stale_cursor' },
+				'get_state'
+			),
+		/stale_cursor/
+	);
+	assert.throws(
+		() =>
+			assertSuccessfulResponse({ type: 'response', command: 'prompt', success: true }, 'get_state'),
+		/expected get_state/
+	);
+});
+
+test('power-user capability classification exposes fleet gaps and proves observed signals', () => {
+	assert.deepEqual(
+		classifyPowerUserCapabilities({
+			commandTypes: baseline.requiredCommandTypes,
+			workerTranscriptObserved: true,
+			abortAndPromptCompletionObserved: true,
+		}),
+		[
+			{
+				id: 'G1',
+				name: 'host-created workers',
+				status: 'unsupported',
+				reason: 'RPC has observation APIs but no create_worker command.',
+			},
+			{
+				id: 'G2',
+				name: 'direct worker steering and messaging',
+				status: 'unsupported',
+				reason: 'RPC steering targets the root session and exposes no command_worker command.',
+			},
+			{
+				id: 'G3',
+				name: 'completed worker transcript visibility',
+				status: 'supported',
+				reason: 'get_subagent_messages exposed the completed worker message.',
+			},
+			{
+				id: 'G5',
+				name: 'deterministic abort-and-prompt completion',
+				status: 'supported',
+				reason: 'Observed response.data.agentInvoked or prompt_result completion correlation.',
+			},
+		]
+	);
+});
+test('power-user capability classification requires an observed Worker transcript', () => {
+	const capabilities = classifyPowerUserCapabilities({
+		commandTypes: baseline.requiredCommandTypes,
+		workerTranscriptObserved: false,
+		abortAndPromptCompletionObserved: true,
+	});
+	assert.equal(capabilities[2].id, 'G3');
+	assert.equal(capabilities[2].status, 'unsupported');
+});
+test('conformance verdict blocks workload parity on missing Worker transcript visibility', () => {
+	const cases = baseline.requiredCases.map((id) => ({ id, required: true, status: 'pass' }));
+	const capabilities = classifyPowerUserCapabilities({
+		commandTypes: [...baseline.requiredCommandTypes, 'create_worker', 'command_worker'],
+		workerTranscriptObserved: false,
+		abortAndPromptCompletionObserved: true,
+	});
+	assert.deepEqual(computeConformanceVerdict({ cases, capabilities }), {
+		adapterProtocol: 'pass',
+		workloadParity: 'blocked',
+		blockingCaseIds: [],
+		blockingCapabilityIds: ['G3'],
+	});
+});
+
+test('power-user capability classification never infers G5 from command acceptance alone', () => {
+	assert.equal(
+		classifyPowerUserCapabilities({
+			commandTypes: baseline.requiredCommandTypes,
+			workerTranscriptObserved: true,
+			abortAndPromptCompletionObserved: false,
+		})[3].status,
+		'ambiguous'
+	);
+});
+
+test('conformance verdict separates adapter protocol readiness from workload parity', () => {
+	const cases = baseline.requiredCases.map((id) => ({ id, required: true, status: 'pass' }));
+	const capabilities = classifyPowerUserCapabilities({
+		commandTypes: baseline.requiredCommandTypes,
+		workerTranscriptObserved: true,
+		abortAndPromptCompletionObserved: true,
+	});
+	assert.deepEqual(computeConformanceVerdict({ cases, capabilities }), {
+		adapterProtocol: 'pass',
+		workloadParity: 'blocked',
+		blockingCaseIds: [],
+		blockingCapabilityIds: ['G1', 'G2'],
+	});
+});
+
+test('required failed, ambiguous, or not-run cases fail the adapter protocol gate', () => {
+	for (const status of ['fail', 'ambiguous', 'not-run']) {
+		const cases = baseline.requiredCases.map((id) => ({
+			id,
+			required: true,
+			status: id === 'A04' ? status : 'pass',
+		}));
+		assert.deepEqual(computeConformanceVerdict({ cases, capabilities: [] }), {
+			adapterProtocol: 'fail',
+			workloadParity: 'blocked',
+			blockingCaseIds: ['A04'],
+			blockingCapabilityIds: [],
+		});
+	}
+});

--- a/scripts/omp-rpc-protocol.mjs
+++ b/scripts/omp-rpc-protocol.mjs
@@ -1,0 +1,520 @@
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { TextDecoder } from 'node:util';
+
+export const OMP_RPC_DEFAULT_MAX_FRAME_BYTES = 1_048_576;
+export const OMP_RPC_DEFAULT_SERVER_MAX_REASSEMBLED_BYTES = 67_108_864;
+export const MAESTRO_RPC_MAX_REASSEMBLED_BYTES = 8_388_608;
+const MAX_CHUNK_COUNT = 65_536;
+const MAX_CHUNK_ID_LENGTH = 128;
+const MAX_STDERR_BYTES = 65_536;
+
+function isRecord(value) {
+	return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseJsonObject(text, label) {
+	let value;
+	try {
+		value = JSON.parse(text);
+	} catch (error) {
+		throw new Error(
+			`${label} contains invalid JSON: ${error instanceof Error ? error.message : String(error)}`
+		);
+	}
+	if (!isRecord(value)) {
+		throw new Error(`${label} must contain a JSON object`);
+	}
+	return value;
+}
+
+export class JsonLineDecoder {
+	#buffer = Buffer.alloc(0);
+	#maxFrameBytes;
+
+	constructor({ maxFrameBytes = OMP_RPC_DEFAULT_MAX_FRAME_BYTES } = {}) {
+		if (!Number.isSafeInteger(maxFrameBytes) || maxFrameBytes < 1) {
+			throw new TypeError('maxFrameBytes must be a positive safe integer');
+		}
+		this.#maxFrameBytes = maxFrameBytes;
+	}
+
+	get bufferedBytes() {
+		return this.#buffer.byteLength;
+	}
+
+	push(chunk) {
+		const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+		if (bytes.byteLength === 0) return [];
+		this.#buffer = this.#buffer.byteLength === 0 ? bytes : Buffer.concat([this.#buffer, bytes]);
+		const frames = [];
+		let start = 0;
+		for (;;) {
+			const newline = this.#buffer.indexOf(0x0a, start);
+			if (newline === -1) break;
+			let end = newline;
+			if (end > start && this.#buffer[end - 1] === 0x0d) end -= 1;
+			const frameLength = end - start;
+			if (frameLength > this.#maxFrameBytes) {
+				this.#buffer = Buffer.alloc(0);
+				throw new Error(
+					`RPC physical frame limit exceeded: ${frameLength} > ${this.#maxFrameBytes}`
+				);
+			}
+			if (frameLength > 0) {
+				const text = new TextDecoder('utf-8', { fatal: true }).decode(
+					this.#buffer.subarray(start, end)
+				);
+				frames.push(parseJsonObject(text, 'RPC JSONL frame'));
+			}
+			start = newline + 1;
+		}
+		this.#buffer = start === 0 ? this.#buffer : this.#buffer.subarray(start);
+		if (this.#buffer.byteLength > this.#maxFrameBytes) {
+			const length = this.#buffer.byteLength;
+			this.#buffer = Buffer.alloc(0);
+			throw new Error(`RPC physical frame limit exceeded: ${length} > ${this.#maxFrameBytes}`);
+		}
+		return frames;
+	}
+
+	flush() {
+		if (this.#buffer.byteLength === 0) return;
+		const remaining = this.#buffer;
+		this.#buffer = Buffer.alloc(0);
+		if (remaining.toString('utf8').trim().length === 0) return;
+		throw new Error(
+			`RPC stdout ended with a truncated JSONL frame (${remaining.byteLength} bytes)`
+		);
+	}
+}
+
+export function validateReadyFrame(frame) {
+	if (!isRecord(frame) || frame.type !== 'ready') {
+		throw new Error('first RPC frame must be a ready object');
+	}
+	const { protocolVersion, supportedProtocolVersions, maxFrameBytes, maxReassembledFrameBytes } =
+		frame;
+	if (!Number.isSafeInteger(protocolVersion) || protocolVersion < 1) {
+		throw new Error('ready.protocolVersion must be a positive integer');
+	}
+	if (
+		!Array.isArray(supportedProtocolVersions) ||
+		supportedProtocolVersions.length === 0 ||
+		!supportedProtocolVersions.every((version) => Number.isSafeInteger(version) && version > 0)
+	) {
+		throw new Error('ready.supportedProtocolVersions must contain positive integers');
+	}
+	if (!supportedProtocolVersions.includes(protocolVersion)) {
+		throw new Error('ready protocolVersion is absent from supportedProtocolVersions');
+	}
+	if (!Number.isSafeInteger(maxFrameBytes) || maxFrameBytes < 1) {
+		throw new Error('ready.maxFrameBytes must be a positive safe integer');
+	}
+	if (!Number.isSafeInteger(maxReassembledFrameBytes) || maxReassembledFrameBytes < maxFrameBytes) {
+		throw new Error(
+			'ready reassembled limit must be a safe integer at least as large as maxFrameBytes'
+		);
+	}
+	return {
+		protocolVersion,
+		supportedProtocolVersions: [...supportedProtocolVersions],
+		maxFrameBytes,
+		maxReassembledFrameBytes,
+	};
+}
+
+export function clampTransportLimits(
+	limits,
+	{
+		maxFrameBytes = OMP_RPC_DEFAULT_MAX_FRAME_BYTES,
+		maxReassembledFrameBytes = MAESTRO_RPC_MAX_REASSEMBLED_BYTES,
+	} = {}
+) {
+	if (!isRecord(limits)) throw new TypeError('transport limits must be an object');
+	return {
+		maxFrameBytes: Math.min(limits.maxFrameBytes, maxFrameBytes),
+		maxReassembledFrameBytes: Math.min(limits.maxReassembledFrameBytes, maxReassembledFrameBytes),
+	};
+}
+
+function decodeCanonicalBase64(data) {
+	if (
+		typeof data !== 'string' ||
+		data.length % 4 !== 0 ||
+		!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(data)
+	) {
+		throw new Error('rpc_chunk.data must be canonical base64');
+	}
+	const bytes = Buffer.from(data, 'base64');
+	if (bytes.toString('base64') !== data) {
+		throw new Error('rpc_chunk.data must be canonical base64');
+	}
+	return bytes;
+}
+
+function validateChunk(frame, maxReassembledFrameBytes) {
+	if (!isRecord(frame) || frame.type !== 'rpc_chunk') {
+		throw new Error('expected an rpc_chunk object');
+	}
+	if (
+		typeof frame.chunkId !== 'string' ||
+		frame.chunkId.length === 0 ||
+		frame.chunkId.length > MAX_CHUNK_ID_LENGTH
+	) {
+		throw new Error('rpc_chunk.chunkId must be a bounded non-empty string');
+	}
+	if (!Number.isSafeInteger(frame.index) || frame.index < 0) {
+		throw new Error('rpc_chunk.index must be a non-negative safe integer');
+	}
+	if (!Number.isSafeInteger(frame.count) || frame.count < 1 || frame.count > MAX_CHUNK_COUNT) {
+		throw new Error(`rpc_chunk.count must be between 1 and ${MAX_CHUNK_COUNT}`);
+	}
+	if (frame.index >= frame.count) {
+		throw new Error('rpc_chunk.index must be smaller than count');
+	}
+	if (
+		!Number.isSafeInteger(frame.byteLength) ||
+		frame.byteLength < 0 ||
+		frame.byteLength > maxReassembledFrameBytes
+	) {
+		throw new Error(
+			`RPC logical frame limit exceeded: ${String(frame.byteLength)} > ${maxReassembledFrameBytes}`
+		);
+	}
+	return { ...frame, bytes: decodeCanonicalBase64(frame.data) };
+}
+
+export class RpcV2FrameDecoder {
+	#active = null;
+	#maxReassembledFrameBytes;
+
+	constructor({ maxReassembledFrameBytes = MAESTRO_RPC_MAX_REASSEMBLED_BYTES } = {}) {
+		if (!Number.isSafeInteger(maxReassembledFrameBytes) || maxReassembledFrameBytes < 1) {
+			throw new TypeError('maxReassembledFrameBytes must be a positive safe integer');
+		}
+		this.#maxReassembledFrameBytes = maxReassembledFrameBytes;
+	}
+
+	get hasActiveSequence() {
+		return this.#active !== null;
+	}
+
+	reset() {
+		this.#active = null;
+	}
+
+	push(frame) {
+		if (!isRecord(frame)) throw new Error('RPC frame must be a JSON object');
+		if (frame.type !== 'rpc_chunk') {
+			if (this.#active) {
+				this.reset();
+				throw new Error('RPC chunk sequence was interrupted by an ordinary frame');
+			}
+			return frame;
+		}
+
+		try {
+			const chunk = validateChunk(frame, this.#maxReassembledFrameBytes);
+			if (!this.#active) {
+				if (chunk.index !== 0) throw new Error('RPC chunk sequence must start at index 0');
+				this.#active = {
+					chunkId: chunk.chunkId,
+					count: chunk.count,
+					byteLength: chunk.byteLength,
+					nextIndex: 0,
+					receivedBytes: 0,
+					chunks: [],
+				};
+			}
+			const active = this.#active;
+			if (chunk.chunkId !== active.chunkId)
+				throw new Error('RPC chunk sequences cannot be interleaved');
+			if (chunk.count !== active.count)
+				throw new Error('RPC chunk count changed during reassembly');
+			if (chunk.byteLength !== active.byteLength) {
+				throw new Error('RPC chunk byteLength changed during reassembly');
+			}
+			if (chunk.index !== active.nextIndex) {
+				throw new Error(
+					`RPC chunk index out of order: expected ${active.nextIndex}, got ${chunk.index}`
+				);
+			}
+			active.receivedBytes += chunk.bytes.byteLength;
+			if (
+				active.receivedBytes > active.byteLength ||
+				active.receivedBytes > this.#maxReassembledFrameBytes
+			) {
+				throw new Error('RPC chunk payload exceeds its declared or configured logical frame limit');
+			}
+			active.chunks.push(chunk.bytes);
+			active.nextIndex += 1;
+			if (active.nextIndex < active.count) return null;
+			if (active.receivedBytes !== active.byteLength) {
+				throw new Error(
+					`RPC chunk byteLength mismatch: expected ${active.byteLength}, received ${active.receivedBytes}`
+				);
+			}
+			const bytes = Buffer.concat(active.chunks, active.receivedBytes);
+			this.reset();
+			let text;
+			try {
+				text = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+			} catch (error) {
+				throw new Error(
+					`RPC logical frame contains invalid UTF-8: ${error instanceof Error ? error.message : String(error)}`
+				);
+			}
+			return parseJsonObject(text, 'RPC logical frame');
+		} catch (error) {
+			this.reset();
+			throw error;
+		}
+	}
+}
+
+export function summarizeProtocolFrame(frame) {
+	if (!isRecord(frame)) {
+		return { type: null, idPresent: false, command: null, success: null, keys: [] };
+	}
+	return {
+		type: typeof frame.type === 'string' ? frame.type : null,
+		idPresent: typeof frame.id === 'string',
+		command: typeof frame.command === 'string' ? frame.command : null,
+		success: typeof frame.success === 'boolean' ? frame.success : null,
+		keys: Object.keys(frame).sort(),
+	};
+}
+
+function replaceCaseInsensitive(value, search, replacement) {
+	if (!search) return value;
+	const lowerValue = value.toLowerCase();
+	const lowerSearch = search.toLowerCase();
+	let cursor = 0;
+	let result = '';
+	for (;;) {
+		const found = lowerValue.indexOf(lowerSearch, cursor);
+		if (found === -1) return result + value.slice(cursor);
+		result += value.slice(cursor, found) + replacement;
+		cursor = found + search.length;
+	}
+}
+
+export function redactConformanceReport(report) {
+	if (!isRecord(report)) throw new TypeError('conformance report must be an object');
+	const executable = typeof report.executable === 'string' ? report.executable : '';
+	const workspace = typeof report.workspace === 'string' ? report.workspace : '';
+	const visit = (value) => {
+		if (typeof value === 'string') {
+			return replaceCaseInsensitive(
+				replaceCaseInsensitive(value, workspace, '<isolated-workspace>'),
+				executable,
+				'<explicit-omp-executable>'
+			);
+		}
+		if (Array.isArray(value)) return value.map(visit);
+		if (!isRecord(value)) return value;
+		return Object.fromEntries(Object.entries(value).map(([key, child]) => [key, visit(child)]));
+	};
+	return visit(report);
+}
+
+export class RpcProcessPeer {
+	#child;
+	#lineDecoder;
+	#chunkDecoder;
+	#pending = new Map();
+	#waiters = new Set();
+	#closed = false;
+	#readySeen = false;
+	#stderr = '';
+	#onFrame;
+	#readyResolve;
+	#readyReject;
+	ready;
+
+	constructor({
+		executable,
+		args,
+		cwd,
+		env,
+		onFrame,
+		maxFrameBytes = OMP_RPC_DEFAULT_MAX_FRAME_BYTES,
+	}) {
+		if (typeof executable !== 'string' || executable.length === 0) {
+			throw new TypeError('executable is required');
+		}
+		this.#lineDecoder = new JsonLineDecoder({ maxFrameBytes });
+		this.#chunkDecoder = new RpcV2FrameDecoder();
+		this.#onFrame = onFrame;
+		this.ready = new Promise((resolve, reject) => {
+			this.#readyResolve = resolve;
+			this.#readyReject = reject;
+		});
+		this.#child = spawn(executable, args, {
+			cwd,
+			env,
+			shell: false,
+			windowsHide: true,
+			stdio: ['pipe', 'pipe', 'pipe'],
+		});
+		this.#child.stdout.on('data', (chunk) => this.#receive(chunk));
+		this.#child.stderr.on('data', (chunk) => {
+			if (Buffer.byteLength(this.#stderr) >= MAX_STDERR_BYTES) return;
+			this.#stderr += chunk.toString('utf8').slice(0, MAX_STDERR_BYTES - this.#stderr.length);
+		});
+		this.#child.on('error', (error) => this.#terminate(error));
+		this.#child.on('close', (code, signal) => {
+			try {
+				this.#lineDecoder.flush();
+			} catch (error) {
+				this.#terminate(error);
+				return;
+			}
+			this.#terminate(
+				new Error(`OMP RPC process exited (code=${String(code)}, signal=${String(signal)})`)
+			);
+		});
+	}
+
+	get stderr() {
+		return this.#stderr;
+	}
+
+	get closed() {
+		return this.#closed;
+	}
+
+	send(frame) {
+		if (this.#closed || !this.#child.stdin.writable) throw new Error('OMP RPC process is closed');
+		this.#child.stdin.write(`${JSON.stringify(frame)}\n`);
+	}
+
+	sendRaw(line) {
+		if (this.#closed || !this.#child.stdin.writable) throw new Error('OMP RPC process is closed');
+		this.#child.stdin.write(line.endsWith('\n') ? line : `${line}\n`);
+	}
+
+	request(type, params = {}, timeoutMs = 10_000) {
+		const id = `maestro-${randomUUID()}`;
+		return new Promise((resolve, reject) => {
+			const timer = setTimeout(() => {
+				this.#pending.delete(id);
+				reject(new Error(`timed out waiting for RPC ${type} response`));
+			}, timeoutMs);
+			this.#pending.set(id, { type, resolve, reject, timer });
+			try {
+				this.send({ id, type, ...params });
+			} catch (error) {
+				clearTimeout(timer);
+				this.#pending.delete(id);
+				reject(error);
+			}
+		});
+	}
+
+	waitForFrame(predicate, timeoutMs = 10_000, description = 'RPC frame') {
+		return new Promise((resolve, reject) => {
+			const waiter = {
+				predicate,
+				resolve,
+				reject,
+				timer: setTimeout(() => {
+					this.#waiters.delete(waiter);
+					reject(new Error(`timed out waiting for ${description}`));
+				}, timeoutMs),
+			};
+			this.#waiters.add(waiter);
+		});
+	}
+
+	async close({ timeoutMs = 2_000 } = {}) {
+		if (this.#closed) return;
+		const child = this.#child;
+		const closed = new Promise((resolve) => child.once('close', resolve));
+		let killTimer;
+		const forced = new Promise((resolve) => {
+			killTimer = setTimeout(() => {
+				if (!this.#closed) child.kill();
+				resolve();
+			}, timeoutMs);
+		});
+		child.stdin.end();
+		try {
+			await Promise.race([closed, forced]);
+		} finally {
+			clearTimeout(killTimer);
+		}
+	}
+
+	#receive(chunk) {
+		try {
+			for (const physicalFrame of this.#lineDecoder.push(chunk)) {
+				const logicalFrame = this.#chunkDecoder.push(physicalFrame);
+				if (logicalFrame) this.#dispatch(logicalFrame);
+			}
+		} catch (error) {
+			this.#terminate(error);
+			this.#child.kill();
+		}
+	}
+
+	#dispatch(frame) {
+		if (frame.type !== 'ready' && !this.#readySeen) {
+			throw new Error('first RPC frame must be ready');
+		}
+		if (frame.type === 'ready' && this.#readySeen) {
+			throw new Error('RPC stream emitted more than one ready frame');
+		}
+		if (frame.type === 'ready') {
+			const ready = validateReadyFrame(frame);
+			const limits = clampTransportLimits(ready);
+			this.#chunkDecoder = new RpcV2FrameDecoder({
+				maxReassembledFrameBytes: limits.maxReassembledFrameBytes,
+			});
+			this.#lineDecoder = new JsonLineDecoder({ maxFrameBytes: limits.maxFrameBytes });
+			this.#readySeen = true;
+			this.#readyResolve(frame);
+		}
+		if (frame.type === 'response' && typeof frame.id === 'string') {
+			const pending = this.#pending.get(frame.id);
+			if (pending) {
+				clearTimeout(pending.timer);
+				this.#pending.delete(frame.id);
+				pending.resolve(frame);
+			}
+		}
+		for (const waiter of [...this.#waiters]) {
+			let matches = false;
+			try {
+				matches = waiter.predicate(frame);
+			} catch (error) {
+				clearTimeout(waiter.timer);
+				this.#waiters.delete(waiter);
+				waiter.reject(error);
+				continue;
+			}
+			if (!matches) continue;
+			clearTimeout(waiter.timer);
+			this.#waiters.delete(waiter);
+			waiter.resolve(frame);
+		}
+		this.#onFrame?.(frame, this);
+	}
+
+	#terminate(error) {
+		if (this.#closed) return;
+		this.#closed = true;
+		this.#readyReject(error);
+		for (const pending of this.#pending.values()) {
+			clearTimeout(pending.timer);
+			pending.reject(error);
+		}
+		this.#pending.clear();
+		for (const waiter of this.#waiters) {
+			clearTimeout(waiter.timer);
+			waiter.reject(error);
+		}
+		this.#waiters.clear();
+	}
+}

--- a/scripts/omp-rpc-protocol.test.mjs
+++ b/scripts/omp-rpc-protocol.test.mjs
@@ -1,0 +1,262 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+	JsonLineDecoder,
+	RpcProcessPeer,
+	RpcV2FrameDecoder,
+	clampTransportLimits,
+	redactConformanceReport,
+	summarizeProtocolFrame,
+	validateReadyFrame,
+} from './omp-rpc-protocol.mjs';
+
+const jsonLine = (value) => Buffer.from(`${JSON.stringify(value)}\n`, 'utf8');
+
+function chunkFrames(value, splitAt) {
+	const bytes = Buffer.from(JSON.stringify(value), 'utf8');
+	const chunks = [bytes.subarray(0, splitAt), bytes.subarray(splitAt)];
+	return chunks.map((chunk, index) => ({
+		type: 'rpc_chunk',
+		chunkId: 'rpc-test',
+		index,
+		count: chunks.length,
+		byteLength: bytes.length,
+		data: chunk.toString('base64'),
+	}));
+}
+
+test('JsonLineDecoder preserves UTF-8 split across byte chunks', () => {
+	const decoder = new JsonLineDecoder({ maxFrameBytes: 128 });
+	const snowman = '\u2603';
+	const frame = jsonLine({ type: 'notice', text: `before ${snowman} after` });
+	const splitAt = frame.indexOf(Buffer.from(snowman)) + 1;
+
+	assert.deepEqual(decoder.push(frame.subarray(0, splitAt)), []);
+	assert.deepEqual(decoder.push(frame.subarray(splitAt)), [
+		{ type: 'notice', text: `before ${snowman} after` },
+	]);
+	assert.equal(decoder.bufferedBytes, 0);
+});
+
+test('JsonLineDecoder accepts CRLF and ignores empty lines', () => {
+	const decoder = new JsonLineDecoder({ maxFrameBytes: 128 });
+	assert.deepEqual(decoder.push(Buffer.from('\r\n{"type":"ready"}\r\n\n')), [{ type: 'ready' }]);
+});
+
+test('JsonLineDecoder rejects non-object JSON and invalid JSON', () => {
+	const decoder = new JsonLineDecoder({ maxFrameBytes: 128 });
+	assert.throws(() => decoder.push(Buffer.from('[]\n')), /JSON object/);
+	assert.throws(() => new JsonLineDecoder().push(Buffer.from('{broken}\n')), /invalid JSON/);
+});
+
+test('JsonLineDecoder enforces the physical frame limit before newline', () => {
+	const decoder = new JsonLineDecoder({ maxFrameBytes: 8 });
+	assert.throws(() => decoder.push(Buffer.from('123456789')), /physical frame limit/);
+});
+
+test('JsonLineDecoder flush rejects a truncated final frame', () => {
+	const decoder = new JsonLineDecoder({ maxFrameBytes: 128 });
+	decoder.push(Buffer.from('{"type":"ready"'));
+	assert.throws(() => decoder.flush(), /truncated JSONL frame/);
+});
+
+test('validateReadyFrame accepts the public v1 ready frame and protocol v2 advertisement', () => {
+	assert.deepEqual(
+		validateReadyFrame({
+			type: 'ready',
+			protocolVersion: 1,
+			supportedProtocolVersions: [1, 2],
+			maxFrameBytes: 1_048_576,
+			maxReassembledFrameBytes: 67_108_864,
+		}),
+		{
+			protocolVersion: 1,
+			supportedProtocolVersions: [1, 2],
+			maxFrameBytes: 1_048_576,
+			maxReassembledFrameBytes: 67_108_864,
+		}
+	);
+});
+
+test('validateReadyFrame rejects malformed or contradictory limits', () => {
+	assert.throws(
+		() =>
+			validateReadyFrame({
+				type: 'ready',
+				protocolVersion: 1,
+				supportedProtocolVersions: [1],
+				maxFrameBytes: 0,
+				maxReassembledFrameBytes: 10,
+			}),
+		/maxFrameBytes/
+	);
+	assert.throws(
+		() =>
+			validateReadyFrame({
+				type: 'ready',
+				protocolVersion: 1,
+				supportedProtocolVersions: [1, 2],
+				maxFrameBytes: 100,
+				maxReassembledFrameBytes: 99,
+			}),
+		/reassembled limit/
+	);
+});
+
+test('clampTransportLimits applies Maestro product ceilings', () => {
+	assert.deepEqual(
+		clampTransportLimits({ maxFrameBytes: 2_000_000, maxReassembledFrameBytes: 67_108_864 }),
+		{ maxFrameBytes: 1_048_576, maxReassembledFrameBytes: 8_388_608 }
+	);
+});
+
+test('RpcV2FrameDecoder reassembles an ordered logical object', () => {
+	const expected = { type: 'response', id: 'messages', data: { value: ''.repeat(20) } };
+	const frames = chunkFrames(expected, 17);
+	const decoder = new RpcV2FrameDecoder({ maxReassembledFrameBytes: 1024 });
+
+	assert.equal(decoder.push(frames[0]), null);
+	assert.deepEqual(decoder.push(frames[1]), expected);
+	assert.equal(decoder.hasActiveSequence, false);
+});
+
+test('RpcV2FrameDecoder passes through ordinary frames when idle', () => {
+	const decoder = new RpcV2FrameDecoder();
+	assert.deepEqual(decoder.push({ type: 'response', id: 'one', success: true }), {
+		type: 'response',
+		id: 'one',
+		success: true,
+	});
+});
+
+test('RpcV2FrameDecoder rejects interleaved and out-of-order sequences', () => {
+	const decoder = new RpcV2FrameDecoder({ maxReassembledFrameBytes: 1024 });
+	const [first, second] = chunkFrames({ type: 'response', data: 'abc' }, 8);
+	assert.equal(decoder.push(first), null);
+	assert.throws(() => decoder.push({ ...second, chunkId: 'rpc-other' }), /interleaved/);
+
+	const fresh = new RpcV2FrameDecoder({ maxReassembledFrameBytes: 1024 });
+	assert.throws(() => fresh.push(second), /index 0/);
+});
+
+test('RpcV2FrameDecoder rejects interruption by an ordinary frame', () => {
+	const decoder = new RpcV2FrameDecoder({ maxReassembledFrameBytes: 1024 });
+	const [first] = chunkFrames({ type: 'response', data: 'abc' }, 8);
+	assert.equal(decoder.push(first), null);
+	assert.throws(() => decoder.push({ type: 'notice' }), /interrupted/);
+	assert.equal(decoder.hasActiveSequence, false);
+});
+
+test('RpcV2FrameDecoder rejects inconsistent metadata and non-canonical base64', () => {
+	const decoder = new RpcV2FrameDecoder({ maxReassembledFrameBytes: 1024 });
+	const [first, second] = chunkFrames({ type: 'response', data: 'abc' }, 8);
+	assert.equal(decoder.push(first), null);
+	assert.throws(() => decoder.push({ ...second, count: 3 }), /count changed/);
+
+	assert.throws(
+		() =>
+			new RpcV2FrameDecoder().push({
+				type: 'rpc_chunk',
+				chunkId: 'rpc-invalid',
+				index: 0,
+				count: 1,
+				byteLength: 3,
+				data: '@@@=',
+			}),
+		/base64/
+	);
+});
+
+test('RpcV2FrameDecoder enforces declared byte length and logical limit', () => {
+	const expected = { type: 'response', data: '0123456789' };
+	const [first, second] = chunkFrames(expected, 8);
+	const mismatch = new RpcV2FrameDecoder({ maxReassembledFrameBytes: 1024 });
+	assert.equal(mismatch.push(first), null);
+	assert.throws(
+		() => mismatch.push({ ...second, byteLength: second.byteLength + 1 }),
+		/byteLength changed/
+	);
+
+	const oversize = new RpcV2FrameDecoder({ maxReassembledFrameBytes: 8 });
+	assert.throws(() => oversize.push(first), /logical frame limit/);
+});
+
+test('RpcV2FrameDecoder rejects invalid UTF-8 and non-object logical JSON', () => {
+	assert.throws(
+		() =>
+			new RpcV2FrameDecoder().push({
+				type: 'rpc_chunk',
+				chunkId: 'rpc-utf8',
+				index: 0,
+				count: 1,
+				byteLength: 2,
+				data: Buffer.from([0xc3, 0x28]).toString('base64'),
+			}),
+		/UTF-8/
+	);
+	assert.throws(
+		() =>
+			new RpcV2FrameDecoder().push({
+				type: 'rpc_chunk',
+				chunkId: 'rpc-array',
+				index: 0,
+				count: 1,
+				byteLength: 2,
+				data: Buffer.from('[]').toString('base64'),
+			}),
+		/JSON object/
+	);
+});
+
+test('summarizeProtocolFrame reports shape without transcript or tool content', () => {
+	const summary = summarizeProtocolFrame({
+		type: 'message_update',
+		message: { role: 'assistant', content: [{ type: 'text', text: 'private transcript value' }] },
+		toolCall: { name: 'write', arguments: { secret: 'private tool argument' } },
+	});
+	assert.deepEqual(summary, {
+		type: 'message_update',
+		idPresent: false,
+		command: null,
+		success: null,
+		keys: ['message', 'toolCall', 'type'],
+	});
+	assert.doesNotMatch(JSON.stringify(summary), /private transcript|private tool/);
+});
+
+test('redactConformanceReport removes absolute executable and workspace paths recursively', () => {
+	const report = {
+		executable: 'C:\\Users\\Example\\AppData\\Local\\omp\\omp.exe',
+		workspace: 'C:\\Temp\\omp-conformance-123',
+		identity: { digest: 'abc', version: '18.1.6' },
+		cases: [{ evidence: ['C:\\Temp\\omp-conformance-123\\session.jsonl', 'safe evidence'] }],
+	};
+	assert.deepEqual(redactConformanceReport(report), {
+		executable: '<explicit-omp-executable>',
+		workspace: '<isolated-workspace>',
+		identity: { digest: 'abc', version: '18.1.6' },
+		cases: [{ evidence: ['<isolated-workspace>\\session.jsonl', 'safe evidence'] }],
+	});
+});
+test('RpcProcessPeer rejects a non-ready first frame', async () => {
+	const script = 'process.stdout.write(\'{"type":"notice"}\\n\'); setTimeout(() => {}, 10000);';
+	const peer = new RpcProcessPeer({ executable: process.execPath, args: ['-e', script] });
+	await assert.rejects(peer.ready, /first RPC frame must be ready/);
+	await peer.close();
+});
+
+test('RpcProcessPeer rejects a duplicate ready frame', async () => {
+	const ready = JSON.stringify({
+		type: 'ready',
+		protocolVersion: 1,
+		supportedProtocolVersions: [1, 2],
+		maxFrameBytes: 1024,
+		maxReassembledFrameBytes: 2048,
+	});
+	const script = `const line = ${JSON.stringify(ready + '\n')}; process.stdout.write(line); process.stdin.once('data', () => process.stdout.write(line)); setTimeout(() => {}, 10000);`;
+	const peer = new RpcProcessPeer({ executable: process.execPath, args: ['-e', script] });
+	await peer.ready;
+	await assert.rejects(peer.request('get_state'), /more than one ready frame/);
+	await peer.close();
+});


### PR DESCRIPTION
## Problem

Maestro cannot safely build the native OMP run/fleet experience until the user-installed OMP public protocol proves the required authority, recovery, steering, approval, model, worker, evidence, and error semantics.

## Change

- Add a pinned OMP 18.1.6 RPC v2 conformance harness and repeatable baseline.
- Add strict JSONL/RPC-v2 framing with UTF-8, size, chunk ordering, response-correlation, and ready-frame guards.
- Compare the advertised ACP, RPC, and RPC-UI surfaces and select RPC for OMP-specific host control.
- Exercise session reattachment, snapshots/paging, live streaming, worker registry/transcript, steering/cancel, approvals, models/providers, todos, host-tool callbacks, process effects, export, and typed errors.
- Pin the exact user-installed binary version and SHA-256; fail before live probing on identity drift.
- Emit a privacy-redacted observed matrix and a machine-readable upstream requirements contract.

## Gate result

The gate correctly fails against OMP 18.1.6. Blocking cases: A04 and A05. Blocking capabilities: G1, G2, G3, G5.

- `create_worker` is absent.
- `command_worker` is absent.
- `get_subagent_messages` does not expose the completed Worker message after terminal root completion.
- `abort_and_prompt` acknowledges acceptance without a correlated completion signal.

Per the implementation blueprint, no native adapter/UI is included until these public-protocol blockers are resolved. No private OMP files or implementation APIs are used.

## Verification

- `npm run test:omp-protocol` — 34 passed
- Targeted ESLint — passed
- Targeted Prettier — passed
- Live pinned OMP 18.1.6 matrix — expected exit 1 with the blocker set above
- Observed artifact path-redaction scan — passed

The repository-wide pre-push `format:check:all` remains red on 82 pre-existing untouched files; this branch's files pass targeted formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated OpenModelProtocol RPC conformance checks covering negotiation, messaging, workers, approvals, cancellation, and error handling.
  * Added protocol framing support with chunk reassembly, transport-limit validation, readiness checks, and sanitized reporting.
  * Added baseline, observed-behavior, and upstream-requirement fixtures for protocol version 18.1.6.

* **Tests**
  * Added unit and integration coverage for protocol decoding, validation, redaction, argument handling, and conformance verdicts.
  * Added commands to run the protocol test suite and execute a conformance probe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->