### PR TITLE
fix(persistence): preserve agents from stale snapshots

### DIFF
--- a/docs/agent-guides/WEB-MOBILE.md
+++ b/docs/agent-guides/WEB-MOBILE.md
@@ -92,10 +92,13 @@ Two rules follow, and both are load-bearing:
   tab can be away for hours and no agent id is ever reused, so an old tombstone
   has nothing left to block but a stale write. A client away long enough to
   outlive its tombstone reloads on reconnect regardless: `BridgeClient` has no
-  replay, so it re-reads the store rather than flushing what it still held. Only ADDITIONS travel from `setAll`: that path is a client's opening
-  snapshot of its own tree, taken before it could have heard about anything a
-  peer created, so treating an absent id there as a close would delete live
-  agents. The delta is deliberately lifecycle-only - tab contents, read-state and
+  replay, so it re-reads the store rather than flushing what it still held.
+  `setAll` merges its opening snapshot into the stored tree and only broadcasts
+  additions: the client may not have heard about agents a peer created, so an
+  absent id is preserved rather than treated as a close. Real closes arrive as
+  explicit `removeIds` through `setMany`. Both handlers share one main-process
+  write queue, so a final-agent backup cannot overlap a peer addition and later
+  overwrite it. The delta is deliberately lifecycle-only - tab contents, read-state and
   queued messages are still last-writer-wins.
 - **Which agent a client is looking at is per-client.** Write and read it through
   `src/renderer/utils/activeSessionPersistence.ts`, never

--- a/src/__tests__/main/ipc/handlers/persistence.test.ts
+++ b/src/__tests__/main/ipc/handlers/persistence.test.ts
@@ -18,6 +18,7 @@ import {
 	GroupsData,
 } from '../../../../main/ipc/handlers/persistence';
 import type Store from 'electron-store';
+import type { StoredSession } from '../../../../main/stores/types';
 import type { WebServer } from '../../../../main/web-server';
 import { broadcastBridgeEvent } from '../../../../main/web-server/handlers/bridgeHandlers';
 
@@ -62,6 +63,13 @@ vi.mock('../../../../main/web-server/handlers/bridgeHandlers', () => ({
 	broadcastBridgeEvent: vi.fn(),
 }));
 
+const { backupSessionsBeforeWipeMock } = vi.hoisted(() => ({
+	backupSessionsBeforeWipeMock: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../../../main/stores/sessions-backup', () => ({
+	backupSessionsBeforeWipe: backupSessionsBeforeWipeMock,
+}));
+
 // Mock the themes module
 vi.mock('../../../../main/themes', () => ({
 	getThemeById: vi.fn().mockReturnValue({
@@ -81,6 +89,7 @@ describe('persistence IPC handlers', () => {
 	let mockSessionsStore: {
 		get: ReturnType<typeof vi.fn>;
 		set: ReturnType<typeof vi.fn>;
+		path: string;
 	};
 	let mockGroupsStore: {
 		get: ReturnType<typeof vi.fn>;
@@ -113,6 +122,7 @@ describe('persistence IPC handlers', () => {
 		mockSessionsStore = {
 			get: vi.fn().mockReturnValue([]),
 			set: vi.fn(),
+			path: '/mock/maestro-sessions.json',
 		};
 
 		mockGroupsStore = {
@@ -729,7 +739,7 @@ describe('persistence IPC handlers', () => {
 			});
 		});
 
-		it('should detect removed sessions and broadcast to web clients', async () => {
+		it('should preserve stored sessions omitted from a bootstrap snapshot', async () => {
 			mockWebServer.getWebClientCount.mockReturnValue(2);
 			const previousSessions = [
 				{
@@ -746,7 +756,8 @@ describe('persistence IPC handlers', () => {
 			const handler = handlers.get('sessions:setAll');
 			await handler!({} as any, []);
 
-			expect(mockWebServer.broadcastSessionRemoved).toHaveBeenCalledWith('session-1');
+			expect(mockSessionsStore.set).toHaveBeenCalledWith('sessions', previousSessions);
+			expect(mockWebServer.broadcastSessionRemoved).not.toHaveBeenCalled();
 		});
 
 		it('should detect state changes and broadcast to web clients', async () => {
@@ -1038,7 +1049,6 @@ describe('persistence IPC handlers', () => {
 					inputMode: 'ai',
 					toolType: 'claude-code',
 				}, // state changed
-				// session-2 removed
 				{
 					id: 'session-3',
 					name: 'Session 3',
@@ -1057,10 +1067,15 @@ describe('persistence IPC handlers', () => {
 				'busy',
 				expect.any(Object)
 			);
-			expect(mockWebServer.broadcastSessionRemoved).toHaveBeenCalledWith('session-2');
+			expect(mockWebServer.broadcastSessionRemoved).not.toHaveBeenCalled();
 			expect(mockWebServer.broadcastSessionAdded).toHaveBeenCalledWith(
 				expect.objectContaining({ id: 'session-3' })
 			);
+			expect(mockSessionsStore.set).toHaveBeenCalledWith('sessions', [
+				newSessions[0],
+				newSessions[1],
+				previousSessions[1],
+			]);
 		});
 
 		it('should return false on ENOSPC write error', async () => {
@@ -1164,6 +1179,51 @@ describe('persistence IPC handlers', () => {
 
 			const merged = mockSessionsStore.set.mock.calls[0][1];
 			expect(merged.map((s: any) => s.id)).toEqual(['s2']);
+		});
+
+		it('backs up before explicit removals empty the registry', async () => {
+			const stored = [{ ...baseSession }];
+			mockSessionsStore.get.mockReturnValue(stored);
+
+			await handlers.get('sessions:setMany')!({} as any, [], ['s1']);
+
+			expect(backupSessionsBeforeWipeMock).toHaveBeenCalledWith(
+				stored,
+				[],
+				'/mock/maestro-sessions.json'
+			);
+			expect(mockSessionsStore.set).toHaveBeenCalledWith('sessions', []);
+		});
+
+		it('serializes additions behind a final-agent backup', async () => {
+			let stored = [{ ...baseSession }];
+			mockSessionsStore.get.mockImplementation((key: string, fallback: unknown) =>
+				key === 'sessions' ? stored : fallback
+			);
+			mockSessionsStore.set.mockImplementation((key: string, value: StoredSession[]) => {
+				if (key === 'sessions') stored = value;
+			});
+			let releaseBackup: (() => void) | undefined;
+			backupSessionsBeforeWipeMock.mockImplementationOnce(
+				() =>
+					new Promise<void>((resolve) => {
+						releaseBackup = resolve;
+					})
+			);
+
+			const removal = handlers.get('sessions:setMany')!({} as any, [], ['s1']);
+			await vi.waitFor(() => expect(backupSessionsBeforeWipeMock).toHaveBeenCalled());
+
+			const addition = handlers.get('sessions:setAll')!({} as any, [
+				{ ...baseSession, id: 'created-concurrently' },
+			]);
+			await Promise.resolve();
+			expect(mockSessionsStore.set).not.toHaveBeenCalled();
+
+			releaseBackup?.();
+			await Promise.all([removal, addition]);
+
+			expect(stored.map((session) => session.id)).toEqual(['created-concurrently']);
 		});
 
 		it('handles mixed updates and removes in one call', async () => {
@@ -1501,7 +1561,7 @@ describe('persistence IPC handlers', () => {
 			expect(merged.map((sess: any) => sess.id)).toEqual(['other', 's1']);
 		});
 
-		it("never reports a removal from setAll, which is one client's opening snapshot", async () => {
+		it("preserves agents omitted from one client's opening snapshot", async () => {
 			// A client that loaded before a peer created an agent has no idea it
 			// exists; treating its absence as a close would delete a live agent.
 			mockSessionsStore.get.mockReturnValue([
@@ -1511,6 +1571,8 @@ describe('persistence IPC handlers', () => {
 
 			await handlers.get('sessions:setAll')!({} as any, [{ ...baseSession, id: 's1' }]);
 
+			const persisted = mockSessionsStore.set.mock.calls.at(-1)![1];
+			expect(persisted.map((session: any) => session.id)).toEqual(['s1', 'created-elsewhere']);
 			expect(lastBridgePayload()).toBeNull();
 		});
 

--- a/src/__tests__/main/stores/sessions-backup.test.ts
+++ b/src/__tests__/main/stores/sessions-backup.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'node:path';
 
 vi.mock('../../../main/utils/logger', () => ({
 	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
@@ -40,7 +41,7 @@ describe('backupSessionsBeforeWipe', () => {
 
 		expect(mockWrite).toHaveBeenCalledTimes(1);
 		const [writtenPath, payload] = mockWrite.mock.calls[0];
-		expect(writtenPath).toBe(`/tmp/maestro-test/${SESSIONS_BACKUP_FILENAME}`);
+		expect(writtenPath).toBe(path.join(path.dirname(STORE_PATH), SESSIONS_BACKUP_FILENAME));
 		expect((payload as { entries: StoredSession[] }).entries).toEqual(stored);
 	});
 

--- a/src/__tests__/renderer/hooks/utils/useDebouncedPersistence.test.ts
+++ b/src/__tests__/renderer/hooks/utils/useDebouncedPersistence.test.ts
@@ -1395,15 +1395,16 @@ describe('useDebouncedPersistence', () => {
 				expect(window.maestro.sessions.setAll).not.toHaveBeenCalled();
 			});
 
-			it('should persist after initialLoadComplete becomes true', () => {
+			it('should use the loaded tree as the first incremental baseline', () => {
 				const session = makeSession();
+				const secondSession = makeSession({ id: 'second-session' });
 				const initialLoadRef = makeInitialLoadRef(false);
 
 				renderPersistence(initialLoadRef);
 
 				// Session change while load incomplete must not persist
 				act(() => {
-					seedSessions([session]);
+					seedSessions([session, secondSession]);
 				});
 				act(() => {
 					vi.advanceTimersByTime(3000);
@@ -1412,7 +1413,7 @@ describe('useDebouncedPersistence', () => {
 
 				// Mark initial load complete, then mutate sessions to schedule persist
 				initialLoadRef.current = true;
-				const updatedSession = makeSession({ id: session.id, name: 'Updated' });
+				const updatedSession = { ...session, name: 'Updated' };
 				act(() => {
 					seedSessions([updatedSession]);
 				});
@@ -1421,7 +1422,65 @@ describe('useDebouncedPersistence', () => {
 					vi.advanceTimersByTime(2000);
 				});
 
-				expect(window.maestro.sessions.setAll).toHaveBeenCalled();
+				expect(window.maestro.sessions.setAll).not.toHaveBeenCalled();
+				expect(window.maestro.sessions.setMany).toHaveBeenCalledWith(
+					[expect.objectContaining({ id: session.id, name: 'Updated' })],
+					['second-session']
+				);
+			});
+
+			it('should persist untouched startup repairs on the first flush', () => {
+				const first = makeSession({ id: 'first', name: 'Stored First' });
+				const second = makeSession({ id: 'second', name: 'Stored Second' });
+				const initialLoadRef = makeInitialLoadRef(false);
+
+				renderPersistence(initialLoadRef);
+				act(() => {
+					seedSessions([first, second]);
+				});
+
+				const repairedFirst = { ...first, name: 'Repaired First' };
+				const repairedSecond = { ...second, name: 'Repaired Second' };
+				act(() => {
+					seedSessions([repairedFirst, repairedSecond]);
+				});
+
+				initialLoadRef.current = true;
+				const updatedFirst = { ...repairedFirst, state: 'busy' as const };
+				act(() => {
+					seedSessions([updatedFirst, repairedSecond]);
+				});
+				act(() => {
+					vi.advanceTimersByTime(2000);
+				});
+
+				expect(window.maestro.sessions.setMany).toHaveBeenCalledWith(
+					[
+						expect.objectContaining({ id: 'first', name: 'Repaired First' }),
+						expect.objectContaining({ id: 'second', name: 'Repaired Second' }),
+					],
+					[]
+				);
+			});
+
+			it('should preserve a deletion when the loaded tree predates the subscription', () => {
+				const first = makeSession({ id: 'first' });
+				const second = makeSession({ id: 'second' });
+				seedSessions([first, second]);
+
+				renderPersistence(makeInitialLoadRef(true));
+				act(() => {
+					seedSessions([first]);
+				});
+				act(() => {
+					vi.advanceTimersByTime(2000);
+				});
+
+				expect(window.maestro.sessions.setAll).not.toHaveBeenCalled();
+				expect(window.maestro.sessions.setMany).toHaveBeenCalledWith(
+					[expect.objectContaining({ id: 'first' })],
+					['second']
+				);
 			});
 		});
 

--- a/src/main/ipc/handlers/persistence.ts
+++ b/src/main/ipc/handlers/persistence.ts
@@ -33,6 +33,7 @@ import { buildSessionLifecycleEvents } from './plugin-session-events';
 import { relocateSessionImages, resolveToDataUrl } from '../../storage/session-image-store';
 import { backupGroupsBeforeWipe } from '../../stores/groups-backup';
 import { backupSessionsBeforeWipe } from '../../stores/sessions-backup';
+import { createKeyedWriteQueue } from '../../utils/atomic-json-store';
 
 /**
  * Shallow-compare cliActivity for the diff broadcast.
@@ -204,6 +205,11 @@ export function registerPersistenceHandlers(
 		emitPluginEvent,
 		flushSessionWrites,
 	} = deps;
+	const sessionWriteQueue = createKeyedWriteQueue();
+	const queueWrite =
+		<TArgs extends unknown[], TResult>(handler: (...args: TArgs) => Promise<TResult>) =>
+		(...args: TArgs): Promise<TResult> =>
+			sessionWriteQueue.enqueue('sessions', () => handler(...args));
 
 	// Ids closed by a client, newest last. Read by every write path to refuse a
 	// stale peer flush that would resurrect a closed agent (see
@@ -492,15 +498,15 @@ export function registerPersistenceHandlers(
 	 *    session in both lists is removed (remove wins).
 	 *  - Sessions not mentioned in either list are preserved as-is.
 	 *  - Broadcasts to web clients fire only for the touched sessions
-	 *    (added / state-changed / removed), matching `setAll` semantics.
+	 *    (added / state-changed / explicitly removed).
 	 */
 	ipcMain.handle(
 		'sessions:setMany',
-		async (ipcEvent, rawUpdates: StoredSession[] = [], removeIds: string[] = []) => {
+		queueWrite(async (event, input: StoredSession[] = [], removeIds: string[] = []) => {
 			// Relocate any freshly-pasted inline images (data URLs) in the dirty
 			// sessions to the image store before they hit disk, so the sessions
 			// JSON only ever grows by lightweight refs.
-			const { sessions: relocatedUpdates } = await relocateSessionImages(rawUpdates);
+			const { sessions: relocatedUpdates } = await relocateSessionImages(input);
 			const previousSessions = sessionsStore.get('sessions', []);
 			const previousMap = new Map(previousSessions.map((s) => [s.id, s]));
 			// Drop any agent this write would resurrect: another client closed it
@@ -594,6 +600,7 @@ export function registerPersistenceHandlers(
 			}
 
 			try {
+				await backupSessionsBeforeWipe(previousSessions, merged, sessionsStore.path);
 				sessionsStore.set('sessions', merged);
 				// Preserve the renderer acknowledgement contract: true means this
 				// revision reached disk, not merely the in-memory cache.
@@ -624,7 +631,7 @@ export function registerPersistenceHandlers(
 			// invisible to - and resurrectable by - the rest.
 			const removedIds = removeIds.filter((id) => previousMap.has(id));
 			rememberRemovedSessions(removedIds);
-			broadcastSessionLifecycle(senderWebContentsIdOf(ipcEvent), {
+			broadcastSessionLifecycle(senderWebContentsIdOf(event), {
 				added: updates.filter((s) => !previousMap.has(s.id) && !removeSet.has(s.id)),
 				removedIds,
 			});
@@ -639,137 +646,122 @@ export function registerPersistenceHandlers(
 			}
 
 			return true;
-		}
+		})
 	);
 
-	ipcMain.handle('sessions:setAll', async (ipcEvent, rawSessions: StoredSession[]) => {
-		// Relocate inline images (data URLs) out of the sessions before they hit
-		// disk. setAll is the bootstrap/first-flush path, so this also migrates a
-		// legacy in-memory sessions tree the first time it is persisted.
-		const { sessions: relocatedSessions } = await relocateSessionImages(rawSessions);
-		// Get previous sessions to detect changes
-		const previousSessions = sessionsStore.get('sessions', []);
-		const previousSessionMap = new Map(previousSessions.map((s) => [s.id, s]));
-		// Same resurrection guard as setMany: a client that loaded before another
-		// closed an agent still carries it, and this path would write it back.
-		const sessions = dropResurrections(relocatedSessions, new Set(previousSessionMap.keys()));
-		const currentSessionMap = new Map(sessions.map((s) => [s.id, s]));
-
-		// Log session lifecycle events at DEBUG level
-		for (const session of sessions) {
-			const prevSession = previousSessionMap.get(session.id);
-			if (!prevSession) {
-				// New session created
-				logger.debug('Session created', 'Sessions', {
-					sessionId: session.id,
-					name: session.name,
-					toolType: session.toolType,
-					cwd: session.cwd,
-				});
+	ipcMain.handle(
+		'sessions:setAll',
+		queueWrite(async (event, input: StoredSession[]) => {
+			// Relocate inline images (data URLs) out of the sessions before they hit
+			// disk. setAll is the bootstrap/first-flush path, so this also migrates a
+			// legacy in-memory sessions tree the first time it is persisted.
+			const { sessions: relocatedSessions } = await relocateSessionImages(input);
+			// Get previous sessions to detect changes
+			const previousSessions = sessionsStore.get('sessions', []);
+			const previousSessionMap = new Map(previousSessions.map((s) => [s.id, s]));
+			// Same resurrection guard as setMany: a client that loaded before another
+			// closed an agent still carries it, and this path would write it back.
+			const sessions = dropResurrections(relocatedSessions, new Set(previousSessionMap.keys()));
+			const incomingIds = new Set(sessions.map((s) => s.id));
+			// setAll is a client's opening snapshot, so an omitted id means the client
+			// never saw that agent. Only setMany's explicit removeIds may delete one.
+			for (const previousSession of previousSessions) {
+				if (!incomingIds.has(previousSession.id)) {
+					sessions.push(previousSession);
+				}
 			}
-		}
-		for (const prevSession of previousSessions) {
-			if (!currentSessionMap.has(prevSession.id)) {
-				// Session destroyed
-				logger.debug('Session destroyed', 'Sessions', {
-					sessionId: prevSession.id,
-					name: prevSession.name,
-				});
-			}
-		}
 
-		const webServer = getWebServer();
-		// Detect and broadcast changes to web clients
-		if (webServer && webServer.getWebClientCount() > 0) {
-			// Check for state changes in existing sessions
+			// Log session lifecycle events at DEBUG level
 			for (const session of sessions) {
 				const prevSession = previousSessionMap.get(session.id);
-				if (prevSession) {
-					// Session exists - check if state or other tracked properties changed
-					if (
-						prevSession.state !== session.state ||
-						prevSession.inputMode !== session.inputMode ||
-						prevSession.name !== session.name ||
-						prevSession.cwd !== session.cwd ||
-						cliActivityChanged(prevSession.cliActivity, session.cliActivity)
-					) {
-						webServer.broadcastSessionStateChange(session.id, session.state, {
-							name: session.name,
-							toolType: session.toolType,
-							inputMode: session.inputMode,
-							cwd: session.cwd,
-							cliActivity: session.cliActivity,
-						});
-					}
-				} else {
-					// New session added
-					webServer.broadcastSessionAdded({
-						id: session.id,
+				if (!prevSession) {
+					// New session created
+					logger.debug('Session created', 'Sessions', {
+						sessionId: session.id,
 						name: session.name,
 						toolType: session.toolType,
-						state: session.state,
-						inputMode: session.inputMode,
 						cwd: session.cwd,
-						groupId: session.groupId || null,
-						groupName: session.groupName || null,
-						groupEmoji: session.groupEmoji || null,
-						parentSessionId: session.parentSessionId || null,
-						worktreeBranch: session.worktreeBranch || null,
-						autoRunFolderPath: session.autoRunFolderPath || null,
 					});
 				}
 			}
-
-			// Check for removed sessions
-			for (const prevSession of previousSessions) {
-				if (!currentSessionMap.has(prevSession.id)) {
-					webServer.broadcastSessionRemoved(prevSession.id);
+			const webServer = getWebServer();
+			// Detect and broadcast changes to web clients
+			if (webServer && webServer.getWebClientCount() > 0) {
+				// Check for state changes in existing sessions
+				for (const session of sessions) {
+					const prevSession = previousSessionMap.get(session.id);
+					if (prevSession) {
+						// Session exists - check if state or other tracked properties changed
+						if (
+							prevSession.state !== session.state ||
+							prevSession.inputMode !== session.inputMode ||
+							prevSession.name !== session.name ||
+							prevSession.cwd !== session.cwd ||
+							cliActivityChanged(prevSession.cliActivity, session.cliActivity)
+						) {
+							webServer.broadcastSessionStateChange(session.id, session.state, {
+								name: session.name,
+								toolType: session.toolType,
+								inputMode: session.inputMode,
+								cwd: session.cwd,
+								cliActivity: session.cliActivity,
+							});
+						}
+					} else {
+						// New session added
+						webServer.broadcastSessionAdded({
+							id: session.id,
+							name: session.name,
+							toolType: session.toolType,
+							state: session.state,
+							inputMode: session.inputMode,
+							cwd: session.cwd,
+							groupId: session.groupId || null,
+							groupName: session.groupName || null,
+							groupEmoji: session.groupEmoji || null,
+							parentSessionId: session.parentSessionId || null,
+							worktreeBranch: session.worktreeBranch || null,
+							autoRunFolderPath: session.autoRunFolderPath || null,
+						});
+					}
 				}
 			}
-		}
 
-		try {
-			// Keep a copy before an empty tree replaces a populated one. setAll is
-			// the bootstrap flush, which is exactly the path a bad read feeds:
-			// sessions:getAll answers [] for an unmounted sync folder, and the
-			// renderer's first flush would write that back over every agent.
-			// The renderer refuses that write when its read failed (see
-			// useDebouncedPersistence), but the CLI and the web bridge reach
-			// this handler too, so the copy is taken here as well.
-			await backupSessionsBeforeWipe(previousSessions, sessions, sessionsStore.path);
-			sessionsStore.set('sessions', sessions);
-			await flushSessionWrites();
-		} catch (err) {
-			// ENOSPC, ENFILE, or JSON serialization failures are recoverable -
-			// the next debounced write will succeed when conditions improve.
-			// Log but don't throw so the renderer doesn't see an unhandled rejection.
-			const code = (err as NodeJS.ErrnoException).code;
-			logger.warn(`Failed to persist sessions: ${code || (err as Error).message}`, 'Sessions');
-			return false;
-		}
-
-		// Tell the other clients about agents this bootstrap flush introduced.
-		// Only ADDITIONS travel from here: setAll is a client's opening statement
-		// of its own tree, made before it can have heard about anything a peer
-		// created since it loaded, so treating an absent id as a close would let
-		// one client's stale snapshot delete another's live agents. Real closes
-		// arrive as explicit `removeIds` through setMany.
-		broadcastSessionLifecycle(senderWebContentsIdOf(ipcEvent), {
-			added: sessions.filter((s) => !previousSessionMap.has(s.id)),
-			removedIds: [],
-		});
-
-		// Surface metadata-only lifecycle events to subscribed plugins
-		// (events:subscribe). Re-authorized per delivery against live grants.
-		if (emitPluginEvent) {
-			const at = new Date().toISOString();
-			for (const event of buildSessionLifecycleEvents(previousSessionMap, sessions, at)) {
-				emitPluginEvent(event);
+			try {
+				sessionsStore.set('sessions', sessions);
+				await flushSessionWrites();
+			} catch (err) {
+				// ENOSPC, ENFILE, or JSON serialization failures are recoverable -
+				// the next debounced write will succeed when conditions improve.
+				// Log but don't throw so the renderer doesn't see an unhandled rejection.
+				const code = (err as NodeJS.ErrnoException).code;
+				logger.warn(`Failed to persist sessions: ${code || (err as Error).message}`, 'Sessions');
+				return false;
 			}
-		}
 
-		return true;
-	});
+			// Tell the other clients about agents this bootstrap flush introduced.
+			// Only ADDITIONS travel from here: setAll is a client's opening statement
+			// of its own tree, made before it can have heard about anything a peer
+			// created since it loaded, so treating an absent id as a close would let
+			// one client's stale snapshot delete another's live agents. Real closes
+			// arrive as explicit `removeIds` through setMany.
+			broadcastSessionLifecycle(senderWebContentsIdOf(event), {
+				added: sessions.filter((s) => !previousSessionMap.has(s.id)),
+				removedIds: [],
+			});
+
+			// Surface metadata-only lifecycle events to subscribed plugins
+			// (events:subscribe). Re-authorized per delivery against live grants.
+			if (emitPluginEvent) {
+				const at = new Date().toISOString();
+				for (const event of buildSessionLifecycleEvents(previousSessionMap, sessions, at)) {
+					emitPluginEvent(event);
+				}
+			}
+
+			return true;
+		})
+	);
 
 	// Groups persistence
 	ipcMain.handle('groups:getAll', async () => {

--- a/src/renderer/hooks/utils/useDebouncedPersistence.ts
+++ b/src/renderer/hooks/utils/useDebouncedPersistence.ts
@@ -6,16 +6,17 @@
  * This hook batches those changes and writes at most once every 2 seconds.
  *
  * Persistence path (after PR-A 1.1):
- *  - First flush after load: ship the entire prepared sessions array via
- *    `sessions:setAll`. This seeds the main process and establishes a
- *    diff baseline (`previouslyPersistedRef`).
- *  - Subsequent flushes: diff `sessionsRef.current` against the baseline
+ *  - During a successful initial load: capture the loaded sessions array as
+ *    the diff baseline (`previouslyPersistedRef`).
+ *  - Subsequent flushes: diff `sessionsRef.current` against that baseline
  *    using reference equality per session, then ship only the changed
  *    sessions plus the ids of any removed sessions via
  *    `sessions:setMany`. With Zustand's immutable update pattern, every
  *    mutated session gets a fresh object reference - so the diff catches
  *    every real change in O(N) without needing per-mutator dirty
  *    tracking.
+ *  - `sessions:setAll` remains a fallback if the hook did not observe the
+ *    initial load, such as after a development remount.
  *
  * Why diff in the hook rather than tracking dirty IDs in the store: the
  * 200+ existing `setSessions((prev) => prev.map(...))` call sites use
@@ -391,11 +392,19 @@ export function useDebouncedPersistence(
 	const flushingRef = useRef(false);
 
 	// Snapshot of the sessions array as it existed at the previous flush.
-	// Starts null - the first flush after load uses setAll to seed the main
-	// process and captures the snapshot. Every subsequent flush diffs the
-	// current sessions array against this snapshot and ships only the
-	// changed subset via setMany.
+	// Captured from the successful initial load. If this hook did not observe
+	// that load, the first flush establishes the baseline instead.
+	// The first observed startup flush makes restored repairs durable, then every
+	// later flush ships only the changed subset via setMany.
 	const previouslyPersistedRef = useRef<Session[] | null>(null);
+	// If loading finished before the subscription mounted, retain that tree only
+	// long enough to express a first-flush deletion through setMany.
+	const mountedSessionsRef = useRef<Session[] | null>(
+		useSessionStore.getState().sessionsReadOk ? sessionsRef.current : null
+	);
+	// Restoring a session repairs its in-memory shape. Those repaired objects are
+	// not durable yet, so the first incremental flush must include the whole tree.
+	const startupBaselineNeedsFullFlushRef = useRef(false);
 
 	/**
 	 * Run one persistence pass. Throws on failure so callers can decide
@@ -404,11 +413,12 @@ export function useDebouncedPersistence(
 	 * leaving beforeunload with no signal to attempt one more retry before
 	 * the window closes.
 	 *
-	 * - First call after load: ships everything via setAll. Baseline is
-	 *   captured ONLY if setAll resolves truthy.
-	 * - Subsequent calls: diffs against the baseline; ships only the
-	 *   changed subset via setMany. Baseline advances ONLY if the IPC
-	 *   resolves truthy.
+	 * - With a startup baseline: the first flush ships the restored tree so
+	 *   startup repairs become durable, then later flushes ship only the changed
+	 *   subset via setMany. Baseline advances ONLY if the IPC resolves truthy.
+	 * - Without a baseline: uses explicit tombstones when a mounted session was
+	 *   removed, otherwise falls back to setAll. Captures the current tree ONLY
+	 *   if the IPC resolves truthy.
 	 * - On rejection or `ok === false`: leave previouslyPersistedRef
 	 *   untouched (so the next diff retries the still-dirty sessions) and
 	 *   throw - caller decides whether to surface and how to handle.
@@ -433,26 +443,36 @@ export function useDebouncedPersistence(
 		const current = sessionsRef.current;
 		if (previouslyPersistedRef.current === null) {
 			const sessionsForPersistence = current.map(prepareSessionForPersistence);
-			const ok = await window.maestro.sessions.setAll(sessionsForPersistence);
+			const tombstones = mountedSessionsRef.current
+				? diffSessions(mountedSessionsRef.current, current).tombstones
+				: [];
+			const ok =
+				tombstones.length > 0
+					? await window.maestro.sessions.setMany(sessionsForPersistence, tombstones)
+					: await window.maestro.sessions.setAll(sessionsForPersistence);
 			if (ok === false) {
-				throw new Error('sessions:setAll returned false (recoverable disk error)');
+				throw new Error('Session persistence returned false (recoverable disk error)');
 			}
 			previouslyPersistedRef.current = current;
+			startupBaselineNeedsFullFlushRef.current = false;
 			return;
 		}
 		const { dirty, tombstones } = diffSessions(previouslyPersistedRef.current, current);
-		if (dirty.length === 0 && tombstones.length === 0) {
+		const sessionsToPersist = startupBaselineNeedsFullFlushRef.current ? current : dirty;
+		if (sessionsToPersist.length === 0 && tombstones.length === 0) {
 			// Nothing changed - safe to advance the baseline (it would be
 			// identical anyway).
 			previouslyPersistedRef.current = current;
+			startupBaselineNeedsFullFlushRef.current = false;
 			return;
 		}
-		const dirtyForPersistence = dirty.map(prepareSessionForPersistence);
+		const dirtyForPersistence = sessionsToPersist.map(prepareSessionForPersistence);
 		const ok = await window.maestro.sessions.setMany(dirtyForPersistence, tombstones);
 		if (ok === false) {
 			throw new Error('sessions:setMany returned false (recoverable disk error)');
 		}
 		previouslyPersistedRef.current = current;
+		startupBaselineNeedsFullFlushRef.current = false;
 	}, []);
 
 	/**
@@ -563,6 +583,15 @@ export function useDebouncedPersistence(
 		const unsubscribe = useSessionStore.subscribe((state, prevState) => {
 			if (state.sessions === prevState.sessions) return;
 			sessionsRef.current = state.sessions;
+			if (
+				!initialLoadComplete.current &&
+				state.sessionsReadOk &&
+				previouslyPersistedRef.current === null
+			) {
+				previouslyPersistedRef.current = state.sessions;
+				startupBaselineNeedsFullFlushRef.current = true;
+				return;
+			}
 			schedulePersist();
 		});
 


### PR DESCRIPTION
## What

- Make `sessions:setAll` merge a client bootstrap snapshot into the stored agent registry instead of treating omitted agent IDs as deletions.
- Capture the successfully loaded session tree as the renderer persistence baseline, so later closes use explicit `removeIds` through `sessions:setMany`.
- Preserve first-flush deletions when the initial load completed before the persistence subscription mounted.
- Serialize `sessions:setAll` and `sessions:setMany` through the existing keyed write queue so an awaited final-agent backup cannot overwrite a concurrent addition.
- Move the pre-wipe backup guard to the explicit removal path, where a legitimate last-agent close can empty the registry.
- Make the backup-path assertion use Node path utilities so the existing backup test is portable on Windows.
- Update the web-desktop lifecycle contract documentation and add regression coverage at the renderer and main IPC layers.

## Why

Each Maestro client owns an in-memory copy of the shared agent tree. A web-desktop tab can load before another client creates agents, then later flush its incomplete snapshot. `sessions:setAll` previously interpreted every missing ID as a deletion and replaced the on-disk registry, so one stale client could remove agents it had never seen.

A bootstrap snapshot cannot distinguish unseen agents from intentionally closed agents. This change makes deletion explicit: only `sessions:setMany(..., removeIds)` removes agents. Session writes are serialized across the backup and write boundary so concurrent clients cannot reintroduce a lost update.

## How to test

1. Start two Maestro clients against the same agent registry.
2. Let client A load its snapshot.
3. Create an agent from client B.
4. Trigger a session persistence flush from client A.
5. Confirm the agent created by client B remains in memory and on disk.
6. Close an agent from either client and confirm the explicit `removeIds` path removes it and notifies peers.
7. Close the final agent while another client adds one, and confirm the addition survives the pre-wipe backup.
8. Mount persistence after a populated load, delete an agent before the first flush, and confirm the deletion is sent through `setMany`.
9. Confirm startup repairs for untouched agents reach disk on the first incremental flush.

## Validation

- `npm run format:check:all`
- `npm run lint`
- `npm run lint:eslint`
- `npm test`: 1,821 files passed, 42,423 tests passed, 110 skipped
- Focused persistence and lifecycle run: 4 files passed, 217 tests passed
- Installed a signed and notarized macOS build, restarted Maestro, and verified a populated agent registry remained intact

## Privacy and scope

- Audited the committed diff for personal names, email addresses, local user paths, IP addresses, credentials, tokens, and private keys. No matches were included.
- Commit author and committer use the authenticated GitHub noreply address.
- Test IDs and the `/mock/maestro-sessions.json` path are synthetic.
- Local Graphify output, screenshots, restored registry data, release artifacts, and backups are not part of this branch.

## Checklist

- [x] Conventional commit used
- [x] Regression tests cover the owning renderer and main-process layers
- [x] Full formatting, type, lint, and test gates pass
- [x] Manual restart behavior verified
- [x] No dependency changes
- [x] No UI screenshots required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session synchronization to preserve sessions omitted from bootstrap snapshots.
  * Explicit session removals are now persisted reliably, including during concurrent updates.
  * Startup repairs and deletions are now retained during incremental persistence.
  * Prevented stale writes from overwriting session additions made by other processes.
  * Added reliable session backups before explicit removal operations.

* **Documentation**
  * Updated session lifecycle synchronization guidance to reflect snapshot merging, explicit removals, and serialized writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->