### PR TITLE
fix(left bar): let the Cue and command indicators hug the agent name

### DIFF
--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -1976,14 +1976,28 @@ html[data-theme-mode='light'] .chrome-raised-active {
 	min-width: 0;
 }
 
-/* Single line, full row width. The ellipsis is now a genuine last resort
-   rather than the normal case it was at fourteen characters. */
+/* Single line. The ellipsis is a genuine last resort rather than the normal
+   case it was at fourteen characters - `min-width: 0` plus `flex-shrink: 1`
+   is what buys that, and both are still here.
+
+   `flex-grow` is 0 on purpose. It used to be 1, which made the name box
+   stretch across the whole title row even when the name was short, shoving
+   every indicator after it (Cue's bolt, the startup-command terminal, the
+   wizard dot) out to the far right edge. They read as a right-hand status
+   column that way, which they are not: they belong to the NAME, and the meta
+   row below already owns the real right-hand column (`.row-actions`, grid
+   row 2). A long name hid the effect, so it looked like only some indicators
+   were misplaced - in fact every row had it.
+
+   Growing changes nothing about truncation: leftover space only exists when
+   the name already fits, and when it does not, shrink and `min-width: 0` do
+   the ellipsis exactly as before. */
 .session-row .row-name {
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	min-width: 0;
-	flex: 1 1 auto;
+	flex: 0 1 auto;
 }
 
 .session-row .row-meta {


### PR DESCRIPTION
Cherry-pick of `d0a7ae566` from `main` ([#1503](https://github.com/RunMaestro/Maestro/pull/1503)). **Applied cleanly** - the rule is identical on both branches, only the offset differs (`main` `:1580`, `rc` `:1986`).

## The premise was half wrong, and that makes the fix better

The report was "the Cue bolt is right-aligned, the command glyph hugs the name." They are **not** laid out differently. Both are siblings rendered back-to-back immediately after the name span, with byte-identical wrappers:

```tsx
<span className="row-name font-medium truncate ...">{session.name}</span>
{cueIndicatorVisible && <CueIndicator ... />}      // SessionItem.tsx:394
<StartupCommandIndicator ... />                    // SessionItem.tsx:402
```

`shrink-0 flex items-center` on both. No `ml-auto`, no `justify-between`, no right-hand column on either.

What pushed them was the **name**:

```css
.session-row .row-name { ... flex: 1 1 auto; }
```

Grow made the name box stretch across the whole title row even when the name was short. A long name hid it - which is why `acappella` looked right and `0DIN.ai` did not. **Every row had the defect**, so one declaration fixes the bolt, the terminal glyph, the wizard dot, and every row type at once.

## Truncation is untouched, with a reason

This rule is deliberate - the comment credits the full row width for making the ellipsis "a genuine last resort rather than the normal case it was at fourteen characters."

That width comes from `grid-column: 1 / -1` on `.row-title`, **not** from grow. `flex-grow` only distributes *leftover* space, which exists only when the name already fits. When it does not, `min-width: 0` and `flex-shrink: 1` - both untouched - do the ellipsis exactly as before.

## Nothing goes ragged

The bookmark, status dot and worktree count are on **grid row 2** (`.row-actions { grid-column: 2; grid-row: 2; justify-self: end }`). The bolt was never in that column, so the right edge stays aligned.

Parent and worktree-child rows are the same component (`variant === 'worktree'` only swaps the branch icon, text size, and pill).

## Verification

`prettier --check` clean. **Not unit-testable** - jsdom computes no layout, so flexbox geometry cannot be asserted in the suite. `main`'s run of the same change was 36,126 passed / 0 failed, which confirms nothing regressed elsewhere but cannot confirm the geometry.

Three hand-checks:

| # | case | watch for |
|---|---|---|
| V1 | narrow sidebar + long agent name | ellipsis returning early |
| V2 | short name, no indicators | row still reads right |
| V3 | double-click to rename, short name | hit region - the target is the `row-title` div (`SessionItem.tsx:353`), not the name span |

If V1 regresses, **do not revert to `flex: 1 1 auto`** - that treats a symptom. Full row width comes from the grid span, so a truncation regression points at `.row-title`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated session title row layout so the name box no longer stretches across the full row.
  * Clarified the related styling documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->