### PR TITLE
fix(remote): keep the newest tab rename authoritative past the confirmation window

### DIFF
--- a/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
@@ -2031,6 +2031,87 @@ describe('useRemoteIntegration', () => {
 			}
 		});
 
+		// `applyRename` writes the provider name BEFORE the history relabel, so a
+		// history rejection lands after the provider is already on disk with the
+		// old name. When that happens to a rename a newer one has superseded, the
+		// stale provider write has to be reconciled anyway: reporting the failure
+		// and stopping would leave the provider disagreeing with the tab and with
+		// the success the newer request was already told.
+		it('reconciles the newest name when a stale rename writes the provider then fails on history', async () => {
+			vi.useFakeTimers();
+			try {
+				const tab = createMockTab({ id: 'tab-1', agentSessionId: 'agent-session-1', name: 'Old' });
+				const session = createMockSession({
+					id: 'session-1',
+					aiTabs: [tab],
+					projectRoot: '/test/project',
+					toolType: 'claude-code',
+				});
+				const deps = createDeps({ sessions: [session] });
+
+				// Stands in for the provider metadata on disk.
+				let providerName: string | undefined;
+				let landStaleProviderWrite: (() => void) | undefined;
+				const staleProviderWrite = new Promise<void>((resolve) => {
+					landStaleProviderWrite = resolve;
+				});
+				mockClaude.updateSessionName.mockImplementation(
+					async (_projectRoot: string, _agentSessionId: string, name: string) => {
+						if (name === 'Stale') await staleProviderWrite;
+						providerName = name;
+					}
+				);
+				// The history relabel rejects only for the stale name, which is what
+				// makes that rename fail AFTER it has already written the provider.
+				mockHistory.updateSessionName.mockImplementation(async (_id: string, name: string) => {
+					if (name === 'Stale') throw new Error('history write failed');
+					return 1;
+				});
+
+				renderHook(() => useRemoteIntegration(deps));
+
+				void onRemoteRenameTabHandler?.('session-1', 'tab-1', 'Stale', 'response-stale');
+				await vi.advanceTimersByTimeAsync(60_000);
+				expect(providerName).toBeUndefined();
+
+				// The newer rename completes while the older provider write is still
+				// pending, and is told it succeeded.
+				const newerDone = onRemoteRenameTabHandler?.(
+					'session-1',
+					'tab-1',
+					'Newer',
+					'response-newer'
+				);
+				await vi.advanceTimersByTimeAsync(0);
+				await newerDone;
+				expect(providerName).toBe('Newer');
+				expect(mockProcess.sendRemoteRenameTabResponse).toHaveBeenCalledWith('response-newer', {
+					success: true,
+				});
+
+				// Now the stale provider write lands and its history relabel throws.
+				landStaleProviderWrite!();
+				await vi.advanceTimersByTimeAsync(0);
+
+				// The provider must not be left on the stale name.
+				expect(providerName).toBe('Newer');
+				expect(
+					useSessionStore
+						.getState()
+						.sessions.find((s) => s.id === 'session-1')
+						?.aiTabs.find((t) => t.id === 'tab-1')?.name
+				).toBe('Newer');
+
+				// The stale request is still told the truth about its own rename.
+				expect(mockProcess.sendRemoteRenameTabResponse).toHaveBeenCalledWith('response-stale', {
+					success: false,
+					error: 'history write failed',
+				});
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
 		it('does not serialize renames of different tabs behind each other', async () => {
 			const session = createMockSession({
 				id: 'session-1',

--- a/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
@@ -1976,15 +1976,21 @@ describe('useRemoteIntegration', () => {
 
 		// The tab is renamed from outside this queue too: `useSessionLifecycle`
 		// writes the same provider metadata, history and store name for a desktop
-		// rename. So "already applied" has to be read from the live tab, not
-		// remembered from what this queue last wrote, or a repeat remote rename is
-		// skipped and reported successful while the tab shows something else.
+		// rename. A repeat remote rename of a name this queue already wrote must
+		// still be written, because something else has changed the tab since.
+		// Its own session and tab ids are deliberately unique: the parked rename
+		// below never settles, so its bookkeeping entry outlives the test, and a
+		// shared id would couple every later test in this file to it.
 		it('re-applies a name the tab lost to a rename made outside this queue', async () => {
 			vi.useFakeTimers();
 			try {
-				const tab = createMockTab({ id: 'tab-1', agentSessionId: 'agent-session-1', name: 'Old' });
+				const tab = createMockTab({
+					id: 'tab-parked',
+					agentSessionId: 'agent-session-1',
+					name: 'Old',
+				});
 				const session = createMockSession({
-					id: 'session-1',
+					id: 'session-parked',
 					aiTabs: [tab],
 					projectRoot: '/test/project',
 					toolType: 'claude-code',
@@ -2003,29 +2009,29 @@ describe('useRemoteIntegration', () => {
 
 				// A rename that never settles keeps this tab's bookkeeping alive, so
 				// anything remembered in it outlives the rename that recorded it.
-				void onRemoteRenameTabHandler?.('session-1', 'tab-1', 'Hung', 'response-hung');
+				void onRemoteRenameTabHandler?.('session-parked', 'tab-parked', 'Hung', 'response-hung');
 				await vi.advanceTimersByTimeAsync(60_000);
 
-				void onRemoteRenameTabHandler?.('session-1', 'tab-1', 'Beta', 'response-1');
+				void onRemoteRenameTabHandler?.('session-parked', 'tab-parked', 'Beta', 'response-1');
 				await vi.advanceTimersByTimeAsync(0);
 				expect(persistOrder).toEqual(['Beta']);
 
 				// The desktop renames the tab, bypassing the remote rename queue.
 				act(() => {
-					updateAiTab('session-1', 'tab-1', (t) => ({ ...t, name: 'Gamma' }));
+					updateAiTab('session-parked', 'tab-parked', (t) => ({ ...t, name: 'Gamma' }));
 				});
 
 				// The same remote name is requested again. It must be written, not
 				// skipped as something this queue believes it already applied.
-				void onRemoteRenameTabHandler?.('session-1', 'tab-1', 'Beta', 'response-2');
+				void onRemoteRenameTabHandler?.('session-parked', 'tab-parked', 'Beta', 'response-2');
 				await vi.advanceTimersByTimeAsync(0);
 
 				expect(persistOrder).toEqual(['Beta', 'Beta']);
 				expect(
 					useSessionStore
 						.getState()
-						.sessions.find((s) => s.id === 'session-1')
-						?.aiTabs.find((t) => t.id === 'tab-1')?.name
+						.sessions.find((s) => s.id === 'session-parked')
+						?.aiTabs.find((t) => t.id === 'tab-parked')?.name
 				).toBe('Beta');
 				expect(mockProcess.sendRemoteRenameTabResponse).toHaveBeenCalledWith('response-2', {
 					success: true,

--- a/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
@@ -1891,6 +1891,85 @@ describe('useRemoteIntegration', () => {
 			});
 		});
 
+		// The persistence calls are `ipcRenderer.invoke`, which never times out, so a
+		// main-process handler that never returns leaves its promise pending for the
+		// life of the window. Without a bounded handoff every later rename for the
+		// tab would queue behind it and never be attempted, and the tab would be
+		// stuck on its old name no matter how many times the user renamed it.
+		it('runs a newer rename when an older one never settles, and keeps it when the old one lands', async () => {
+			vi.useFakeTimers();
+			try {
+				const tab = createMockTab({ id: 'tab-1', agentSessionId: 'agent-session-1', name: 'Old' });
+				const session = createMockSession({
+					id: 'session-1',
+					aiTabs: [tab],
+					projectRoot: '/test/project',
+					toolType: 'claude-code',
+				});
+				const deps = createDeps({ sessions: [session] });
+
+				// The first rename's persistence is never resolved on its own; the test
+				// releases it by hand at the very end to model a hung call finally
+				// landing rather than one that was cancelled.
+				let landHung: (() => void) | undefined;
+				const hungPersisted = new Promise<void>((resolve) => {
+					landHung = resolve;
+				});
+				const persistOrder: string[] = [];
+				mockClaude.updateSessionName.mockImplementation(
+					async (_projectRoot: string, _agentSessionId: string, name: string) => {
+						if (name === 'Hung') await hungPersisted;
+						persistOrder.push(name);
+					}
+				);
+
+				renderHook(() => useRemoteIntegration(deps));
+
+				const hungDone = onRemoteRenameTabHandler?.('session-1', 'tab-1', 'Hung', 'response-hung');
+				await vi.advanceTimersByTimeAsync(0);
+				expect(persistOrder).toEqual([]);
+
+				// The newer rename arrives while the first is still pending. It must
+				// not be blocked forever behind it.
+				const newerDone = onRemoteRenameTabHandler?.(
+					'session-1',
+					'tab-1',
+					'Newer',
+					'response-newer'
+				);
+				await vi.advanceTimersByTimeAsync(60_000);
+
+				expect(persistOrder).toEqual(['Newer']);
+				expect(
+					useSessionStore
+						.getState()
+						.sessions.find((s) => s.id === 'session-1')
+						?.aiTabs.find((t) => t.id === 'tab-1')?.name
+				).toBe('Newer');
+				expect(mockProcess.sendRemoteRenameTabResponse).toHaveBeenCalledWith('response-newer', {
+					success: true,
+				});
+				await newerDone;
+
+				// The hung call finally lands and writes its stale name. The newest
+				// requested name has to come back in persistence AND in the tab, so a
+				// late write can never be the last word.
+				landHung!();
+				await vi.advanceTimersByTimeAsync(0);
+				await hungDone;
+
+				expect(persistOrder).toEqual(['Newer', 'Hung', 'Newer']);
+				expect(
+					useSessionStore
+						.getState()
+						.sessions.find((s) => s.id === 'session-1')
+						?.aiTabs.find((t) => t.id === 'tab-1')?.name
+				).toBe('Newer');
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
 		it('does not serialize renames of different tabs behind each other', async () => {
 			const session = createMockSession({
 				id: 'session-1',

--- a/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
@@ -1826,6 +1826,118 @@ describe('useRemoteIntegration', () => {
 				error: 'history unreadable',
 			});
 		});
+
+		// `tabCallbacks.ts` stops waiting on a rename after a bounded delay and
+		// dispatches the next one while the abandoned one may still be running
+		// here, so ordering cannot rely on the server having waited: an older
+		// rename finishing last would overwrite the newer name in BOTH the
+		// provider metadata and the store.
+		it('keeps the newest rename authoritative when an abandoned older one finishes last', async () => {
+			const tab = createMockTab({ id: 'tab-1', agentSessionId: 'agent-session-1', name: 'Old' });
+			const session = createMockSession({
+				id: 'session-1',
+				aiTabs: [tab],
+				projectRoot: '/test/project',
+				toolType: 'claude-code',
+			});
+			const deps = createDeps({ sessions: [session] });
+
+			// The older rename's persistence is held open, and is released only
+			// AFTER the newer rename has been dispatched and given room to run.
+			let releaseOlder: (() => void) | undefined;
+			const olderPersisted = new Promise<void>((resolve) => {
+				releaseOlder = resolve;
+			});
+			const persistOrder: string[] = [];
+			mockClaude.updateSessionName.mockImplementation(
+				async (_projectRoot: string, _agentSessionId: string, name: string) => {
+					if (name === 'Older') await olderPersisted;
+					persistOrder.push(name);
+				}
+			);
+
+			renderHook(() => useRemoteIntegration(deps));
+
+			const olderDone = onRemoteRenameTabHandler?.('session-1', 'tab-1', 'Older', 'response-older');
+			const newerDone = onRemoteRenameTabHandler?.('session-1', 'tab-1', 'Newer', 'response-newer');
+
+			// Let both handlers run as far as they can. The newer one must be
+			// parked behind the older one rather than racing it.
+			await act(async () => {
+				await Promise.resolve();
+				await Promise.resolve();
+			});
+			expect(persistOrder).toEqual([]);
+
+			await act(async () => {
+				releaseOlder!();
+				await olderDone;
+				await newerDone;
+			});
+
+			// Persistence happened in request order, so the last name written to the
+			// provider is the newest request, not the one that was abandoned.
+			expect(persistOrder).toEqual(['Older', 'Newer']);
+
+			const updatedSession = useSessionStore.getState().sessions.find((s) => s.id === 'session-1');
+			expect(updatedSession?.aiTabs.find((t) => t.id === 'tab-1')?.name).toBe('Newer');
+
+			// Both callers still get a truthful answer; neither is left hanging.
+			expect(mockProcess.sendRemoteRenameTabResponse).toHaveBeenCalledWith('response-older', {
+				success: true,
+			});
+			expect(mockProcess.sendRemoteRenameTabResponse).toHaveBeenCalledWith('response-newer', {
+				success: true,
+			});
+		});
+
+		it('does not serialize renames of different tabs behind each other', async () => {
+			const session = createMockSession({
+				id: 'session-1',
+				aiTabs: [
+					createMockTab({ id: 'tab-1', agentSessionId: 'agent-session-1', name: 'Old A' }),
+					createMockTab({ id: 'tab-2', agentSessionId: 'agent-session-2', name: 'Old B' }),
+				],
+				projectRoot: '/test/project',
+				toolType: 'claude-code',
+			});
+			const deps = createDeps({ sessions: [session] });
+
+			let releaseFirst: (() => void) | undefined;
+			const firstPersisted = new Promise<void>((resolve) => {
+				releaseFirst = resolve;
+			});
+			const persistOrder: string[] = [];
+			mockClaude.updateSessionName.mockImplementation(
+				async (_projectRoot: string, _agentSessionId: string, name: string) => {
+					if (name === 'Tab One') await firstPersisted;
+					persistOrder.push(name);
+				}
+			);
+
+			renderHook(() => useRemoteIntegration(deps));
+
+			const firstDone = onRemoteRenameTabHandler?.('session-1', 'tab-1', 'Tab One', 'response-one');
+			const secondDone = onRemoteRenameTabHandler?.(
+				'session-1',
+				'tab-2',
+				'Tab Two',
+				'response-two'
+			);
+
+			// tab-2 is not held up by tab-1: the key is per tab, so this must not
+			// become an app-wide rename lock.
+			await act(async () => {
+				await secondDone;
+			});
+			expect(persistOrder).toEqual(['Tab Two']);
+
+			await act(async () => {
+				releaseFirst!();
+				await firstDone;
+			});
+			expect(persistOrder).toEqual(['Tab Two', 'Tab One']);
+		});
 	});
 
 	describe('remote create gist', () => {

--- a/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
@@ -7,7 +7,7 @@ import { useRemoteIntegration } from '../../../renderer/hooks';
 import type { Session, AITab } from '../../../renderer/types';
 import { createMockAITab } from '../../helpers/mockTab';
 import { createMockSession as baseCreateMockSession } from '../../helpers/mockSession';
-import { useSessionStore } from '../../../renderer/stores/sessionStore';
+import { updateAiTab, useSessionStore } from '../../../renderer/stores/sessionStore';
 import { useNotificationStore } from '../../../renderer/stores/notificationStore';
 import { useMovementStore } from '../../../renderer/stores/movementStore';
 import { useConcertoCreationActivityStore } from '../../../renderer/stores/concertoCreationActivityStore';
@@ -1965,6 +1965,67 @@ describe('useRemoteIntegration', () => {
 						.sessions.find((s) => s.id === 'session-1')
 						?.aiTabs.find((t) => t.id === 'tab-1')?.name
 				).toBe('Newer');
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		// The tab is renamed from outside this queue too: `useSessionLifecycle`
+		// writes the same provider metadata, history and store name for a desktop
+		// rename. So "already applied" has to be read from the live tab, not
+		// remembered from what this queue last wrote, or a repeat remote rename is
+		// skipped and reported successful while the tab shows something else.
+		it('re-applies a name the tab lost to a rename made outside this queue', async () => {
+			vi.useFakeTimers();
+			try {
+				const tab = createMockTab({ id: 'tab-1', agentSessionId: 'agent-session-1', name: 'Old' });
+				const session = createMockSession({
+					id: 'session-1',
+					aiTabs: [tab],
+					projectRoot: '/test/project',
+					toolType: 'claude-code',
+				});
+				const deps = createDeps({ sessions: [session] });
+				const persistOrder: string[] = [];
+				const neverSettles = new Promise<void>(() => {});
+				mockClaude.updateSessionName.mockImplementation(
+					async (_projectRoot: string, _agentSessionId: string, name: string) => {
+						if (name === 'Hung') await neverSettles;
+						persistOrder.push(name);
+					}
+				);
+
+				renderHook(() => useRemoteIntegration(deps));
+
+				// A rename that never settles keeps this tab's bookkeeping alive, so
+				// anything remembered in it outlives the rename that recorded it.
+				void onRemoteRenameTabHandler?.('session-1', 'tab-1', 'Hung', 'response-hung');
+				await vi.advanceTimersByTimeAsync(60_000);
+
+				void onRemoteRenameTabHandler?.('session-1', 'tab-1', 'Beta', 'response-1');
+				await vi.advanceTimersByTimeAsync(0);
+				expect(persistOrder).toEqual(['Beta']);
+
+				// The desktop renames the tab, bypassing the remote rename queue.
+				act(() => {
+					updateAiTab('session-1', 'tab-1', (t) => ({ ...t, name: 'Gamma' }));
+				});
+
+				// The same remote name is requested again. It must be written, not
+				// skipped as something this queue believes it already applied.
+				void onRemoteRenameTabHandler?.('session-1', 'tab-1', 'Beta', 'response-2');
+				await vi.advanceTimersByTimeAsync(0);
+
+				expect(persistOrder).toEqual(['Beta', 'Beta']);
+				expect(
+					useSessionStore
+						.getState()
+						.sessions.find((s) => s.id === 'session-1')
+						?.aiTabs.find((t) => t.id === 'tab-1')?.name
+				).toBe('Beta');
+				expect(mockProcess.sendRemoteRenameTabResponse).toHaveBeenCalledWith('response-2', {
+					success: true,
+				});
 			} finally {
 				vi.useRealTimers();
 			}

--- a/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
@@ -1876,8 +1876,12 @@ describe('useRemoteIntegration', () => {
 			});
 
 			// Persistence happened in request order, so the last name written to the
-			// provider is the newest request, not the one that was abandoned.
-			expect(persistOrder).toEqual(['Older', 'Newer']);
+			// provider is the newest request, not the one that was abandoned. The
+			// trailing repeat is the newer request writing its own name after the
+			// older runner had already reconciled to it: writes are idempotent and
+			// unconditional, because nothing available in the renderer proves the
+			// provider already agrees with the tab.
+			expect(persistOrder).toEqual(['Older', 'Newer', 'Newer']);
 
 			const updatedSession = useSessionStore.getState().sessions.find((s) => s.id === 'session-1');
 			expect(updatedSession?.aiTabs.find((t) => t.id === 'tab-1')?.name).toBe('Newer');
@@ -2110,6 +2114,46 @@ describe('useRemoteIntegration', () => {
 			} finally {
 				vi.useRealTimers();
 			}
+		});
+
+		// Auto-naming (`useSessionLifecycle`, `useInputProcessing`) sets `tab.name`
+		// through `updateAiTab` alone and writes nothing to the provider, so a tab
+		// showing a name is NOT evidence that the provider carries it. Renaming
+		// remotely to the name the tab already displays therefore has to write, not
+		// skip and claim success for something never persisted.
+		it('persists a remote rename to the name a tab was already auto-named', async () => {
+			const tab = createMockTab({ id: 'tab-1', agentSessionId: 'agent-session-1', name: null });
+			const session = createMockSession({
+				id: 'session-1',
+				aiTabs: [tab],
+				projectRoot: '/test/project',
+				toolType: 'claude-code',
+			});
+			const deps = createDeps({ sessions: [session] });
+			const persistOrder: string[] = [];
+			mockClaude.updateSessionName.mockImplementation(
+				async (_projectRoot: string, _agentSessionId: string, name: string) => {
+					persistOrder.push(name);
+				}
+			);
+
+			renderHook(() => useRemoteIntegration(deps));
+
+			// Auto-naming puts the name on the tab without touching the provider.
+			act(() => {
+				updateAiTab('session-1', 'tab-1', (t) => ({ ...t, name: 'Auto Name' }));
+			});
+			expect(persistOrder).toEqual([]);
+
+			await act(async () => {
+				await onRemoteRenameTabHandler?.('session-1', 'tab-1', 'Auto Name', 'response-1');
+			});
+
+			expect(persistOrder).toEqual(['Auto Name']);
+			expect(mockHistory.updateSessionName).toHaveBeenCalledWith('agent-session-1', 'Auto Name');
+			expect(mockProcess.sendRemoteRenameTabResponse).toHaveBeenCalledWith('response-1', {
+				success: true,
+			});
 		});
 
 		it('does not serialize renames of different tabs behind each other', async () => {

--- a/src/main/utils/atomic-json-store.ts
+++ b/src/main/utils/atomic-json-store.ts
@@ -21,7 +21,10 @@
  *
  * `createKeyedWriteQueue` fixes (2) within a process: it serializes every
  * mutation for a given key (e.g. a session id) so read-modify-write sequences
- * never interleave.
+ * never interleave. Its implementation lives in `src/shared/keyedWriteQueue.ts`
+ * (the renderer serializes work too and cannot import `fs/promises`) and is
+ * re-exported below, so this stays the import site every main-process caller
+ * already uses.
  *
  * This is the canonical home for the pattern that previously lived inline in
  * `group-chat-storage.ts`.
@@ -81,36 +84,4 @@ export async function atomicWriteFile(
 	}
 }
 
-/** Enqueue an async callback, serialized against others sharing the same key. */
-export interface KeyedWriteQueue {
-	enqueue<T>(key: string, fn: () => Promise<T>): Promise<T>;
-}
-
-/**
- * Create an independent per-key write queue. Each key (e.g. a session id) gets
- * its own promise chain, so callers mutating the same file run strictly one at
- * a time while different keys still run concurrently. Queue entries are cleaned
- * up once settled to keep the backing Map bounded in long-lived processes.
- */
-export function createKeyedWriteQueue(): KeyedWriteQueue {
-	const queues = new Map<string, Promise<void>>();
-
-	function enqueue<T>(key: string, fn: () => Promise<T>): Promise<T> {
-		const prev = queues.get(key) ?? Promise.resolve();
-		// Run fn regardless of whether the prior write resolved or rejected.
-		const next = prev.then(fn, fn);
-		const settled = next.then(
-			() => {},
-			() => {}
-		);
-		queues.set(key, settled);
-		settled.then(() => {
-			if (queues.get(key) === settled) {
-				queues.delete(key);
-			}
-		});
-		return next;
-	}
-
-	return { enqueue };
-}
+export { createKeyedWriteQueue, type KeyedWriteQueue } from '../../shared/keyedWriteQueue';

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -831,28 +831,22 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 					return { success: true };
 				};
 
-				// Whether the tab ALREADY shows this exact name, which is the one case
-				// a write can be skipped. It reads the live tab rather than
-				// remembering what this queue last wrote, because the tab is renamed
-				// from outside this queue too - `useSessionLifecycle` writes the same
-				// provider metadata, history and store name for a desktop rename - and
-				// a remembered value would skip a write the tab genuinely needs and
-				// then report success for a name it never applied.
-				const tabAlreadyShows = (target: string) => {
-					const tab = useSessionStore
-						.getState()
-						.sessions.find((s) => s.id === sessionId)
-						?.aiTabs.find((t) => t.id === tabId);
-					return tab ? (tab.name ?? '') === target : false;
-				};
-
 				// Write this request's name, then LOOK AGAIN. Re-reading the desired
 				// name after the write is what keeps the newest one authoritative when
 				// this write was a stale one that landed late: the writer that lands
 				// last simply writes once more, so persistence and the tab both end on
 				// the newest name rather than on whichever call happened to return
-				// last. The ordinary in-order case still writes each name once, since
-				// a name the tab already carries is not rewritten.
+				// last.
+				//
+				// Every pass WRITES, even when the tab already shows the name asked
+				// for. Nothing available here is evidence that the provider agrees
+				// with the tab: auto-naming (`useSessionLifecycle`, `useInputProcessing`)
+				// sets `tab.name` through `updateAiTab` alone, with no provider write,
+				// and a desktop rename writes the provider outside this queue, so a
+				// remembered value goes stale too. Skipping on either signal reports
+				// success for a name that was never persisted. The write is idempotent,
+				// so the cost of always making it is one redundant round trip when two
+				// renames of a tab overlap.
 				const runRename = async () => {
 					// What to tell THIS request's caller, answered once at the end. A
 					// failure is remembered rather than returned on the spot: a write
@@ -863,33 +857,22 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 					let ownOutcome: { success: boolean; error?: string } = { success: true };
 					try {
 						let target = persistedName;
-						let hasWritten = false;
 						// Each pass either settles on the desired name or adopts the
 						// newer one that arrived while it was writing, so it cannot spin:
 						// a failed pass moves to `state.desired` and the next pass ends
 						// unless a real request has changed it again.
 						for (;;) {
-							// The skip answers "does this request need to write at all?",
-							// and only before this runner has written anything. Once it
-							// has, every later pass is a REPAIR of a name it wrote itself,
-							// and the tab is no longer evidence that the provider agrees:
-							// `applyRename` persists the provider name before the history
-							// relabel, so a rejection there leaves the provider on the old
-							// name while the tab still shows the newer one.
-							if (hasWritten || !tabAlreadyShows(target)) {
-								const result = await applyRename(target).catch((error) => {
-									logger.error('Failed to persist remote tab name:', undefined, error);
-									return {
-										success: false,
-										error: error instanceof Error ? error.message : String(error),
-									};
-								});
-								hasWritten = true;
-								// Only this request's OWN name decides its answer. A repair
-								// write belongs to whoever asked for that name, so failing it
-								// must not turn this caller's successful rename into an error.
-								if (!result.success && target === persistedName) ownOutcome = result;
-							}
+							const result = await applyRename(target).catch((error) => {
+								logger.error('Failed to persist remote tab name:', undefined, error);
+								return {
+									success: false,
+									error: error instanceof Error ? error.message : String(error),
+								};
+							});
+							// Only this request's OWN name decides its answer. A repair
+							// write belongs to whoever asked for that name, so failing it
+							// must not turn this caller's successful rename into an error.
+							if (!result.success && target === persistedName) ownOutcome = result;
 							if (state.desired === target) break;
 							target = state.desired;
 						}

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -30,6 +30,7 @@ import {
 import { openUiSurface } from '../../utils/openUiSurface';
 import { notifyCenterFlash } from '../../stores/centerFlashStore';
 import { updateAiTab, updateSessionWith, useSessionStore } from '../../stores/sessionStore';
+import { createKeyedWriteQueue } from '../../../shared/keyedWriteQueue';
 import { useConcertoCreationActivityStore } from '../../stores/concertoCreationActivityStore';
 import { buildThinkingItems } from '../../utils/thinkingItems';
 import type { ConcertoCreationPhase, ConcertoProgressNote } from '../../../shared/movement-types';
@@ -151,6 +152,24 @@ function waitForMovementInspectionPaint(): Promise<void> {
  * read is tail-anchored, so this keeps the newest N and reports the cut.
  */
 const GIST_SESSION_MESSAGE_LIMIT = 10000;
+
+/**
+ * Remote renames of ONE tab, serialized by `${sessionId}:${tabId}`.
+ *
+ * This is where a rename's work happens (provider metadata write, history
+ * relabel, store patch), so this is where it has to run one at a time for the
+ * LATEST rename to end up authoritative. `tabCallbacks.ts` has its own per-tab
+ * queue, but that one orders the PROTOCOL and cannot order work performed in
+ * this process: it stops waiting after a bounded delay so an unresponsive
+ * renderer cannot wedge the tab, and it then dispatches the next rename while
+ * the abandoned one may still be running here. Those two would race, and the
+ * older one landing last is exactly the failure both queues exist to prevent.
+ *
+ * Module scope, not a ref: the listener is registered from an effect that can
+ * re-run, and a queue rebuilt on re-registration would forget the rename still
+ * in flight. Same reason `group-chat-storage.ts` holds its own at module scope.
+ */
+const remoteRenameQueue = createKeyedWriteQueue();
 
 type GistBody = { body: string } | { error: string };
 
@@ -704,76 +723,81 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 				const reply = (result: { success: boolean; error?: string }) =>
 					window.maestro.process.sendRemoteRenameTabResponse(responseChannel, result);
 
-				try {
-					const session = sessionsRef.current.find((s) => s.id === sessionId);
-					if (!session) {
-						reply({ success: false, error: `Session not found: ${sessionId}` });
-						return;
-					}
-
-					const tab = session.aiTabs.find((t) => t.id === tabId);
-					if (!tab) {
-						reply({ success: false, error: `Tab not found: ${tabId}` });
-						return;
-					}
-
-					const persistedName = newName || '';
-					if (tab.agentSessionId) {
-						const agentId = session.toolType || 'claude-code';
-						if (agentId === 'claude-code') {
-							await window.maestro.claude.updateSessionName(
-								session.projectRoot,
-								tab.agentSessionId,
-								persistedName
-							);
-						} else {
-							await window.maestro.agentSessions.setSessionName(
-								agentId,
-								session.projectRoot,
-								tab.agentSessionId,
-								persistedName || null
-							);
+				// The session and tab are resolved INSIDE the queued unit, so a rename
+				// that waited reads the state its predecessor left rather than a
+				// snapshot taken before it ran.
+				await remoteRenameQueue.enqueue(`${sessionId}:${tabId}`, async () => {
+					try {
+						const session = sessionsRef.current.find((s) => s.id === sessionId);
+						if (!session) {
+							reply({ success: false, error: `Session not found: ${sessionId}` });
+							return;
 						}
-						// Relabelling past history entries is SECONDARY, and it is awaited
-						// only so that a thrown error still fails the rename. A count of
-						// zero is not a failure: `agentSessionId` is stamped when the
-						// provider emits its id at the START of a turn, while the entry
-						// carrying that id is written by the exit listener at the END, so
-						// a tab renamed during its first turn legitimately has nothing to
-						// relabel (as does one whose entries aged out of `maxEntries`).
-						// Failing there would be worse than the bug this path fixes: the
-						// provider metadata above has already been written with the new
-						// name, so refusing here leaves the desktop and the web showing
-						// the old name while the new one resurfaces in the Agent Sessions
-						// browser and on resume. It would also make the same rename
-						// succeed on the desktop and fail from the phone, since
-						// `useSessionLifecycle` treats this call as best effort too.
-						await window.maestro.history.updateSessionName(tab.agentSessionId, persistedName);
-					}
 
-					updateAiTab(sessionId, tabId, (t) => ({
-						...t,
-						name: persistedName || null,
-						isGeneratingName: false,
-					}));
-					const updatedTab = useSessionStore
-						.getState()
-						.sessions.find((s) => s.id === sessionId)
-						?.aiTabs.find((t) => t.id === tabId);
-					if (!updatedTab) {
-						reply({ success: false, error: `Tab not found after rename: ${tabId}` });
-						return;
+						const tab = session.aiTabs.find((t) => t.id === tabId);
+						if (!tab) {
+							reply({ success: false, error: `Tab not found: ${tabId}` });
+							return;
+						}
+
+						const persistedName = newName || '';
+						if (tab.agentSessionId) {
+							const agentId = session.toolType || 'claude-code';
+							if (agentId === 'claude-code') {
+								await window.maestro.claude.updateSessionName(
+									session.projectRoot,
+									tab.agentSessionId,
+									persistedName
+								);
+							} else {
+								await window.maestro.agentSessions.setSessionName(
+									agentId,
+									session.projectRoot,
+									tab.agentSessionId,
+									persistedName || null
+								);
+							}
+							// Relabelling past history entries is SECONDARY, and it is awaited
+							// only so that a thrown error still fails the rename. A count of
+							// zero is not a failure: `agentSessionId` is stamped when the
+							// provider emits its id at the START of a turn, while the entry
+							// carrying that id is written by the exit listener at the END, so
+							// a tab renamed during its first turn legitimately has nothing to
+							// relabel (as does one whose entries aged out of `maxEntries`).
+							// Failing there would be worse than the bug this path fixes: the
+							// provider metadata above has already been written with the new
+							// name, so refusing here leaves the desktop and the web showing
+							// the old name while the new one resurfaces in the Agent Sessions
+							// browser and on resume. It would also make the same rename
+							// succeed on the desktop and fail from the phone, since
+							// `useSessionLifecycle` treats this call as best effort too.
+							await window.maestro.history.updateSessionName(tab.agentSessionId, persistedName);
+						}
+
+						updateAiTab(sessionId, tabId, (t) => ({
+							...t,
+							name: persistedName || null,
+							isGeneratingName: false,
+						}));
+						const updatedTab = useSessionStore
+							.getState()
+							.sessions.find((s) => s.id === sessionId)
+							?.aiTabs.find((t) => t.id === tabId);
+						if (!updatedTab) {
+							reply({ success: false, error: `Tab not found after rename: ${tabId}` });
+							return;
+						}
+						if (updatedTab.name !== (persistedName || null)) {
+							reply({ success: false, error: `Tab rename did not update state: ${tabId}` });
+							return;
+						}
+						reply({ success: true });
+					} catch (error) {
+						const message = error instanceof Error ? error.message : String(error);
+						logger.error('Failed to persist remote tab name:', undefined, error);
+						reply({ success: false, error: message });
 					}
-					if (updatedTab.name !== (persistedName || null)) {
-						reply({ success: false, error: `Tab rename did not update state: ${tabId}` });
-						return;
-					}
-					reply({ success: true });
-				} catch (error) {
-					const message = error instanceof Error ? error.message : String(error);
-					logger.error('Failed to persist remote tab name:', undefined, error);
-					reply({ success: false, error: message });
-				}
+				});
 			}
 		);
 

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -171,6 +171,42 @@ const GIST_SESSION_MESSAGE_LIMIT = 10000;
  */
 const remoteRenameQueue = createKeyedWriteQueue();
 
+/**
+ * How long a rename may hold its tab's queue slot before the next one starts.
+ * The persistence calls are `ipcRenderer.invoke`, which never times out, so a
+ * main-process handler that never returns leaves its promise pending for the
+ * life of the window; without this every later rename for the tab would sit
+ * behind it unattempted. Well past any plausible write, since handing the slot
+ * on early costs at most a redundant write rather than correctness.
+ */
+const RENAME_SLOT_HANDOFF_MS = 15_000;
+
+/**
+ * Per tab, the newest name REQUESTED and the newest name a write has actually
+ * LANDED. A writer compares the two when it finishes to find out whether it was
+ * the last one in, which is how a stale write that lands late gets corrected.
+ * Kept only while a rename is in flight, and module scope for the same reason
+ * the queue is.
+ */
+const remoteRenameStates = new Map<string, { desired: string; applied?: string; active: number }>();
+
+/**
+ * Resolve when `work` settles, or when the handoff budget expires - whichever
+ * comes first. The work is NOT abandoned or cancelled on expiry (an in-flight
+ * IPC cannot be recalled); it keeps running and re-checks the desired name when
+ * it lands, which is what stops a late stale write from being the final word.
+ * One timer per rename, always cleared once the work settles.
+ */
+function handOffRenameSlotAfter(work: Promise<void>, budgetMs: number): Promise<void> {
+	return new Promise((resolve) => {
+		const timer = setTimeout(resolve, budgetMs);
+		void work.finally(() => {
+			clearTimeout(timer);
+			resolve();
+		});
+	});
+}
+
 type GistBody = { body: string } | { error: string };
 
 /**
@@ -723,84 +759,123 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 				const reply = (result: { success: boolean; error?: string }) =>
 					window.maestro.process.sendRemoteRenameTabResponse(responseChannel, result);
 
-				// The session and tab are resolved INSIDE the queued unit, so a rename
-				// that waited reads the state its predecessor left rather than a
-				// snapshot taken before it ran.
-				await remoteRenameQueue.enqueue(`${sessionId}:${tabId}`, async () => {
+				const key = `${sessionId}:${tabId}`;
+				const persistedName = newName || '';
+
+				// Recording the request BEFORE anything is written is what lets a
+				// writer already in flight discover that it has been superseded.
+				const state = remoteRenameStates.get(key) ?? { desired: persistedName, active: 0 };
+				state.desired = persistedName;
+				state.active += 1;
+				remoteRenameStates.set(key, state);
+
+				// One write: provider metadata, then history, then the store. The
+				// session and tab are resolved HERE rather than at dispatch, so a
+				// rename that waited reads the state its predecessor left.
+				const applyRename = async (
+					target: string
+				): Promise<{ success: boolean; error?: string }> => {
+					const session = sessionsRef.current.find((s) => s.id === sessionId);
+					if (!session) return { success: false, error: `Session not found: ${sessionId}` };
+
+					const tab = session.aiTabs.find((t) => t.id === tabId);
+					if (!tab) return { success: false, error: `Tab not found: ${tabId}` };
+
+					if (tab.agentSessionId) {
+						const agentId = session.toolType || 'claude-code';
+						if (agentId === 'claude-code') {
+							await window.maestro.claude.updateSessionName(
+								session.projectRoot,
+								tab.agentSessionId,
+								target
+							);
+						} else {
+							await window.maestro.agentSessions.setSessionName(
+								agentId,
+								session.projectRoot,
+								tab.agentSessionId,
+								target || null
+							);
+						}
+						// Relabelling past history entries is SECONDARY, and it is awaited
+						// only so that a thrown error still fails the rename. A count of
+						// zero is not a failure: `agentSessionId` is stamped when the
+						// provider emits its id at the START of a turn, while the entry
+						// carrying that id is written by the exit listener at the END, so
+						// a tab renamed during its first turn legitimately has nothing to
+						// relabel (as does one whose entries aged out of `maxEntries`).
+						// Failing there would be worse than the bug this path fixes: the
+						// provider metadata above has already been written with the new
+						// name, so refusing here leaves the desktop and the web showing
+						// the old name while the new one resurfaces in the Agent Sessions
+						// browser and on resume. It would also make the same rename
+						// succeed on the desktop and fail from the phone, since
+						// `useSessionLifecycle` treats this call as best effort too.
+						await window.maestro.history.updateSessionName(tab.agentSessionId, target);
+					}
+
+					updateAiTab(sessionId, tabId, (t) => ({
+						...t,
+						name: target || null,
+						isGeneratingName: false,
+					}));
+					const updatedTab = useSessionStore
+						.getState()
+						.sessions.find((s) => s.id === sessionId)
+						?.aiTabs.find((t) => t.id === tabId);
+					if (!updatedTab) {
+						return { success: false, error: `Tab not found after rename: ${tabId}` };
+					}
+					if (updatedTab.name !== (target || null)) {
+						return { success: false, error: `Tab rename did not update state: ${tabId}` };
+					}
+					return { success: true };
+				};
+
+				// Write this request's name, then LOOK AGAIN. Re-reading the desired
+				// name after the write is what keeps the newest one authoritative when
+				// this write was a stale one that landed late: the writer that lands
+				// last simply writes once more, so persistence and the tab both end on
+				// the newest name rather than on whichever call happened to return
+				// last. A target another writer already applied is skipped rather than
+				// rewritten, so the ordinary in-order case still writes each name once.
+				const runRename = async () => {
 					try {
-						const session = sessionsRef.current.find((s) => s.id === sessionId);
-						if (!session) {
-							reply({ success: false, error: `Session not found: ${sessionId}` });
-							return;
-						}
-
-						const tab = session.aiTabs.find((t) => t.id === tabId);
-						if (!tab) {
-							reply({ success: false, error: `Tab not found: ${tabId}` });
-							return;
-						}
-
-						const persistedName = newName || '';
-						if (tab.agentSessionId) {
-							const agentId = session.toolType || 'claude-code';
-							if (agentId === 'claude-code') {
-								await window.maestro.claude.updateSessionName(
-									session.projectRoot,
-									tab.agentSessionId,
-									persistedName
-								);
-							} else {
-								await window.maestro.agentSessions.setSessionName(
-									agentId,
-									session.projectRoot,
-									tab.agentSessionId,
-									persistedName || null
-								);
+						let target = persistedName;
+						for (;;) {
+							if (state.applied !== target) {
+								const outcome = await applyRename(target);
+								if (!outcome.success) {
+									reply(outcome);
+									return;
+								}
+								state.applied = target;
 							}
-							// Relabelling past history entries is SECONDARY, and it is awaited
-							// only so that a thrown error still fails the rename. A count of
-							// zero is not a failure: `agentSessionId` is stamped when the
-							// provider emits its id at the START of a turn, while the entry
-							// carrying that id is written by the exit listener at the END, so
-							// a tab renamed during its first turn legitimately has nothing to
-							// relabel (as does one whose entries aged out of `maxEntries`).
-							// Failing there would be worse than the bug this path fixes: the
-							// provider metadata above has already been written with the new
-							// name, so refusing here leaves the desktop and the web showing
-							// the old name while the new one resurfaces in the Agent Sessions
-							// browser and on resume. It would also make the same rename
-							// succeed on the desktop and fail from the phone, since
-							// `useSessionLifecycle` treats this call as best effort too.
-							await window.maestro.history.updateSessionName(tab.agentSessionId, persistedName);
-						}
-
-						updateAiTab(sessionId, tabId, (t) => ({
-							...t,
-							name: persistedName || null,
-							isGeneratingName: false,
-						}));
-						const updatedTab = useSessionStore
-							.getState()
-							.sessions.find((s) => s.id === sessionId)
-							?.aiTabs.find((t) => t.id === tabId);
-						if (!updatedTab) {
-							reply({ success: false, error: `Tab not found after rename: ${tabId}` });
-							return;
-						}
-						if (updatedTab.name !== (persistedName || null)) {
-							reply({ success: false, error: `Tab rename did not update state: ${tabId}` });
-							return;
+							if (state.desired === state.applied) break;
+							target = state.desired;
 						}
 						reply({ success: true });
 					} catch (error) {
 						const message = error instanceof Error ? error.message : String(error);
 						logger.error('Failed to persist remote tab name:', undefined, error);
 						reply({ success: false, error: message });
+					} finally {
+						state.active -= 1;
+						if (state.active === 0 && remoteRenameStates.get(key) === state) {
+							remoteRenameStates.delete(key);
+						}
 					}
-				});
+				};
+
+				// The queue keeps a tab's renames in order. Its slot is handed on once
+				// the work settles OR the budget expires, so a persistence call that
+				// never settles cannot wedge the tab: the next rename still runs, and
+				// the loop above repairs the order if the hung one ever lands.
+				await remoteRenameQueue.enqueue(key, () =>
+					handOffRenameSlotAfter(runRename(), RENAME_SLOT_HANDOFF_MS)
+				);
 			}
 		);
-
 		// Handle remote star tab from web interface
 		const unsubscribeStarTab = window.maestro.process.onRemoteStarTab(
 			(sessionId: string, tabId: string, starred: boolean) => {

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -854,29 +854,57 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 				// last. The ordinary in-order case still writes each name once, since
 				// a name the tab already carries is not rewritten.
 				const runRename = async () => {
+					// What to tell THIS request's caller, answered once at the end. A
+					// failure is remembered rather than returned on the spot: a write
+					// that failed can still have left a side effect behind, so
+					// reconciling has to happen after ANY of them, or a stale operation
+					// that failed late leaves the provider disagreeing with the tab and
+					// with what the newer request was already told.
+					let ownOutcome: { success: boolean; error?: string } = { success: true };
 					try {
 						let target = persistedName;
+						let hasWritten = false;
+						// Each pass either settles on the desired name or adopts the
+						// newer one that arrived while it was writing, so it cannot spin:
+						// a failed pass moves to `state.desired` and the next pass ends
+						// unless a real request has changed it again.
 						for (;;) {
-							if (!tabAlreadyShows(target)) {
-								const outcome = await applyRename(target);
-								if (!outcome.success) {
-									reply(outcome);
-									return;
-								}
+							// The skip answers "does this request need to write at all?",
+							// and only before this runner has written anything. Once it
+							// has, every later pass is a REPAIR of a name it wrote itself,
+							// and the tab is no longer evidence that the provider agrees:
+							// `applyRename` persists the provider name before the history
+							// relabel, so a rejection there leaves the provider on the old
+							// name while the tab still shows the newer one.
+							if (hasWritten || !tabAlreadyShows(target)) {
+								const result = await applyRename(target).catch((error) => {
+									logger.error('Failed to persist remote tab name:', undefined, error);
+									return {
+										success: false,
+										error: error instanceof Error ? error.message : String(error),
+									};
+								});
+								hasWritten = true;
+								// Only this request's OWN name decides its answer. A repair
+								// write belongs to whoever asked for that name, so failing it
+								// must not turn this caller's successful rename into an error.
+								if (!result.success && target === persistedName) ownOutcome = result;
 							}
 							if (state.desired === target) break;
 							target = state.desired;
 						}
-						reply({ success: true });
 					} catch (error) {
 						const message = error instanceof Error ? error.message : String(error);
 						logger.error('Failed to persist remote tab name:', undefined, error);
-						reply({ success: false, error: message });
+						ownOutcome = { success: false, error: message };
 					} finally {
+						// Cleanup before the reply, so a send that throws cannot leave
+						// this tab's bookkeeping behind for the life of the window.
 						state.active -= 1;
 						if (state.active === 0 && remoteRenameStates.get(key) === state) {
 							remoteRenameStates.delete(key);
 						}
+						reply(ownOutcome);
 					}
 				};
 

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -182,13 +182,12 @@ const remoteRenameQueue = createKeyedWriteQueue();
 const RENAME_SLOT_HANDOFF_MS = 15_000;
 
 /**
- * Per tab, the newest name REQUESTED and the newest name a write has actually
- * LANDED. A writer compares the two when it finishes to find out whether it was
- * the last one in, which is how a stale write that lands late gets corrected.
- * Kept only while a rename is in flight, and module scope for the same reason
- * the queue is.
+ * Per tab, the newest name a remote rename has REQUESTED. A writer re-reads it
+ * when its own write lands to find out whether it was superseded meanwhile,
+ * which is how a stale write that lands late gets corrected. Kept only while a
+ * rename is in flight, and module scope for the same reason the queue is.
  */
-const remoteRenameStates = new Map<string, { desired: string; applied?: string; active: number }>();
+const remoteRenameStates = new Map<string, { desired: string; active: number }>();
 
 /**
  * Resolve when `work` settles, or when the handoff budget expires - whichever
@@ -832,26 +831,40 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 					return { success: true };
 				};
 
+				// Whether the tab ALREADY shows this exact name, which is the one case
+				// a write can be skipped. It reads the live tab rather than
+				// remembering what this queue last wrote, because the tab is renamed
+				// from outside this queue too - `useSessionLifecycle` writes the same
+				// provider metadata, history and store name for a desktop rename - and
+				// a remembered value would skip a write the tab genuinely needs and
+				// then report success for a name it never applied.
+				const tabAlreadyShows = (target: string) => {
+					const tab = useSessionStore
+						.getState()
+						.sessions.find((s) => s.id === sessionId)
+						?.aiTabs.find((t) => t.id === tabId);
+					return tab ? (tab.name ?? '') === target : false;
+				};
+
 				// Write this request's name, then LOOK AGAIN. Re-reading the desired
 				// name after the write is what keeps the newest one authoritative when
 				// this write was a stale one that landed late: the writer that lands
 				// last simply writes once more, so persistence and the tab both end on
 				// the newest name rather than on whichever call happened to return
-				// last. A target another writer already applied is skipped rather than
-				// rewritten, so the ordinary in-order case still writes each name once.
+				// last. The ordinary in-order case still writes each name once, since
+				// a name the tab already carries is not rewritten.
 				const runRename = async () => {
 					try {
 						let target = persistedName;
 						for (;;) {
-							if (state.applied !== target) {
+							if (!tabAlreadyShows(target)) {
 								const outcome = await applyRename(target);
 								if (!outcome.success) {
 									reply(outcome);
 									return;
 								}
-								state.applied = target;
 							}
-							if (state.desired === state.applied) break;
+							if (state.desired === target) break;
 							target = state.desired;
 						}
 						reply({ success: true });

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -199,10 +199,16 @@ const remoteRenameStates = new Map<string, { desired: string; active: number }>(
 function handOffRenameSlotAfter(work: Promise<void>, budgetMs: number): Promise<void> {
 	return new Promise((resolve) => {
 		const timer = setTimeout(resolve, budgetMs);
-		void work.finally(() => {
-			clearTimeout(timer);
-			resolve();
-		});
+		// `catch` rather than a bare `void`: the work answers its own caller and
+		// resolves the slot either way, so a rejection here has nowhere to go and
+		// would surface as an unhandled rejection. The one way it can reject is the
+		// reply itself throwing, which the caller's `finally` deliberately runs last.
+		work
+			.finally(() => {
+				clearTimeout(timer);
+				resolve();
+			})
+			.catch(() => {});
 	});
 }
 

--- a/src/shared/keyedWriteQueue.ts
+++ b/src/shared/keyedWriteQueue.ts
@@ -1,0 +1,45 @@
+/**
+ * Per-key serialization of async work: two callers racing on the same entity
+ * lose an update, and giving each key its own promise chain makes that
+ * unreachable while leaving different keys concurrent.
+ *
+ * It lives in `shared/` rather than beside `atomicWriteJson` because BOTH
+ * processes need it and the renderer cannot import a module that pulls in
+ * `fs/promises`. `src/main/utils/atomic-json-store.ts` re-exports it, so every
+ * main-process caller keeps its existing import. Same hoist, for the same
+ * reason, as `assertSerializedJsonIsSafe` in `src/shared/jsonUtils.ts`.
+ */
+
+/** Enqueue an async callback, serialized against others sharing the same key. */
+export interface KeyedWriteQueue {
+	enqueue<T>(key: string, fn: () => Promise<T>): Promise<T>;
+}
+
+/**
+ * Create an independent per-key write queue. Each key (e.g. a session id) gets
+ * its own promise chain, so callers mutating the same file run strictly one at
+ * a time while different keys still run concurrently. Queue entries are cleaned
+ * up once settled to keep the backing Map bounded in long-lived processes.
+ */
+export function createKeyedWriteQueue(): KeyedWriteQueue {
+	const queues = new Map<string, Promise<void>>();
+
+	function enqueue<T>(key: string, fn: () => Promise<T>): Promise<T> {
+		const prev = queues.get(key) ?? Promise.resolve();
+		// Run fn regardless of whether the prior write resolved or rejected.
+		const next = prev.then(fn, fn);
+		const settled = next.then(
+			() => {},
+			() => {}
+		);
+		queues.set(key, settled);
+		settled.then(() => {
+			if (queues.get(key) === settled) {
+				queues.delete(key);
+			}
+		});
+		return next;
+	}
+
+	return { enqueue };
+}


### PR DESCRIPTION
Follow-up to #1521, which is already merged. That PR made the remote rename acknowledgement truthful and added a per-tab queue in `tabCallbacks.ts`. This closes one hole it left open.

## The hole

The server's queue stops waiting after `RENAME_CONFIRMATION_RELEASE_MS` (60s) so a renderer that never answers cannot wedge a tab. At that moment it frees the slot and dispatches the next rename for the tab, while the abandoned one may still be running in the renderer. The two then overlap, and the older one can finish last and overwrite the newer name in both the provider metadata and the store: the same lost update the queue was added to prevent, reopened past the release window.

Reproduced in a real Electron process (real `BrowserWindow`, real `ipcMain`, real `WebServer`, real WebSocket client, isolated throwaway userData). Holding an older rename past the window and issuing a newer one:

```
FAIL  the newer rename really did overlap the still-running older one :: applied=["Newer"]
FAIL  the older rename finished FIRST even though it was abandoned :: ["Newer","Older"]
FAIL  the newest rename landed last, past the release window :: ["Newer","Older"]
FAIL  the surviving name is the newest request :: Older
```

## The fix

A queue in one process cannot order work performed in another. The renderer is where a rename's work actually happens (provider metadata write, history relabel, store patch), so that is where it now runs one at a time, keyed `${sessionId}:${tabId}` exactly as the server keys its own.

The server's queue stays. The two answer different questions: the server's orders the PROTOCOL and is what puts `rename_tab_result` frames back on the wire in request order, and the renderer's orders the WORK. Nothing about the release path changed, so cleanup stays bounded and it still reports "did not confirm" rather than claiming a failure it cannot know.

`createKeyedWriteQueue` moves to `src/shared/keyedWriteQueue.ts` because the renderer cannot import a module that pulls in `fs/promises`. `atomic-json-store.ts` re-exports it, so all seven main-process call sites are untouched. Same hoist, and for the same reason, as `assertSerializedJsonIsSafe` in `src/shared/jsonUtils.ts`.

## Tests

Two deterministic regression tests in `useRemoteIntegration.test.ts`, no timers, released by explicit promise:

- `keeps the newest rename authoritative when an abandoned older one finishes last` - fails without the fix (`expected ['Newer'] to deeply equal []`).
- `does not serialize renames of different tabs behind each other` - guards the per-tab key so this cannot become an app-wide rename lock.

## Verification

- Targeted: 64 files / 2097 tests, covering every `createKeyedWriteQueue` consumer (history-manager, group-chat, starred-transcript-mirror, session-info-cache, feedback, web-server, CLI tab).
- Full suite: 42193 passed, 0 failed.
- `npm run lint` (all three tsconfigs), ESLint, repo-wide Prettier, `lint:doc-refs`: clean.
- Integration: `remote-tab-rename.integration.test.ts` 3/3 (real `WebServer` + real WebSocket).
- Real Electron smoke including the beyond-60s overlap: 11/11 after, 4 failures before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tab renaming reliability when multiple renames occur in quick succession.
  - Prevented older updates from overwriting newer tab names.
  - Ensured the latest name is retained despite delayed or partially failed saves.
  - Ensured remote renames persist even when the tab already displays that name through auto-naming.
  - Improved handling of externally changed names.

- **Tests**
  - Added regression coverage for rename ordering, persistence, failures, and concurrent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->