### PR TITLE
fix: suppress unconfirmed remote tab rename failures

### DIFF
--- a/src/__tests__/main/web-server/callbacks/tabCallbacks.test.ts
+++ b/src/__tests__/main/web-server/callbacks/tabCallbacks.test.ts
@@ -205,6 +205,7 @@ describe('tab callbacks', () => {
 			await expect(unanswered).resolves.toEqual({
 				success: false,
 				error: 'The desktop did not confirm the rename; it may still be applying',
+				unconfirmed: true,
 			});
 			expect(ipcMain.removeListener).toHaveBeenCalled();
 

--- a/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
@@ -1016,6 +1016,28 @@ describe('WebSocketMessageHandler', () => {
 			expect(response.error).toBe('Tab not found: tab-1');
 		});
 
+		it('should not report a definitive rename result while desktop confirmation is unknown', async () => {
+			vi.mocked(callbacks.renameTab).mockResolvedValueOnce({
+				success: false,
+				error: 'The desktop did not confirm the rename; it may still be applying',
+				unconfirmed: true,
+			});
+
+			handler.handleMessage(client, {
+				type: 'rename_tab',
+				sessionId: 'session-1',
+				tabId: 'tab-1',
+				newName: 'Slow Name',
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.renameTab).toHaveBeenCalledWith('session-1', 'tab-1', 'Slow Name');
+			});
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(client.socket.send).not.toHaveBeenCalled();
+		});
+
 		it('should return explicit failure when desktop rename throws', async () => {
 			vi.mocked(callbacks.renameTab).mockRejectedValueOnce(new Error('disk full'));
 

--- a/src/main/web-server/callbacks/tabCallbacks.ts
+++ b/src/main/web-server/callbacks/tabCallbacks.ts
@@ -214,6 +214,7 @@ export function registerTabCallbacks(
 					settle({
 						success: false,
 						error: 'The desktop did not confirm the rename; it may still be applying',
+						unconfirmed: true,
 					});
 				}, RENAME_CONFIRMATION_RELEASE_MS);
 			});

--- a/src/main/web-server/handlers/messageHandlers/tabs.ts
+++ b/src/main/web-server/handlers/messageHandlers/tabs.ts
@@ -171,6 +171,7 @@ export function handleRenameTab(
 		.renameTab(sessionId, tabId, newName || '')
 		.then((result) => {
 			const renameResult = normalizeRenameTabResult(result);
+			if (renameResult.unconfirmed) return;
 			ctx.send(client, {
 				type: 'rename_tab_result',
 				success: renameResult.success,

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -329,15 +329,17 @@ export type CloseTabCallback = (sessionId: string, tabId: string) => Promise<boo
 export interface RenameTabResult {
 	success: boolean;
 	error?: string;
+	unconfirmed?: boolean;
 }
 
 export function normalizeRenameTabResult(result: unknown): RenameTabResult {
 	if (typeof result === 'boolean') return { success: result };
 	if (result && typeof result === 'object' && 'success' in result) {
-		const candidate = result as { success?: unknown; error?: unknown };
+		const candidate = result as { success?: unknown; error?: unknown; unconfirmed?: unknown };
 		return {
 			success: candidate.success === true,
 			...(typeof candidate.error === 'string' ? { error: candidate.error } : {}),
+			...(candidate.unconfirmed === true ? { unconfirmed: true } : {}),
 		};
 	}
 	return { success: false, error: 'Invalid rename tab response' };


### PR DESCRIPTION
## Summary
- Follow-up to PR #1521/#1522 for remote tab rename confirmation semantics.
- Prevent the server from sending a definitive rename_tab_result failure when the desktop confirmation is only unconfirmed after the internal release timer.
- Keep bounded queue cleanup while avoiding a false Remote/Desktop contradiction if the renderer finishes later.

## Validation
- npm run test -- src/__tests__/main/web-server/callbacks/tabCallbacks.test.ts src/__tests__/main/web-server/handlers/messageHandlers.test.ts
- RUN_INTEGRATION_TESTS=true npx vitest run --config vitest.integration.config.ts src/__tests__/integration/remote-tab-rename.integration.test.ts
- npm run lint
- npm run lint:eslint
- bun run validate:push
- npm run build

## Review findings
- Greptile stale rename: already resolved by per-tab rename queue on rc.
- Greptile timeout contradiction: valid remaining gap; fixed here by making release-timeout result internal/unconfirmed instead of a public failure.
- Greptile canonical tab updater: not applicable across the web/main boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab renaming when confirmation is delayed.
  * Prevented an incorrect failure result from being sent before the rename is confirmed.
  * Delayed the rename response when confirmation is unavailable, allowing the operation to remain unresolved rather than reporting a definitive failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->