### PR TITLE
chore(deps): override tar to 7.5.x for node-tar Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1194,16 +1194,6 @@
 				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/@electron/rebuild/node_modules/chownr": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/@electron/rebuild/node_modules/isexe": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
@@ -1212,19 +1202,6 @@
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=20"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/minizlib": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.1.2"
-			},
-			"engines": {
-				"node": ">= 18"
 			}
 		},
 		"node_modules/@electron/rebuild/node_modules/node-abi": {
@@ -1291,23 +1268,6 @@
 				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/@electron/rebuild/node_modules/tar": {
-			"version": "7.5.22",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
-			"integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.1.0",
-				"yallist": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/@electron/rebuild/node_modules/undici": {
 			"version": "6.28.1",
 			"resolved": "https://registry.npmjs.org/undici/-/undici-6.28.1.tgz",
@@ -1332,16 +1292,6 @@
 			},
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/yallist": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/@electron/universal": {
@@ -5489,16 +5439,6 @@
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
-		"node_modules/app-builder-lib/node_modules/chownr": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/app-builder-lib/node_modules/ci-info": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
@@ -5559,36 +5499,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/app-builder-lib/node_modules/minizlib": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.1.2"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/tar": {
-			"version": "7.5.22",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
-			"integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.1.0",
-				"yallist": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/app-builder-lib/node_modules/which": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
@@ -5603,16 +5513,6 @@
 			},
 			"engines": {
 				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/yallist": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/aproba": {
@@ -18241,22 +18141,20 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-			"deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"version": "7.5.22",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+			"integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
+				"@isaacs/fs-minipass": "^4.0.0",
+				"chownr": "^3.0.0",
+				"minipass": "^7.1.2",
+				"minizlib": "^3.1.0",
+				"yallist": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			}
 		},
 		"node_modules/tar-fs": {
@@ -18333,22 +18231,38 @@
 				}
 			}
 		},
-		"node_modules/tar/node_modules/minipass": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+		"node_modules/tar/node_modules/chownr": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
+			}
+		},
+		"node_modules/tar/node_modules/minizlib": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
 			}
 		},
 		"node_modules/tar/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
 			"dev": true,
-			"license": "ISC"
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/teex": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -426,7 +426,8 @@
 		"vitest": "^4.1.5"
 	},
 	"overrides": {
-		"brace-expansion": "^5.0.9"
+		"brace-expansion": "^5.0.9",
+		"tar": "^7.5.17"
 	},
 	"engines": {
 		"node": ">=22.0.0"


### PR DESCRIPTION
## Summary
- Force every `tar` copy on `main` to 7.5.22 via the same npm override `rc` already uses (`^7.5.17`).
- Closes the 8 node-tar Dependabot alerts on the default branch (path traversal, hardlink/symlink overwrite, APFS ligature race, PAX parser issues). Maestro does not import `tar`; it is install and packaging only (`cacache`, `node-gyp`, `electron-rebuild`, `app-builder-lib`).
- Leaves Fastify 4 on `main` on purpose. Fastify 5 already lives on `rc` (#1532) and should wait for the 0.18 release.

## Test plan
- [x] `npm install` / electron-rebuild for `node-pty` and `better-sqlite3`
- [x] `npm ls tar` shows only `7.5.22`
- [x] `npm audit` no longer reports tar (7 remaining are Fastify / vitest / adm-zip)
- [x] Full `npm test`: 36958 passed, 110 skipped
- [x] Local `validate:push` (prettier, lint, eslint, tests) on pre-push
- [x] CI `test (ubuntu-latest)` and `test (windows-latest)`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package resolution to use a specified version of the `tar` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->