### PR TITLE
fix(maestro-p): stop handing node-pty a signal on Windows

### DIFF
--- a/src/__tests__/maestro-p/tui-driver.ptyKill.test.ts
+++ b/src/__tests__/maestro-p/tui-driver.ptyKill.test.ts
@@ -13,6 +13,8 @@
  * the desktop process manager (Sentry MAESTRO-XZ); this is the maestro-p half.
  */
 
+import * as os from 'os';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
@@ -92,7 +94,9 @@ async function makeDriver(): Promise<TuiDriver> {
 	const driver = new TuiDriver({
 		binPath: 'claude',
 		args: [],
-		cwd: '/tmp',
+		// Inert here - node-pty is mocked, so this never reaches path logic - but
+		// this is a Windows test and should not read as a POSIX-only fixture.
+		cwd: os.tmpdir(),
 		env: {},
 	});
 	await driver.start();

--- a/src/__tests__/maestro-p/tui-driver.ptyKill.test.ts
+++ b/src/__tests__/maestro-p/tui-driver.ptyKill.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @file tui-driver.ptyKill.test.ts
+ * @description Windows regression for how TuiDriver tears down its PTY.
+ *
+ * node-pty's Windows backend throws `Signals not supported on windows.` for any
+ * signal argument, and it throws from a DEFERRED that is flushed later on a
+ * socket `data` event - so the throw lands on an unrelated stack and the
+ * try/catch wrapped around the call site does not contain it. In maestro-p that
+ * escapes as an uncaught exception and the CLI dies with a non-zero exit code,
+ * which is what `--status` reports back to Maestro.
+ *
+ * Same defect that produced 822 fatal events from a single Windows install in
+ * the desktop process manager (Sentry MAESTRO-XZ); this is the maestro-p half.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+type DataListener = (data: string) => void;
+type ExitListener = (event: { exitCode: number; signal?: number }) => void;
+
+const dataListeners: DataListener[] = [];
+const exitListeners: ExitListener[] = [];
+
+const mockIsWindows = vi.fn(() => true);
+
+/**
+ * A node-pty `IPty` reproducing the two Windows behaviours that matter here:
+ *
+ *  1. Any signal argument throws `Signals not supported on windows.`
+ *  2. The call is QUEUED as a deferred until the ConPTY agent reports ready,
+ *     and the queue is flushed later from a socket `data` handler.
+ *
+ * (2) is what makes the call site's try/catch decorative, so a fake that threw
+ * synchronously would let the bug pass. `flushDeferreds()` stands in for the
+ * socket event.
+ */
+class FakeWindowsPty {
+	/** ConPTY reports pid 0 when the shell fails to launch - the field case. */
+	pid = 0;
+	kill = vi.fn((signal?: string) => {
+		const run = () => {
+			if (signal) throw new Error('Signals not supported on windows.');
+		};
+		if (this.isReady) {
+			run();
+			return;
+		}
+		this.deferreds.push(run);
+	});
+	onData = vi.fn((listener: DataListener) => {
+		dataListeners.push(listener);
+		return { dispose: vi.fn() };
+	});
+	onExit = vi.fn((listener: ExitListener) => {
+		exitListeners.push(listener);
+		return { dispose: vi.fn() };
+	});
+	write = vi.fn();
+	resize = vi.fn();
+
+	private isReady = false;
+	private deferreds: Array<() => void> = [];
+
+	flushDeferreds(): void {
+		this.isReady = true;
+		const queued = this.deferreds;
+		this.deferreds = [];
+		for (const fn of queued) fn();
+	}
+}
+
+let fakePty: FakeWindowsPty;
+
+vi.mock('node-pty', () => ({
+	spawn: () => fakePty,
+}));
+
+vi.mock('../../shared/platformDetection', async (importOriginal) => ({
+	...(await importOriginal<typeof import('../../shared/platformDetection')>()),
+	isWindows: () => mockIsWindows(),
+}));
+
+// ── Imports (after mocks) ──────────────────────────────────────────────────
+
+import { QUIT_GRACE_MS, TuiDriver } from '../../maestro-p/tui-driver';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+async function makeDriver(): Promise<TuiDriver> {
+	const driver = new TuiDriver({
+		binPath: 'claude',
+		args: [],
+		cwd: '/tmp',
+		env: {},
+	});
+	await driver.start();
+	return driver;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('TuiDriver PTY teardown on Windows', () => {
+	beforeEach(() => {
+		dataListeners.length = 0;
+		exitListeners.length = 0;
+		fakePty = new FakeWindowsPty();
+		mockIsWindows.mockReturnValue(true);
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('kill() hands node-pty no signal on Windows', async () => {
+		const driver = await makeDriver();
+
+		driver.kill();
+
+		expect(fakePty.kill).toHaveBeenCalledWith(undefined);
+		expect(fakePty.kill).not.toHaveBeenCalledWith('SIGKILL');
+	});
+
+	it('kill() survives the deferred flush - the throw never reaches an unrelated stack', async () => {
+		const driver = await makeDriver();
+
+		driver.kill();
+
+		// The ConPTY agent becomes ready and node-pty drains its queue. With a
+		// signal in that queue this is where the uncaught exception is born.
+		expect(() => fakePty.flushDeferreds()).not.toThrow();
+	});
+
+	it("quit()'s grace-timer escalation hands node-pty no signal on Windows", async () => {
+		const driver = await makeDriver();
+
+		const promise = driver.quit();
+		expect(fakePty.write).toHaveBeenCalledWith('/quit\r');
+
+		// The TUI ignores /quit, so the grace timer escalates. This is the
+		// `maestro-p --status` path.
+		await vi.advanceTimersByTimeAsync(QUIT_GRACE_MS);
+		await promise;
+
+		expect(fakePty.kill).toHaveBeenCalledWith(undefined);
+		expect(fakePty.kill).not.toHaveBeenCalledWith('SIGTERM');
+		expect(() => fakePty.flushDeferreds()).not.toThrow();
+	});
+
+	it('still passes the signal through on POSIX', async () => {
+		mockIsWindows.mockReturnValue(false);
+		const driver = await makeDriver();
+
+		driver.kill();
+
+		expect(fakePty.kill).toHaveBeenCalledWith('SIGKILL');
+	});
+});

--- a/src/__tests__/maestro-p/tui-driver.test.ts
+++ b/src/__tests__/maestro-p/tui-driver.test.ts
@@ -58,6 +58,16 @@ vi.mock('node-pty', () => ({
 	spawn: (file: string, args: string[], options: SpawnOptions) => mockSpawn(file, args, options),
 }));
 
+// Pin the platform to POSIX. The kill assertions below name a literal signal,
+// and killPty deliberately drops the signal on Windows - without this the
+// quit()/kill() expectations would pass locally and fail only on the Windows
+// CI leg. The Windows half of that contract is covered in
+// tui-driver.ptyKill.test.ts.
+vi.mock('../../shared/platformDetection', async (importOriginal) => ({
+	...(await importOriginal<typeof import('../../shared/platformDetection')>()),
+	isWindows: () => false,
+}));
+
 // ── Imports (after mocks) ──────────────────────────────────────────────────
 
 import {

--- a/src/maestro-p/tui-driver.ts
+++ b/src/maestro-p/tui-driver.ts
@@ -26,6 +26,7 @@ import * as pty from 'node-pty';
 import type { IDisposable, IPty } from 'node-pty';
 
 import { stripAnsiCodes } from '../shared/stringUtils';
+import { killPty } from '../shared/ptyKill';
 
 export interface TuiDriverOptions {
 	binPath: string;
@@ -393,7 +394,10 @@ export class TuiDriver extends EventEmitter {
 				settled = true;
 				this.off('exit', onExit);
 				try {
-					this.ptyProcess?.kill('SIGTERM');
+					// killPty, not ptyProcess.kill('SIGTERM'): node-pty's Windows
+					// backend throws for ANY signal, and it throws from a deferred
+					// flushed on a socket event, so this catch would not contain it.
+					if (this.ptyProcess) killPty(this.ptyProcess, 'SIGTERM');
 				} catch {
 					// PTY may already be gone; nothing to escalate against.
 				}
@@ -406,7 +410,7 @@ export class TuiDriver extends EventEmitter {
 	kill(): void {
 		if (!this.ptyProcess || this.exited) return;
 		try {
-			this.ptyProcess.kill('SIGKILL');
+			killPty(this.ptyProcess, 'SIGKILL');
 		} catch {
 			// Already gone - nothing to do.
 		}

--- a/src/main/process-manager/utils/commandKill.ts
+++ b/src/main/process-manager/utils/commandKill.ts
@@ -1,10 +1,7 @@
 // src/main/process-manager/utils/commandKill.ts
 
-import type * as pty from 'node-pty';
-
 import { execFileNoThrow } from '../../utils/execFile';
 import { killQuiet } from '../../utils/processTree';
-import { isWindows } from '../../../shared/platformDetection';
 
 /**
  * Kill a command's whole process tree RIGHT NOW, with SIGKILL.
@@ -18,27 +15,12 @@ export { killProcessTreeNow } from '../../utils/processTree';
 /**
  * Kill a PTY, dropping the POSIX signal on Windows.
  *
- * node-pty's Windows backend throws `Signals not supported on windows.` for any
- * signal argument at all - it only implements the no-argument form, which closes
- * the pty and kills the ConPTY/winpty agent. On POSIX the signal is honoured, so
- * it is passed straight through.
- *
- * A plain try/catch around `ptyProcess.kill(signal)` does NOT contain that throw.
- * node-pty queues the call as a *deferred* whenever the agent has not signalled
- * ready yet, and later runs the queue from a socket `data` handler - so the throw
- * surfaces on a completely different stack, escapes as an uncaught exception, and
- * takes the main process down (Sentry MAESTRO-XZ: 822 fatal events from a single
- * Windows install). Callers must therefore never hand node-pty a signal on
- * Windows, rather than trying to catch what it throws.
- *
- * Windows PTYs are normally torn down by pid with `taskkill /t /f`, which also
- * gets grandchildren. This path is what remains when the pid is unavailable -
- * ConPTY reports pid 0 when the shell fails to launch - and a signal-less kill()
- * is then the only correct call.
+ * Re-exported from `shared/ptyKill` so the process-manager callers keep one
+ * import site, exactly as `killProcessTreeNow` is above. The implementation
+ * lives in `shared/` because the standalone `maestro-p` CLI drives its own PTY
+ * and must follow the same rule (Sentry MAESTRO-XZ).
  */
-export function killPty(ptyProcess: pty.IPty, signal: NodeJS.Signals): void {
-	ptyProcess.kill(isWindows() ? undefined : signal);
-}
+export { killPty } from '../../../shared/ptyKill';
 
 /**
  * Best-effort async sweep for anything that outlived the synchronous kill.

--- a/src/shared/ptyKill.ts
+++ b/src/shared/ptyKill.ts
@@ -1,0 +1,37 @@
+// src/shared/ptyKill.ts
+
+import type * as pty from 'node-pty';
+
+import { isWindows } from './platformDetection';
+
+/**
+ * Kill a PTY, dropping the POSIX signal on Windows.
+ *
+ * node-pty's Windows backend throws `Signals not supported on windows.` for any
+ * signal argument at all - it only implements the no-argument form, which closes
+ * the pty and kills the ConPTY/winpty agent. On POSIX the signal is honoured, so
+ * it is passed straight through.
+ *
+ * A plain try/catch around `ptyProcess.kill(signal)` does NOT contain that throw.
+ * node-pty queues the call as a *deferred* whenever the agent has not signalled
+ * ready yet, and later runs the queue from a socket `data` handler - so the throw
+ * surfaces on a completely different stack, escapes as an uncaught exception, and
+ * takes the process down (Sentry MAESTRO-XZ: 822 fatal events from a single
+ * Windows install). Callers must therefore never hand node-pty a signal on
+ * Windows, rather than trying to catch what it throws.
+ *
+ * Windows PTYs are normally torn down by pid with `taskkill /t /f`, which also
+ * gets grandchildren. This path is what remains when the pid is unavailable -
+ * ConPTY reports pid 0 when the shell fails to launch - and a signal-less kill()
+ * is then the only correct call.
+ *
+ * Lives in `shared/` rather than beside the process-manager callers because the
+ * standalone `maestro-p` CLI drives its own PTY and needs the same rule. That
+ * binary is esbuild-bundled from `src/maestro-p/index.ts` with everything inlined
+ * except node-pty, so it cannot reach the main-process copy without pulling the
+ * Electron logger and the process-tree helpers into the CLI bundle. Keep this
+ * module dependency-free apart from the type-only node-pty import.
+ */
+export function killPty(ptyProcess: pty.IPty, signal: NodeJS.Signals): void {
+	ptyProcess.kill(isWindows() ? undefined : signal);
+}


### PR DESCRIPTION
## Context

Sentry was **unreachable this session** - the MCP OAuth token store is still empty (`accessToken: ""`, no refresh token) from the 2026-08-24 wipe, and re-auth needs an interactive sentry.io sign-in. So this triage inverted: instead of ranking issues by field volume and then finding the code, find defects provable from source alone.

Sweeps run first, all clean at HEAD:

- **Prior-guard re-verification** - all ~28 guards from triages 2-13 intact (M9's `RangeError` carve-out, `write EPIPE`, the LinkedErrors haystack, `isExpectedGroomingFailure`, 3x `db.isReady()`, `isExpectedQuotaStatus`, `killPty`, `EXPECTED_*_ERROR_CODES` sets, the four hardened `editingCommand !== null &&` comparisons). Several files had moved in the recent merge; the symbols are all still there.
- **IPC wiring** - 531 preload `ipcRenderer.invoke` vs 530 `ipcMain.handle`, only gap the known-dead `tempfile:*` surface. No duplicate channels (all 23 hits are the known test / JSDoc / dev-stub false positives). Dead-list registrars are a subset of the live bootstrap list.
- **`sentryFilters.ts` rule liveness** - every rule's target string checked against its emitting site. No dead rules this round.

## The fix

node-pty's Windows backend throws `Signals not supported on windows.` for **any** signal argument, and it throws from a *deferred* that is flushed later on a socket `data` event. The throw therefore lands on an unrelated stack, so the `try/catch` wrapped around the call site is decorative. In maestro-p it escapes as an uncaught exception and the CLI exits non-zero.

Both of `TuiDriver`'s teardown paths were passing a signal:

| Site | Signal | Reached when |
| --- | --- | --- |
| `quit()` grace-timer escalation | `SIGTERM` | the TUI ignores `/quit` - this is the `maestro-p --status` path |
| `kill()` | `SIGKILL` | explicit teardown |

This is the same defect that produced **822 fatal events from a single Windows install** in the desktop process manager (MAESTRO-XZ). That fix added `killPty()`, and the triage that shipped it explicitly recorded this call site as a known-latent second instance: *"Still latent, deliberately left out (no field evidence): `tui-driver.ts` `ptyProcess.kill('SIGKILL')`, no platform guard - same bug, one-line `killPty()` swap if it ever fires."*

I fixed it now rather than waiting for evidence because the throw is **uncatchable at the call site** and kills the process, and because I could not consult Sentry to check whether it already fires.

### Why `killPty` moved to `shared/`

maestro-p is esbuild-bundled from its own entry point with everything inlined except node-pty, so importing the helper from `src/main/process-manager/utils/commandKill.ts` would pull the Electron logger and the process-tree helpers into the CLI bundle. `killPty` now lives in `src/shared/ptyKill.ts` (dependency-free apart from a type-only node-pty import), and `commandKill.ts` re-exports it so **every existing main-process import site is unchanged** - the same pattern that file already uses for `killProcessTreeNow`.

Verified the built bundle contains the guarded call and no main-process code:

```
4129:function killPty(ptyProcess, signal) {
4130:  ptyProcess.kill(isWindows() ? void 0 : signal);
4327:          if (this.ptyProcess) killPty(this.ptyProcess, "SIGTERM");
4338:      killPty(this.ptyProcess, "SIGKILL");
```
...and zero remaining raw `kill('SIG...')` calls.

## Tests

`src/__tests__/maestro-p/tui-driver.ptyKill.test.ts` uses a node-pty-faithful fake reproducing **both** Windows rules - throw-on-any-signal *and* the ready/deferred queue with an explicit `flushDeferreds()`. A fake that threw synchronously would let this bug pass, which is the mock-permissiveness trap that has now bitten five prior triages.

Vacuity-checked against unfixed source: **3 of 4 red**, and the POSIX control case stayed green, which is what proves that path is unchanged.

The existing `tui-driver.test.ts` gets a platform pin. Its assertions name literal signals (`toHaveBeenCalledWith('SIGTERM')`), so without it they would pass locally and fail **only on the Windows CI leg**.

## Validation

- Full suite: **1797 files, 41,931 tests, 0 failures**
- `tsc -p tsconfig.json`: 5 errors, byte-identical to the clean `rc` baseline, none in these files (see note below)
- `tsc -p tsconfig.cli.json` (covers maestro-p): clean
- ESLint + Prettier clean on changed files
- `node scripts/build-maestro-p.mjs` builds

## Heads-up, not fixed here (does NOT block CI)

`npx tsc --noEmit -p tsconfig.json` reports 5 `TS6133` errors on clean `rc`:

```
src/renderer/App.tsx(436,3) 'fontFamily' is declared but its value is never read.
src/renderer/App.tsx(437,3) 'fontSize' is declared but its value is never read.
src/renderer/components/AppStandaloneModals.tsx(1,32) 'useCallback' ...
src/renderer/components/AppStandaloneModals.tsx(8,1) 'useSettingsStore' ...
src/renderer/components/MainPanel/MainPanelContent.tsx(482,8) 'fontSize' ...
```

To be clear, since an earlier revision of this description overstated it: **these do not gate CI.** `npm run lint` builds `tsconfig.lint.json` / `tsconfig.main.json` / `tsconfig.cli.json`, all of which are clean, and `lint-and-format` passes on this PR with the errors present. The bare `tsconfig.json` is not a config CI builds.

They are leftover destructures from the typography-snapshot work (`f376b4f82` / `2b6cb75e6`) after font resolution moved to `useSurfaceTypography` and CSS custom properties. Dead code, not a functional regression. Left alone for scope discipline; happy to strip them in a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal process termination on Windows to prevent uncaught errors during graceful and forced shutdowns.
  * Preserved signal-based termination behavior on POSIX systems.
  * Improved reliability when terminating processes before the Windows terminal backend is fully ready.

* **Tests**
  * Added cross-platform regression coverage for terminal process shutdown and deferred termination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->