### PR TITLE
fix(sidebar): sit the Cue bolt against the agent name, not the row edge

### DIFF
--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -1569,14 +1569,28 @@ html[data-theme-mode='light'] .chrome-raised-active {
 	min-width: 0;
 }
 
-/* Single line, full row width. The ellipsis is now a genuine last resort
-   rather than the normal case it was at fourteen characters. */
+/* Single line. The ellipsis is a genuine last resort rather than the normal
+   case it was at fourteen characters - `min-width: 0` plus `flex-shrink: 1`
+   is what buys that, and both are still here.
+
+   `flex-grow` is 0 on purpose. It used to be 1, which made the name box
+   stretch across the whole title row even when the name was short, shoving
+   every indicator after it (Cue's bolt, the startup-command terminal, the
+   wizard dot) out to the far right edge. They read as a right-hand status
+   column that way, which they are not: they belong to the NAME, and the meta
+   row below already owns the real right-hand column (`.row-actions`, grid
+   row 2). A long name hid the effect, so it looked like only some indicators
+   were misplaced - in fact every row had it.
+
+   Growing changes nothing about truncation: leftover space only exists when
+   the name already fits, and when it does not, shrink and `min-width: 0` do
+   the ellipsis exactly as before. */
 .session-row .row-name {
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	min-width: 0;
-	flex: 1 1 auto;
+	flex: 0 1 auto;
 }
 
 .session-row .row-meta {


### PR DESCRIPTION
## The premise was wrong, and that makes the fix smaller

The Cue bolt (⚡) floated at the far right of the Left Bar row; the startup-command glyph (`>_`) appeared to hug the name. That looked like two different layouts.

**It isn't.** Both are siblings in the same flex container, rendered back-to-back right after the name span, with identical `shrink-0` wrappers:

```tsx
<span className="row-name font-medium truncate ...">{session.name}</span>
{cueIndicatorVisible && <CueIndicator ... />}   // SessionItem.tsx:378
<StartupCommandIndicator ... />                 // SessionItem.tsx:385
```

No `ml-auto`, no `justify-between`, no right-hand column.

## The actual cause

`src/renderer/index.css` — `.session-row .row-name { flex: 1 1 auto }`

`flex-grow: 1` makes the **name box** consume the whole title row even when the name is short, shoving everything after it to the right edge.

`>_` only *looked* right because that row's name (`acappella`) is long enough to fill the width and hide the same gap. **Every row had the defect** — long names concealed it. So this one change fixes the bolt, the terminal glyph, and the wizard dot, on parent rows and worktree children alike (one component, `variant === 'worktree'` only swaps icon/size/pill).

## The change

`flex: 1 1 auto` → `flex: 0 1 auto`. One declaration.

## The risk I checked, because the rule is deliberate

The comment above it says the ellipsis is *"a genuine last resort rather than the normal case it was at fourteen characters"* — someone fixed aggressive truncation with this rule, so removing grow needed justifying rather than assuming.

**Truncation is unaffected.** That fix is the work of `min-width: 0` + `flex-shrink: 1`, both untouched. `flex-grow` only distributes **leftover** space, which by definition exists only when the name already fits. When it doesn't fit, shrink still runs and the ellipsis appears exactly where it did before. Grow was never load-bearing for truncation.

## What does not move

The bookmark, status dot, and worktree count are on **grid row 2** (`.row-actions { grid-column: 2; grid-row: 2 }`). The bolt was never in that column, so the right edge cannot go ragged.

## Validation

- `prettier` clean, `tsc -p tsconfig.lint.json` clean
- `SessionItem` + `SessionList` suites: **10 files / 281 tests pass**
- No test asserts `row-name`/`row-title`; single JSX consumer (`SessionItem.tsx:370`) with no competing Tailwind `flex-1`

**Not covered by tests** — jsdom computes no layout, so flexbox geometry is unverifiable in the suite. Worth one look at a narrow sidebar with a long agent name to confirm the ellipsis doesn't return early.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Session names no longer expand to fill the entire title row.
  - Adjacent session indicators retain their natural placement while long names continue to truncate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->