### PR TITLE
fix(macos): declare the TCC usage strings so agent CLIs can be granted access

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -249,6 +249,32 @@ EOF
 
 Then rebuild the cache: `fc-cache -f -v`
 
+## macOS Privacy Permissions
+
+macOS gates calendars, reminders, contacts, photos, the local network, and the Desktop / Documents / Downloads folders behind TCC (Transparency, Consent, and Control). TCC attributes a request to the **responsible process**, which for anything an agent shells out to is Maestro itself:
+
+```
+Maestro.app -> claude -> zsh -> ical
+```
+
+So when an agent runs a CLI that touches one of those services, the consent dialog names **Maestro**, and the switch you flip afterwards lives under Maestro's row in System Settings > Privacy & Security. That attribution is expected, not a bug: the tool is borrowing Maestro's identity because Maestro is what launched it.
+
+### A tool reports "access denied" and no dialog ever appears
+
+On older builds, Maestro declared no usage-description string for these services, so macOS denied every such request instantly and silently. It will not prompt on behalf of a purpose string an app never declared, and with nothing to prompt for, no Maestro row appears in the Privacy pane to enable. Update Maestro.
+
+On a current build, a missing prompt usually means macOS has cached an earlier decision. Reset the relevant service and run the command again:
+
+```bash
+tccutil reset Calendar com.maestro.app
+tccutil reset Reminders com.maestro.app
+tccutil reset AddressBook com.maestro.app
+tccutil reset Photos com.maestro.app
+tccutil reset SystemPolicyDocumentsFolder com.maestro.app
+```
+
+Omitting the bundle id resets that service for every app on the machine.
+
 ## Getting Help
 
 - **GitHub Issues**: [Report bugs or request features](https://github.com/RunMaestro/Maestro/issues)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -270,8 +270,17 @@ tccutil reset Calendar com.maestro.app
 tccutil reset Reminders com.maestro.app
 tccutil reset AddressBook com.maestro.app
 tccutil reset Photos com.maestro.app
+tccutil reset MediaLibrary com.maestro.app
+tccutil reset AppleEvents com.maestro.app
+tccutil reset SpeechRecognition com.maestro.app
+tccutil reset SystemPolicyDesktopFolder com.maestro.app
 tccutil reset SystemPolicyDocumentsFolder com.maestro.app
+tccutil reset SystemPolicyDownloadsFolder com.maestro.app
+tccutil reset SystemPolicyRemovableVolumes com.maestro.app
+tccutil reset SystemPolicyNetworkVolumes com.maestro.app
 ```
+
+Run `tccutil reset All com.maestro.app` to clear every service at once. Local network access has no `tccutil` service name; toggle Maestro off and on under System Settings > Privacy & Security > Local Network instead.
 
 Omitting the bundle id resets that service for every app on the machine.
 

--- a/package.json
+++ b/package.json
@@ -101,6 +101,23 @@
 			"notarize": false,
 			"entitlements": "build/entitlements.mac.plist",
 			"entitlementsInherit": "build/entitlements.mac.plist",
+			"extendInfo": {
+				"NSCalendarsUsageDescription": "A program running inside Maestro wants to access your calendars.",
+				"NSCalendarsFullAccessUsageDescription": "A program running inside Maestro wants to read and change your calendars.",
+				"NSCalendarsWriteOnlyAccessUsageDescription": "A program running inside Maestro wants to add events to your calendars.",
+				"NSRemindersUsageDescription": "A program running inside Maestro wants to access your reminders.",
+				"NSRemindersFullAccessUsageDescription": "A program running inside Maestro wants to read and change your reminders.",
+				"NSContactsUsageDescription": "A program running inside Maestro wants to access your contacts.",
+				"NSPhotoLibraryUsageDescription": "A program running inside Maestro wants to access your photo library.",
+				"NSPhotoLibraryAddUsageDescription": "A program running inside Maestro wants to add photos to your photo library.",
+				"NSAppleEventsUsageDescription": "A program running inside Maestro wants to control another app on your Mac.",
+				"NSLocalNetworkUsageDescription": "A program running inside Maestro wants to reach devices on your local network.",
+				"NSDesktopFolderUsageDescription": "A program running inside Maestro wants to read files on your Desktop.",
+				"NSDocumentsFolderUsageDescription": "A program running inside Maestro wants to read files in your Documents folder.",
+				"NSDownloadsFolderUsageDescription": "A program running inside Maestro wants to read files in your Downloads folder.",
+				"NSRemovableVolumesUsageDescription": "A program running inside Maestro wants to read files on a removable volume.",
+				"NSNetworkVolumesUsageDescription": "A program running inside Maestro wants to read files on a network volume."
+			},
 			"target": [
 				"dmg",
 				"zip"

--- a/package.json
+++ b/package.json
@@ -110,13 +110,16 @@
 				"NSContactsUsageDescription": "A program running inside Maestro wants to access your contacts.",
 				"NSPhotoLibraryUsageDescription": "A program running inside Maestro wants to access your photo library.",
 				"NSPhotoLibraryAddUsageDescription": "A program running inside Maestro wants to add photos to your photo library.",
+				"NSAppleMusicUsageDescription": "A program running inside Maestro wants to access your media library.",
 				"NSAppleEventsUsageDescription": "A program running inside Maestro wants to control another app on your Mac.",
+				"NSSpeechRecognitionUsageDescription": "A program running inside Maestro wants to send speech to Apple for recognition.",
 				"NSLocalNetworkUsageDescription": "A program running inside Maestro wants to reach devices on your local network.",
-				"NSDesktopFolderUsageDescription": "A program running inside Maestro wants to read files on your Desktop.",
-				"NSDocumentsFolderUsageDescription": "A program running inside Maestro wants to read files in your Documents folder.",
-				"NSDownloadsFolderUsageDescription": "A program running inside Maestro wants to read files in your Downloads folder.",
-				"NSRemovableVolumesUsageDescription": "A program running inside Maestro wants to read files on a removable volume.",
-				"NSNetworkVolumesUsageDescription": "A program running inside Maestro wants to read files on a network volume."
+				"NSLocationWhenInUseUsageDescription": "A program running inside Maestro wants to use your location.",
+				"NSDesktopFolderUsageDescription": "A program running inside Maestro wants to read and change files on your Desktop.",
+				"NSDocumentsFolderUsageDescription": "A program running inside Maestro wants to read and change files in your Documents folder.",
+				"NSDownloadsFolderUsageDescription": "A program running inside Maestro wants to read and change files in your Downloads folder.",
+				"NSRemovableVolumesUsageDescription": "A program running inside Maestro wants to read and change files on a removable volume.",
+				"NSNetworkVolumesUsageDescription": "A program running inside Maestro wants to read and change files on a network volume."
 			},
 			"target": [
 				"dmg",


### PR DESCRIPTION
Closes #1523

## The bug

macOS attributes a TCC request to the **responsible process**, which for anything an agent shells out to is Maestro.app at the root of the chain:

```
Maestro.app -> claude -> zsh -> ical
```

A service with no `NS*UsageDescription` string in the bundle plist is an instant denial by design. macOS will not prompt on behalf of a purpose string an app never declared, so the user gets **no consent dialog and no Maestro row in System Settings > Privacy & Security** to switch on. The same command works under kitty, which declares these keys.

There is no user-side workaround worth having: patching the plist locally breaks the code signature and is clobbered on every update.

## What was there before

Only the five keys Electron ships in its default `Info.plist`, all media and Bluetooth:

`NSAudioCaptureUsageDescription`, `NSBluetoothAlwaysUsageDescription`, `NSBluetoothPeripheralUsageDescription`, `NSCameraUsageDescription`, `NSMicrophoneUsageDescription`

Every other TCC-gated service was unreachable.

## The change

Adds `build.mac.extendInfo` to `package.json` with the 15 missing strings: calendars, reminders, contacts, photos, Apple Events, local network, and the Desktop / Documents / Downloads / removable / network volume folders. No entitlement changes: Maestro uses the hardened runtime and is not sandboxed, so the usage string is the only gate.

Three judgement calls worth flagging for review:

- **Phrasing names the real requester.** "A program running inside Maestro wants to access your calendars", following kitty's lead. The tool that triggered the dialog is not Maestro itself, and a string that claims otherwise misleads the person being asked to consent.
- **Calendars and Reminders get the macOS 14+ split keys** (`NSCalendarsFullAccessUsageDescription`, `NSCalendarsWriteOnlyAccessUsageDescription`, `NSRemindersFullAccessUsageDescription`) alongside the legacy ones. A tool built against the newer SDK asks for full access specifically and would be denied exactly as before without them.
- **The five Electron defaults are left untouched.** Their strings ("This app needs access to the camera") have the same misleading framing, but rewording them is a separate call and touching them here risks a behaviour change the issue did not ask for. Happy to fold that in if wanted.

Scope note: `com.apple.security.device.audio-input` is set to `false` in `build/entitlements.mac.plist`, which likely blocks microphone access for child processes independently of the usage string. Left alone deliberately, since it looks intentional and is outside this issue.

## Verification

Packed a real bundle (`electron-builder --dir --mac`) and read the generated plist back:

```
$ /usr/libexec/PlistBuddy -c "Print :NSCalendarsUsageDescription" \
    release/mac-arm64/Maestro.app/Contents/Info.plist
A program running inside Maestro wants to access your calendars.
```

All 20 usage keys (5 Electron defaults + 15 new, no collisions) are present in `Maestro.app/Contents/Info.plist`, and `macPackager` merges `extendInfo` before `signApp`, so the signature covers them.

`npm run docs:verify` passes; prettier clean.

Not verified: that the consent dialog actually appears at runtime, which needs a signed and notarized build on a machine with a TCC-gated CLI installed. Worth confirming on the next RC before this is called done.

## Docs

Adds a "macOS Privacy Permissions" section to `docs/troubleshooting.md` explaining why the prompt names Maestro rather than the tool, and the `tccutil reset` recipe for users whose earlier silent denial got cached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded macOS privacy troubleshooting guidance with additional reset commands, an all-services reset option, and instructions for managing Local Network access.
* **Improvements**
  * Added macOS privacy usage descriptions for calendars, reminders, contacts, photos, media library, Apple Events, speech recognition, local network, and location access.
  * Clarified that access requests for desktop, documents, downloads, removable volumes, and network volumes may include the ability to read and modify files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->