### PR TITLE
fix(preview): stop file-preview search from crashing the app

### DIFF
--- a/src/__tests__/renderer/hooks/file/useFilePreviewSearch.test.tsx
+++ b/src/__tests__/renderer/hooks/file/useFilePreviewSearch.test.tsx
@@ -90,7 +90,6 @@ function Host(props: {
 		markdownEditMode: false,
 		editContent: '',
 		fileContent: props.fileContent ?? 'Hello world hello again hello upper',
-		accentColor: '#ff0000',
 		searchMode: 'text',
 		searchAdapter: props.adapter,
 	});
@@ -395,7 +394,6 @@ describe('useFilePreviewSearch - gutter exclusion (B5)', () => {
 				markdownEditMode: false,
 				editContent: '',
 				fileContent: '42 in body\nline 42',
-				accentColor: '#ff0000',
 				searchMode: 'text',
 			});
 			props.expose({
@@ -464,7 +462,6 @@ describe('useFilePreviewSearch - search kind (text / regex / line)', () => {
 			markdownEditMode: false,
 			editContent: '',
 			fileContent: 'axb a.b\nline three',
-			accentColor: '#ff0000',
 			searchMode: 'text',
 			supportsLineSearch: props.supportsLineSearch,
 			searchAdapter: props.adapter,
@@ -580,5 +577,149 @@ describe('useFilePreviewSearch - search kind (text / regex / line)', () => {
 			handle.setSearchQuery('a.b');
 		});
 		expect(findHits).toHaveBeenLastCalledWith('a.b', { regex: false });
+	});
+});
+
+/**
+ * Regression: the syntax-highlighted code tier used to wrap every match in an
+ * injected `<mark>` via `replaceChild`, mutating DOM that React owns. When the
+ * highlighter later re-rendered a token that now sat under one of those
+ * wrappers, Chromium threw
+ * `NotFoundError: Failed to execute 'removeChild' on 'Node'` and the app-level
+ * error boundary took the whole window down. Reported live from a file preview.
+ *
+ * The tier now paints through the CSS Custom Highlight API instead, so these
+ * tests assert the DOM is left byte-identical and the highlight registry does
+ * the work.
+ */
+describe('useFilePreviewSearch - code tier does not mutate React-owned DOM', () => {
+	interface CodeHandle {
+		setSearchQuery: (q: string) => void;
+		goToNextMatch: () => void;
+		getTotalMatches: () => number;
+		getCurrentMatchIndex: () => number;
+	}
+
+	function CodeHost(props: { expose: (h: CodeHandle) => void }) {
+		const containerRef = useRef<HTMLDivElement>(null);
+		const codeRef = useRef<HTMLDivElement>(null);
+		const contentRef = useRef<HTMLDivElement>(null);
+		const editorRef = useRef<MarkdownEditorHandle>(null);
+
+		const hook = useFilePreviewSearch({
+			codeContainerRef: codeRef,
+			markdownContainerRef: containerRef,
+			contentRef,
+			editorRef,
+			isMarkdown: false,
+			isReadableText: false,
+			isImage: false,
+			isCsv: false,
+			isJsonl: false,
+			isJson: false,
+			isEditableText: true,
+			markdownEditMode: false,
+			editContent: '',
+			fileContent: 'const alpha = 1;\nconst beta = alpha + alpha;',
+			searchMode: 'text',
+		});
+
+		props.expose({
+			setSearchQuery: hook.setSearchQuery,
+			goToNextMatch: hook.goToNextMatch,
+			getTotalMatches: () => hook.totalMatches,
+			getCurrentMatchIndex: () => hook.currentMatchIndex,
+		});
+
+		return (
+			<div>
+				<div ref={contentRef} style={{ height: 200, overflow: 'auto' }}>
+					{/* Mimics the highlighter's nested token tree. */}
+					<div ref={codeRef}>
+						<pre>
+							<code>
+								<span>const alpha = 1;</span>
+								<span>const beta = alpha + alpha;</span>
+							</code>
+						</pre>
+					</div>
+				</div>
+				<div ref={containerRef} />
+			</div>
+		);
+	}
+
+	function renderCodeHost() {
+		const ref: { current: CodeHandle | undefined } = { current: undefined };
+		const utils = render(
+			<CodeHost
+				expose={(h) => {
+					ref.current = h;
+				}}
+			/>
+		);
+		if (!ref.current) throw new Error('CodeHost failed to expose handle');
+		// Indirect through the holder, same reason as `renderHost` above: a
+		// captured handle goes stale the moment setState re-renders.
+		const handle: CodeHandle = {
+			setSearchQuery: (q) => ref.current!.setSearchQuery(q),
+			goToNextMatch: () => ref.current!.goToNextMatch(),
+			getTotalMatches: () => ref.current!.getTotalMatches(),
+			getCurrentMatchIndex: () => ref.current!.getCurrentMatchIndex(),
+		};
+		return { ...utils, handle };
+	}
+
+	it('leaves the code container untouched while highlighting matches', async () => {
+		const { handle, container } = renderCodeHost();
+		const codeEl = container.querySelector('pre') as HTMLElement;
+		const before = codeEl.innerHTML;
+
+		await act(async () => {
+			handle.setSearchQuery('alpha');
+		});
+
+		// The defect: any `<mark>` here means the crash path is back.
+		expect(codeEl.querySelectorAll('mark').length).toBe(0);
+		expect(codeEl.innerHTML).toBe(before);
+		// And the search still works: 3 occurrences of "alpha".
+		expect(handle.getTotalMatches()).toBe(3);
+		expect(fakeHighlightStore.get('search-results')?.ranges).toHaveLength(3);
+	});
+
+	it('swaps the current-match highlight without touching the DOM', async () => {
+		const { handle, container } = renderCodeHost();
+		const codeEl = container.querySelector('pre') as HTMLElement;
+
+		await act(async () => {
+			handle.setSearchQuery('alpha');
+		});
+		const afterQuery = codeEl.innerHTML;
+		const first = fakeHighlightStore.get('search-current')?.ranges[0];
+
+		await act(async () => {
+			handle.goToNextMatch();
+		});
+
+		expect(handle.getCurrentMatchIndex()).toBe(1);
+		expect(fakeHighlightStore.get('search-current')?.ranges[0]).not.toBe(first);
+		expect(codeEl.querySelectorAll('mark').length).toBe(0);
+		expect(codeEl.innerHTML).toBe(afterQuery);
+	});
+
+	it('clears its highlights when the query is emptied', async () => {
+		const { handle } = renderCodeHost();
+
+		await act(async () => {
+			handle.setSearchQuery('alpha');
+		});
+		expect(fakeHighlightStore.has('search-results')).toBe(true);
+
+		await act(async () => {
+			handle.setSearchQuery('');
+		});
+		expect(fakeHighlightStore.has('search-results')).toBe(false);
+		expect(fakeHighlightStore.has('search-current')).toBe(false);
+		expect(handle.getTotalMatches()).toBe(0);
 	});
 });

--- a/src/renderer/components/FilePreview/FilePreview.tsx
+++ b/src/renderer/components/FilePreview/FilePreview.tsx
@@ -609,7 +609,6 @@ export const FilePreview = React.memo(
 			markdownEditMode,
 			editContent,
 			fileContent: file?.content,
-			accentColor: theme.colors.accent,
 			searchMode,
 			supportsLineSearch: viewHasLineNumbers,
 			displayedContentLength: displayContent.length,

--- a/src/renderer/hooks/file/useFilePreviewSearch.ts
+++ b/src/renderer/hooks/file/useFilePreviewSearch.ts
@@ -107,6 +107,25 @@ function clearTextHighlights(): void {
 	(CSS as any).highlights.delete('search-current');
 }
 
+/**
+ * Centre `range` inside `scrollParent`. A Range has no `scrollIntoView`, so the
+ * offset is computed from its rect the same way the navigate effect does it for
+ * the markdown tier.
+ *
+ * jsdom's Range has no `getBoundingClientRect`; the guard keeps tests from
+ * crashing and costs nothing in a real browser.
+ */
+function scrollRangeIntoView(range: Range | null, scrollParent: HTMLElement | null): void {
+	if (!range || !scrollParent) return;
+	if (typeof range.getBoundingClientRect !== 'function') return;
+	const rect = range.getBoundingClientRect();
+	if (!rect) return;
+	const parentRect = scrollParent.getBoundingClientRect();
+	const offsetInParent = rect.top - parentRect.top + scrollParent.scrollTop;
+	const scrollTop = offsetInParent - scrollParent.clientHeight / 2 + rect.height / 2;
+	scrollParent.scrollTo({ top: Math.max(0, scrollTop), behavior: 'smooth' });
+}
+
 export interface UseFilePreviewSearchParams {
 	codeContainerRef: RefObject<HTMLDivElement | null>;
 	markdownContainerRef: RefObject<HTMLDivElement | null>;
@@ -124,7 +143,6 @@ export interface UseFilePreviewSearchParams {
 	markdownEditMode: boolean;
 	editContent: string;
 	fileContent: string | undefined;
-	accentColor: string;
 	/** When in 'jq' mode, skip DOM-based highlighting (jq filtering is handled externally) */
 	searchMode: 'text' | 'jq';
 	/**
@@ -178,7 +196,6 @@ export function useFilePreviewSearch({
 	markdownEditMode,
 	editContent,
 	fileContent,
-	accentColor,
 	searchMode,
 	supportsLineSearch = false,
 	displayedContentLength,
@@ -253,7 +270,11 @@ export function useFilePreviewSearch({
 		return compileSearchRegex(searchQuery, { regex: true }).error;
 	}, [useRegex, searchQuery]);
 
-	const matchElementsRef = useRef<HTMLElement[]>([]);
+	// Ranges for the syntax-highlighted code tier, painted via the CSS Custom
+	// Highlight API. Kept separate from `rangesRef` (markdown / readable-text /
+	// adapter tier) because the two effects own different containers and the
+	// navigation callbacks below must know which tier produced the matches.
+	const codeRangesRef = useRef<Range[]>([]);
 	const searchInputRef = useRef<HTMLInputElement>(null);
 	const prevSearchQueryRef = useRef<string>('');
 	const prevMatchIndexRef = useRef<number>(0);
@@ -288,84 +309,36 @@ export function useFilePreviewSearch({
 		) {
 			setTotalMatches(0);
 			setCurrentMatchIndex(-1);
-			matchElementsRef.current = [];
+			codeRangesRef.current = [];
 			return;
 		}
 
 		const container = codeContainerRef.current;
-		const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
-		const textNodes: Text[] = [];
 
-		// Collect all text nodes
-		let node;
-		while ((node = walker.nextNode())) {
-			textNodes.push(node as Text);
+		// Ranges, not `<mark>` wrappers. This container is React-rendered (the
+		// syntax highlighter's token tree), so splicing elements into it means
+		// mutating nodes React still believes it owns. The next render that
+		// unmounts one of those tokens asks React to remove a child that now
+		// sits under an injected wrapper, and Chromium throws
+		// `NotFoundError: Failed to execute 'removeChild' on 'Node'`, taking the
+		// whole app down through the error boundary. The CSS Custom Highlight
+		// API paints the same result from the side: no DOM is touched, so React
+		// and the browser never disagree about the tree.
+		const ranges = walkContainerForRanges(container, searchPattern);
+
+		codeRangesRef.current = ranges;
+		setTotalMatches(ranges.length);
+		setCurrentMatchIndex(ranges.length > 0 ? 0 : -1);
+
+		applyAllHighlight(ranges);
+		if (ranges.length > 0) {
+			applyCurrentHighlight(ranges[0]);
+			scrollRangeIntoView(ranges[0], contentRef.current);
 		}
 
-		const regex = new RegExp(searchPattern, 'gi');
-		const matchElements: HTMLElement[] = [];
-
-		// Highlight matches using safe DOM methods
-		textNodes.forEach((textNode) => {
-			const text = textNode.textContent || '';
-			const matches = text.match(regex);
-
-			if (matches) {
-				const fragment = document.createDocumentFragment();
-				let lastIndex = 0;
-
-				text.replace(regex, (match, offset) => {
-					// Add text before match
-					if (offset > lastIndex) {
-						fragment.appendChild(document.createTextNode(text.substring(lastIndex, offset)));
-					}
-
-					// Add highlighted match
-					const mark = document.createElement('mark');
-					mark.style.backgroundColor = '#ffd700';
-					mark.style.color = '#000';
-					mark.style.padding = '0 2px';
-					mark.style.borderRadius = '2px';
-					mark.className = 'search-match';
-					mark.textContent = match;
-					fragment.appendChild(mark);
-					matchElements.push(mark);
-
-					lastIndex = offset + match.length;
-					return match;
-				});
-
-				// Add remaining text
-				if (lastIndex < text.length) {
-					fragment.appendChild(document.createTextNode(text.substring(lastIndex)));
-				}
-
-				textNode.parentNode?.replaceChild(fragment, textNode);
-			}
-		});
-
-		// Store match elements and update count
-		matchElementsRef.current = matchElements;
-		setTotalMatches(matchElements.length);
-		setCurrentMatchIndex(matchElements.length > 0 ? 0 : -1);
-
-		// Highlight first match with different color and scroll to it
-		if (matchElements.length > 0) {
-			matchElements[0].style.backgroundColor = accentColor;
-			matchElements[0].style.color = '#fff';
-			matchElements[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
-		}
-
-		// Cleanup function to remove highlights
 		return () => {
-			container.querySelectorAll('mark.search-match').forEach((mark) => {
-				const parent = mark.parentNode;
-				if (parent) {
-					parent.replaceChild(document.createTextNode(mark.textContent || ''), mark);
-					parent.normalize();
-				}
-			});
-			matchElementsRef.current = [];
+			clearTextHighlights();
+			codeRangesRef.current = [];
 		};
 	}, [
 		searchQuery,
@@ -380,7 +353,7 @@ export function useFilePreviewSearch({
 		isJsonl,
 		isJson,
 		isJqMode,
-		accentColor,
+		contentRef,
 		// The early-return guard reads `searchAdapter` to defer to the Fast/Giant
 		// tier's own search; include it in deps so flipping the tier chip
 		// re-runs the effect with the fresh adapter state.
@@ -422,7 +395,7 @@ export function useFilePreviewSearch({
 				setCurrentMatchIndex(-1);
 				hitsRef.current = null;
 				rangesRef.current = [];
-				matchElementsRef.current = [];
+				codeRangesRef.current = [];
 				clearTextHighlights();
 			}
 			return;
@@ -719,23 +692,17 @@ export function useFilePreviewSearch({
 		const nextIndex = (currentMatchIndex + 1) % totalMatches;
 		setCurrentMatchIndex(nextIndex);
 
-		// For code files, handle DOM-based highlighting
-		const matches = matchElementsRef.current;
-		if (matches.length > 0) {
-			// Reset previous highlight
-			if (matches[currentMatchIndex]) {
-				matches[currentMatchIndex].style.backgroundColor = '#ffd700';
-				matches[currentMatchIndex].style.color = '#000';
-			}
-			// Highlight new current match and scroll to it
-			if (matches[nextIndex]) {
-				matches[nextIndex].style.backgroundColor = accentColor;
-				matches[nextIndex].style.color = '#fff';
-				matches[nextIndex].scrollIntoView({ behavior: 'smooth', block: 'center' });
-			}
+		// Code tier: move the current-match highlight. No "reset the previous one"
+		// step is needed - `search-results` still covers every match underneath,
+		// so replacing `search-current` is the whole swap.
+		const ranges = codeRangesRef.current;
+		if (ranges.length > 0) {
+			const target = ranges[nextIndex] ?? null;
+			applyCurrentHighlight(target);
+			scrollRangeIntoView(target, contentRef.current);
 		}
 		// For markdown edit mode, the effect will handle selecting text
-	}, [totalMatches, currentMatchIndex, accentColor]);
+	}, [totalMatches, currentMatchIndex, contentRef]);
 
 	// Navigate to previous search match
 	const goToPrevMatch = useCallback(() => {
@@ -746,23 +713,15 @@ export function useFilePreviewSearch({
 		const prevIndex = (base - 1 + totalMatches) % totalMatches;
 		setCurrentMatchIndex(prevIndex);
 
-		// For code files, handle DOM-based highlighting
-		const matches = matchElementsRef.current;
-		if (matches.length > 0) {
-			// Reset previous highlight
-			if (matches[currentMatchIndex]) {
-				matches[currentMatchIndex].style.backgroundColor = '#ffd700';
-				matches[currentMatchIndex].style.color = '#000';
-			}
-			// Highlight new current match and scroll to it
-			if (matches[prevIndex]) {
-				matches[prevIndex].style.backgroundColor = accentColor;
-				matches[prevIndex].style.color = '#fff';
-				matches[prevIndex].scrollIntoView({ behavior: 'smooth', block: 'center' });
-			}
+		// Code tier: see the note in `goToNextMatch`.
+		const ranges = codeRangesRef.current;
+		if (ranges.length > 0) {
+			const target = ranges[prevIndex] ?? null;
+			applyCurrentHighlight(target);
+			scrollRangeIntoView(target, contentRef.current);
 		}
 		// For markdown edit mode, the effect will handle selecting text
-	}, [totalMatches, currentMatchIndex, accentColor]);
+	}, [totalMatches, currentMatchIndex, contentRef]);
 
 	const setMatchCount = useCallback((count: number) => {
 		setTotalMatches(count);


### PR DESCRIPTION
Cherry-pick of `8a5ce4751` from `main` (authored there by @Maestro), which fixes the `removeChild` crash Pedram hit live.

## The crash

```
NotFoundError: Failed to execute 'removeChild' on 'Node':
The node to be removed is not a child of this node.
```

The code tier of the file-preview search spliced `<mark>` fragments into a container React owns, then called `normalize()` on cleanup, coalescing text nodes React's fiber still referenced. The next reconcile tried to remove a node that was no longer its parent's child.

It now routes through the non-mutating CSS Custom Highlight API already present in the same file (`walkContainerForRanges` + `applyAllHighlight`), with `clearTextHighlights()` for cleanup. `matchElementsRef` and the `accentColor` parameter are gone from the interface and every call site.

## Why it looked random

`searchQuery` is persisted on the file tab (`FileTab.searchQuery`, fed back through `MainPanelContent.tsx:906` and `TiledLayout.tsx:390`), and `searchOpen` initializes to `Boolean(initialSearchQuery)`. Search a tab **once, ever**, and every later remount re-runs the mutation with no keystroke. Nothing resets the query when the file path changes either, so switching files inside a preview re-runs it against fresh content.

That matches the Sentry shape: `MAESTRO-ST` (`removeChild`, 7 events since 06-17) and `MAESTRO-10V` (`insertBefore`, 1) sharing a `trace_id` 1 ms apart.

## Cherry-pick notes

The commit touches three files, and **only one of them is identical across branches**. `useFilePreviewSearch.ts` matched (`398015542`); `FilePreview.tsx` diverges (`rc` carries the fuller scroll-restore work) and **auto-merged**. I checked for `rc`-only call sites the auto-merge could have missed: zero remaining references to `accentColor` or `matchElementsRef` anywhere in the renderer.

## Validation on `rc`

- `tsc --noEmit`: **5 errors, exactly `rc`'s pre-existing baseline**, zero from this change
- **781 tests pass** across `useFilePreviewSearch` + all `FilePreview` suites, including the 3 new regression tests asserting `codeEl.innerHTML` is byte-identical across a search and that zero `<mark>` elements appear
- `prettier --check` clean

> [!NOTE]
> `rc`'s own tip is red on `lint-and-format` and the Windows shards for unrelated pre-existing reasons (5 unused bindings; the `file-tree-walk` POSIX-keyed mock, whose fix sits inside #1508). Read this PR's CI as a delta against that baseline, not as an absolute.

## Deliberately not included

**C2** — wrapping `FilePreview`'s unwrapped `<SyntaxHighlighter>` in the existing `SyntaxHighlightBoundary`. That is containment, not a cure, and it becomes much less likely to fire once this lands. It needs a per-branch edit because `FilePreview.tsx` diverged. Worth doing after the cut, not with this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search highlighting in code previews for more reliable match rendering.
  * Search results now remain visually highlighted without altering the displayed code content.
  * The active search match updates smoothly when navigating between results.
  * Clearing the search query now consistently removes all code highlights.
  * Matching results are automatically centered within the preview when selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->