### PR TITLE
fix(web-desktop): mirror a web-started Auto Run into the desktop app

### DIFF
--- a/src/__tests__/main/ipc/handlers/web.test.ts
+++ b/src/__tests__/main/ipc/handlers/web.test.ts
@@ -4,6 +4,9 @@ import { ipcMain } from 'electron';
 // Track registered handlers
 const registeredHandlers = new Map<string, Function>();
 
+// Desktop windows the Auto Run mirror forward should reach. Mutated per test.
+let mockBrowserWindows: any[] = [];
+
 // Mock ipcMain
 vi.mock('electron', () => ({
 	ipcMain: {
@@ -13,6 +16,9 @@ vi.mock('electron', () => ({
 	},
 	app: {
 		getVersion: vi.fn(() => '0.0.0-test'),
+	},
+	BrowserWindow: {
+		getAllWindows: vi.fn(() => mockBrowserWindows),
 	},
 }));
 
@@ -69,6 +75,7 @@ describe('web handlers', () => {
 		vi.clearAllMocks();
 		registeredHandlers.clear();
 		lastWrittenInfo = null;
+		mockBrowserWindows = [];
 		resetAutoRunStateTracker();
 		// Re-wire the writeCliServerInfo / readCliServerInfo mocks after
 		// clearAllMocks blew away their implementations.
@@ -255,6 +262,112 @@ describe('web handlers', () => {
 
 			expect(mockWebServer.broadcastAutoRunState).toHaveBeenCalledWith('session-123', state);
 			expect(result).toBe(true);
+		});
+	});
+
+	// Auto Run is renderer-owned, and `autorun_state` only ever reaches WebSocket
+	// clients. A run started in a browser tab therefore had no path back to the
+	// Electron app and the desktop drew the agent as idle for the whole run
+	// (issue #1519). Main forwards a bridge-originated frame to the desktop
+	// windows on the channel the mirror hook already consumes.
+	describe('web:broadcastAutoRunState -> desktop mirror forward', () => {
+		/** The synthetic event `handleBridgeInvoke` calls ipcMain handlers with. */
+		const BRIDGE_EVENT = { senderFrame: null, frameId: -1, processId: -1, type: 'bridge' };
+
+		const makeWindow = () => ({
+			isDestroyed: vi.fn(() => false),
+			webContents: { isDestroyed: vi.fn(() => false), send: vi.fn() },
+		});
+
+		const runningState = { isRunning: true, totalTasks: 3, completedTasks: 1 };
+
+		it('forwards a web-owned run to every desktop window', async () => {
+			const [a, b] = [makeWindow(), makeWindow()];
+			mockBrowserWindows = [a, b];
+
+			const handler = registeredHandlers.get('web:broadcastAutoRunState');
+			await handler!(BRIDGE_EVENT, 'session-123', runningState);
+
+			for (const win of [a, b]) {
+				expect(win.webContents.send).toHaveBeenCalledWith(
+					'remote:autoRunStateMirror',
+					'session-123',
+					runningState
+				);
+			}
+		});
+
+		// The echo that would break the owner: a desktop window receiving its own
+		// state back can have its live run stamped `mirrored: true`, which disables
+		// Stop/Skip/Resume/Abort on the very window driving the run.
+		it('does not forward a run owned by a desktop renderer', async () => {
+			const win = makeWindow();
+			mockBrowserWindows = [win];
+
+			const handler = registeredHandlers.get('web:broadcastAutoRunState');
+			await handler!({ senderFrame: {} }, 'session-123', runningState);
+
+			expect(win.webContents.send).not.toHaveBeenCalled();
+		});
+
+		// `null` is how the owner says the run ended. It has to reach the desktop
+		// or the mirrored card outlives the run it describes.
+		it('forwards a cleared run so the mirror can be torn down', async () => {
+			const win = makeWindow();
+			mockBrowserWindows = [win];
+
+			const handler = registeredHandlers.get('web:broadcastAutoRunState');
+			await handler!(BRIDGE_EVENT, 'session-123', null);
+
+			expect(win.webContents.send).toHaveBeenCalledWith(
+				'remote:autoRunStateMirror',
+				'session-123',
+				null
+			);
+		});
+
+		it('skips a destroyed window and still reaches the live ones', async () => {
+			const dead = makeWindow();
+			dead.isDestroyed.mockReturnValue(true);
+			const live = makeWindow();
+			mockBrowserWindows = [dead, live];
+
+			const handler = registeredHandlers.get('web:broadcastAutoRunState');
+			await handler!(BRIDGE_EVENT, 'session-123', runningState);
+
+			expect(dead.webContents.send).not.toHaveBeenCalled();
+			expect(live.webContents.send).toHaveBeenCalled();
+		});
+
+		// A window closing mid-broadcast must not cost the others their frame, nor
+		// fail the broadcast the web clients are also waiting on.
+		it('keeps going when one window throws', async () => {
+			const throwing = makeWindow();
+			throwing.webContents.send.mockImplementation(() => {
+				throw new Error('render frame disposed');
+			});
+			const healthy = makeWindow();
+			mockBrowserWindows = [throwing, healthy];
+
+			const handler = registeredHandlers.get('web:broadcastAutoRunState');
+			const result = await handler!(BRIDGE_EVENT, 'session-123', runningState);
+
+			expect(healthy.webContents.send).toHaveBeenCalled();
+			expect(result).toBe(true);
+		});
+
+		// The forward must not depend on Live Mode having a server attached: the
+		// tracker and the desktop mirror are both first-party main-process state.
+		it('forwards even when no web server is attached', async () => {
+			webServerRef.current = null;
+			const win = makeWindow();
+			mockBrowserWindows = [win];
+
+			const handler = registeredHandlers.get('web:broadcastAutoRunState');
+			const result = await handler!(BRIDGE_EVENT, 'session-123', runningState);
+
+			expect(win.webContents.send).toHaveBeenCalled();
+			expect(result).toBe(false);
 		});
 	});
 

--- a/src/main/ipc/handlers/web.ts
+++ b/src/main/ipc/handlers/web.ts
@@ -22,8 +22,9 @@
  * Extracted from main/index.ts to improve code organization.
  */
 
-import { ipcMain, app } from 'electron';
+import { ipcMain, app, BrowserWindow } from 'electron';
 import { logger } from '../../utils/logger';
+import { isWebContentsAvailable } from '../../utils/safe-send';
 import { WebServer } from '../../web-server';
 import type { AITabData } from '../../web-server/services/broadcastService';
 import { getAutoRunStateTracker } from '../../autorun/autorun-state-tracker';
@@ -235,6 +236,69 @@ export function stopCliDiscoveryWatchdog(): void {
 }
 
 /**
+ * True when this invoke arrived over the web-desktop WebSocket bridge rather
+ * than from an Electron renderer.
+ *
+ * `handleBridgeInvoke` dispatches to the registered `ipcMain` handler with a
+ * synthetic event (`FAKE_EVENT` in `web-server/handlers/bridgeHandlers.ts`)
+ * stamped `type: 'bridge'`; a real `IpcMainInvokeEvent` has no `type`. This is
+ * the only thing that tells main WHICH client owns an Auto Run, and the whole
+ * echo-safety of the forward below rests on it.
+ */
+function isBridgeOriginatedInvoke(event: unknown): boolean {
+	return (event as { type?: unknown } | null)?.type === 'bridge';
+}
+
+/**
+ * Mirror a web-owned Auto Run into the Electron desktop windows.
+ *
+ * Auto Run is renderer-owned state, so a run started in a web-desktop browser
+ * tab lives entirely in that tab. #1508 taught the browser to RENDER a run
+ * owned by the desktop (`autorun_state` -> `remote:autoRunStateMirror`), but
+ * only in that direction: the desktop is not a WebSocket client, so nothing
+ * carried the reverse. The desktop drew the agent as idle for the whole run.
+ *
+ * Two deliberate narrowings:
+ *
+ * 1. **Bridge-originated frames only.** A desktop-owned run must never be
+ *    forwarded, or the owning window would receive its own state back and
+ *    `applyAutoRunMirrorFrame` could stamp its own live run `mirrored: true` -
+ *    which disables Stop, Skip, Resume and Abort on the window that is actually
+ *    driving the run. The renderer has an ownership guard of its own, but the
+ *    cheapest way to be sure is not to send the echo in the first place.
+ *
+ * 2. **Not `safeSend`.** `safeSend` fans every push out to the bridge as well,
+ *    which would deliver this frame to web clients a second time on a second
+ *    channel - they already receive it as `autorun_state`. The desktop windows
+ *    are the entire audience for this message, so it goes straight to them.
+ *
+ * Still out of scope: desktop window A does not mirror into desktop window B.
+ * That needs the same echo reasoning applied per-window and is not what #1519
+ * reports.
+ */
+function forwardAutoRunStateToDesktopWindows(
+	event: unknown,
+	sessionId: string,
+	state: AutoRunBroadcastState | null
+): void {
+	if (!isBridgeOriginatedInvoke(event)) return;
+
+	for (const win of BrowserWindow.getAllWindows()) {
+		try {
+			if (isWebContentsAvailable(win)) {
+				win.webContents.send('remote:autoRunStateMirror', sessionId, state);
+			}
+		} catch (error) {
+			// A window closing mid-broadcast is routine, not a fault. Keep going so
+			// one dead window never costs the others their frame.
+			logger.debug('Failed to mirror Auto Run state to a desktop window', 'WebHandlers', {
+				error: String(error),
+			});
+		}
+	}
+}
+
+/**
  * Register all web/live-related IPC handlers.
  */
 export function registerWebHandlers(deps: WebHandlerDependencies): void {
@@ -269,7 +333,7 @@ export function registerWebHandlers(deps: WebHandlerDependencies): void {
 
 	ipcMain.handle(
 		'web:broadcastAutoRunState',
-		async (_, sessionId: string, state: AutoRunBroadcastState | null) => {
+		async (event, sessionId: string, state: AutoRunBroadcastState | null) => {
 			// Feed the first-party main-process tracker FIRST, unconditionally.
 			// The web-server branch below returns early when Live Mode is off, so
 			// anything downstream of it (dispatch callbacks, and later Cue's
@@ -277,6 +341,13 @@ export function registerWebHandlers(deps: WebHandlerDependencies): void {
 			// finished. Auto Run finality is main-process state now, not a
 			// web-broadcast side effect.
 			getAutoRunStateTracker().update(sessionId, state);
+
+			// A run OWNED by a web-desktop browser client has to reach the desktop
+			// windows too, or the desktop renders the agent as idle for the whole
+			// run. Web clients are already served by the `autorun_state` packet
+			// below; the desktop is not a WebSocket client, so this is its only
+			// path to the frame.
+			forwardAutoRunStateToDesktopWindows(event, sessionId, state);
 
 			const webServer = getWebServer();
 			if (webServer) {

--- a/src/main/preload/process/autoRunControlRemote.ts
+++ b/src/main/preload/process/autoRunControlRemote.ts
@@ -6,11 +6,16 @@ export function createAutoRunControlRemoteApi() {
 		/**
 		 * Subscribe to Auto Run state belonging to a DIFFERENT Maestro client.
 		 *
-		 * Only ever fires in the web-desktop (browser) build, where the WebSocket
-		 * shim maps the server's `autorun_state` packet onto this channel. In the
-		 * Electron desktop app nothing sends it - the desktop renderer is the
-		 * owner of its own runs, so there is nothing to mirror - and the
-		 * subscription simply sits idle.
+		 * Two producers feed this one channel. In the web-desktop (browser) build
+		 * the WebSocket shim maps the server's `autorun_state` packet onto it. In
+		 * the Electron desktop app main sends it directly, for a run owned by a
+		 * browser tab - the desktop is not a WebSocket client, so without that
+		 * forward a web-started run was invisible here for its whole duration
+		 * (issue #1519).
+		 *
+		 * A window is never sent its own run back, so the owner keeps its
+		 * controls; see `forwardAutoRunStateToDesktopWindows` in
+		 * `main/ipc/handlers/web.ts`.
 		 */
 		onRemoteAutoRunStateMirror: (
 			callback: (sessionId: string, state: AutoRunBroadcastState | null) => void

--- a/src/renderer/hooks/batch/useAutoRunStateMirror.ts
+++ b/src/renderer/hooks/batch/useAutoRunStateMirror.ts
@@ -23,6 +23,18 @@
  * parsed and dropped. This hook is the consumer for the channel the shim now
  * maps it onto.
  *
+ * The mirror runs in BOTH directions, and the second one needed its own
+ * plumbing (issue #1519). `autorun_state` only ever reaches WebSocket clients,
+ * so a run started in a BROWSER tab had no path back to the Electron app and
+ * the desktop drew the agent as idle for the entire run. Main closes that half
+ * by forwarding a bridge-originated broadcast straight to the desktop windows
+ * on this same channel (`forwardAutoRunStateToDesktopWindows` in
+ * `main/ipc/handlers/web.ts`). One consumer, two producers.
+ *
+ * Note this fixes only VISIBILITY, in both directions. A run still dies with
+ * the client that owns it, because the loop and its cursors live there; that is
+ * issue #1470 and it needs the ownership primitive described below.
+ *
  * What it deliberately does NOT do: take over. The entry it writes is stamped
  * `mirrored: true`, every Auto Run mutator refuses to act on a mirrored entry,
  * and the controls that call them render disabled. Resuming or steering a run
@@ -38,7 +50,6 @@ import type { AgentErrorType } from '../../../shared/types';
 import type { BatchRunState } from '../../types';
 import { useBatchStore } from '../../stores/batchStore';
 import { DEFAULT_BATCH_STATE } from './batchReducer';
-import { isWebDesktop } from '../../utils/runtimeContext';
 
 /**
  * Tooltip for an Auto Run control disabled because the run belongs to another
@@ -272,10 +283,18 @@ export function resetMirrorFrameClock(): void {
 /**
  * Subscribe to Auto Run state broadcast by other Maestro clients.
  *
- * Mount once, alongside the batch processor. No-ops outside the web-desktop
- * build: the Electron desktop renderer is not a WebSocket client, so the
- * channel never fires there, and the guard keeps that intent explicit rather
- * than relying on it.
+ * Mount once, alongside the batch processor. Runs in BOTH builds, and that is
+ * the point: mirroring used to be gated to the web-desktop build, on the
+ * reasoning that the Electron renderer is not a WebSocket client so the channel
+ * could never fire there. True of the channel, wrong about the need - it left a
+ * run STARTED in a browser tab invisible in the desktop app for its whole
+ * duration (issue #1519). Main now forwards a bridge-originated frame to the
+ * desktop windows (`forwardAutoRunStateToDesktopWindows`), so the desktop has a
+ * producer and needs its consumer.
+ *
+ * A desktop window is never handed its own run back - main forwards only
+ * bridge-originated frames - and `applyAutoRunMirrorFrame` refuses to overwrite
+ * a live local run regardless, so the owner keeps its controls.
  */
 export function useAutoRunStateMirror(): void {
 	const handleFrame = useCallback((sessionId: string, state: AutoRunBroadcastState | null) => {
@@ -283,14 +302,12 @@ export function useAutoRunStateMirror(): void {
 	}, []);
 
 	useEffect(() => {
-		if (!isWebDesktop()) return;
 		const subscribe = window.maestro?.process?.onRemoteAutoRunStateMirror;
 		if (!subscribe) return;
 		return subscribe(handleFrame);
 	}, [handleFrame]);
 
 	useEffect(() => {
-		if (!isWebDesktop()) return;
 		const timer = setInterval(() => {
 			void reapStaleMirrors();
 		}, MIRROR_REAP_INTERVAL_MS);


### PR DESCRIPTION
closes #1519

## The report

Start an Auto Run from the web-desktop browser client and the desktop app never shows the agent as Auto Run-active, though it is running. Close the browser and the next queued task may never start. Starting from the desktop shows correctly in the browser.

## Two symptoms, two different bugs

The reporter's instinct that these "likely share one root cause" is right about the root cause and wrong about the fix boundary, so this PR deliberately only takes the first.

**Symptom (a), the desktop showing nothing, is a real gap and is fixed here.**

**Symptom (b), the run dying when the web client closes, is #1470** and is not fixed here. The run loop is a live async closure with `let` cursors inside it; when the client holding it goes away, the loop goes with it. Re-claiming an orphaned run needs a renderer liveness/ownership primitive that does not exist yet, which is exactly what #1470 is open on. Shipping a guess there can have two clients spawning tasks into the same working tree.

## Root cause of (a)

Auto Run is renderer-owned state, so a run lives entirely in whichever client pressed Go. #1508 taught a web-desktop tab to RENDER a run owned by the desktop, but only in that direction:

- The owner pushes state to main every tick via `web:broadcastAutoRunState`.
- Main fans it out as an `autorun_state` **WebSocket packet**.
- The Electron desktop app is **not a WebSocket client**.

So a run started in a browser tab had no path back to the desktop at all. `useAutoRunStateMirror` even encoded the assumption, gating both its effects on `isWebDesktop()`, and the preload comment said "In the Electron desktop app nothing sends it". True of the channel, wrong about the need.

## The change

- **`main/ipc/handlers/web.ts`** - `forwardAutoRunStateToDesktopWindows()` sends a bridge-originated broadcast straight to the desktop windows on `remote:autoRunStateMirror`, the channel the mirror hook already consumes. One consumer, two producers.
- **`useAutoRunStateMirror`** drops its `isWebDesktop()` gate so the desktop has a consumer.
- Preload and hook docs corrected; they asserted the one-way behaviour as intentional.

## The echo, which is the part worth reviewing

The forward is narrowed to frames that arrived over the **WebSocket bridge**, identified by the synthetic `FAKE_EVENT` (`type: 'bridge'`) that `handleBridgeInvoke` calls ipcMain handlers with.

A desktop-owned run must never be echoed back to its owner. The owning window would receive its own state and `applyAutoRunMirrorFrame` could stamp its own live run `mirrored: true` - and every Auto Run mutator refuses a mirrored entry, so Stop, Skip, Resume and Abort would go dead on the window actually driving the run. The renderer has its own ownership guard (`existing?.isRunning === true && !isMirror`), but the cheapest way to be certain is not to send the echo at all. Both layers are now in place.

It also deliberately **bypasses `safeSend`**, which fans every push out to the bridge as well - that would deliver this frame to web clients a second time, on a second channel, when they already receive it as `autorun_state`.

## Deliberately unchanged

- **The mirror stays read-only.** Controls remain disabled on a mirrored run with the existing tooltip. Same reason as #1508: steering another client's run needs #1470's ownership primitive.
- **Desktop window A does not mirror into desktop window B.** Same echo reasoning applied per-window, and not what this issue reports.
- Because the desktop now mirrors a web-owned run, `startBatchRun`'s existing `isMirroredBatchRun` backstop also stops the desktop launching a second loop against an agent the browser is already running. That is the intended interaction, not a side effect.

## Targeting `rc`, not `main`

`src/web-desktop/` and `useAutoRunStateMirror.ts` do not exist on `main` - the whole feature is rc-only.

## Validation

- `npm run lint` clean (all three tsconfigs).
- `npx eslint` clean on every changed file.
- `npm run test` - **42,091 passed, 0 failures**.
- 6 new tests covering the forward: fan-out to all windows, the owner echo being suppressed, `null` teardown reaching the desktop, destroyed-window skip, one window throwing not costing the others, and the forward surviving Live Mode having no server attached.

Local runs are single-OS; both CI matrix legs still need to be green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-run state is now mirrored between browser and desktop clients, keeping run status visible across connected views.
  * State updates, including cleared states, are forwarded to available desktop windows.

* **Bug Fixes**
  * Improved auto-run synchronization when multiple desktop windows are open.
  * Updates continue reaching available windows when another window is closed or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->