### PR TITLE
fix(transcript): hide the embedded system prompt in a hydrated tab

### DIFF
--- a/src/__tests__/renderer/utils/transcriptMessages.test.ts
+++ b/src/__tests__/renderer/utils/transcriptMessages.test.ts
@@ -18,6 +18,7 @@ import {
 	transcriptMessagesToLogEntries,
 	type TranscriptMessage,
 } from '../../../renderer/utils/transcriptMessages';
+import { embedSystemPromptInPrompt } from '../../../shared/embeddedSystemPrompt';
 
 function entry(id: string, text: string, source: LogEntry['source'] = 'user', ts = 0): LogEntry {
 	return { id, text, source, timestamp: ts };
@@ -53,6 +54,57 @@ describe('transcriptMessagesToLogEntries', () => {
 
 		expect(entries.map((e) => e.id)).toEqual(['img']);
 		expect(entries[0].images).toEqual(['data:image/png;base64,AAA']);
+	});
+
+	// Issue #1533: every provider but Claude Code takes Maestro's system prompt
+	// embedded in the first user turn, and that turn is what lands on disk. A
+	// hydrated tab used to render the whole envelope as if the user had typed it.
+	it('unwraps the embedded system prompt from a hydrated user turn', () => {
+		const wrapped = embedSystemPromptInPrompt(
+			'# Maestro System Context\n\nYou are **Scout**, working in /repo.',
+			'run the test suite'
+		);
+
+		const entries = transcriptMessagesToLogEntries([
+			message({ uuid: 'u', type: 'user', content: wrapped }),
+		]);
+
+		expect(entries[0].text).toBe('run the test suite');
+		expect(entries[0].text).not.toContain('Maestro System Context');
+	});
+
+	it('drops a turn that carried nothing but the envelope', () => {
+		const entries = transcriptMessagesToLogEntries([
+			message({ uuid: 'sys', type: 'user', content: embedSystemPromptInPrompt('# Context', '') }),
+			message({ uuid: 'a', type: 'assistant', content: 'done' }),
+		]);
+
+		expect(entries.map((e) => e.id)).toEqual(['a']);
+	});
+
+	it('leaves an assistant message that quotes the marker alone', () => {
+		// Only a user turn is ever wrapped, and an agent explaining the format
+		// must not have its answer truncated.
+		const quoted = 'The spawn path sends:\n\n---\n\n# User Request\n\n<your prompt>';
+		const entries = transcriptMessagesToLogEntries([
+			message({ uuid: 'a', type: 'assistant', content: quoted }),
+		]);
+
+		expect(entries[0].text).toBe(quoted);
+	});
+
+	// The backfill matches a hydrated entry against what the live tab logged to
+	// find its splice point, and a live tab logs the CLEAN prompt. Unwrapping is
+	// what lets those two texts line up at all.
+	it('produces a first turn that matches the entry a live tab logged', () => {
+		const wrapped = embedSystemPromptInPrompt('# Maestro System Context', 'fix the flaky test');
+		const loaded = transcriptMessagesToLogEntries([
+			message({ uuid: 'disk-1', type: 'user', content: wrapped }),
+			message({ uuid: 'disk-2', type: 'assistant', content: 'on it' }),
+		]);
+
+		const visible = [entry('live-2', 'on it', 'stdout')];
+		expect(selectOlderEntries(loaded, visible).map((e) => e.text)).toEqual(['fix the flaky test']);
 	});
 });
 

--- a/src/__tests__/shared/embeddedSystemPrompt.test.ts
+++ b/src/__tests__/shared/embeddedSystemPrompt.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for the system-prompt envelope Maestro wraps a first user turn in when
+ * the provider has no `--append-system-prompt` flag (issue #1533).
+ *
+ * The producer and the reader have to agree exactly: the envelope is written
+ * into the provider's session file on disk, so a reader that fails to recognise
+ * it renders the whole system prompt as something the user typed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	EMBEDDED_SYSTEM_PROMPT_SEPARATOR,
+	embedSystemPromptInPrompt,
+	hasEmbeddedSystemPrompt,
+	stripEmbeddedSystemPrompt,
+} from '../../shared/embeddedSystemPrompt';
+
+const SYSTEM_PROMPT = '# Maestro System Context\n\nYou are **Scout**, powered by **codex**.';
+
+describe('embedSystemPromptInPrompt', () => {
+	it('round-trips: the strip recovers exactly what was embedded', () => {
+		const wrapped = embedSystemPromptInPrompt(SYSTEM_PROMPT, 'summarise the release notes');
+
+		expect(wrapped.startsWith(SYSTEM_PROMPT)).toBe(true);
+		expect(stripEmbeddedSystemPrompt(wrapped)).toBe('summarise the release notes');
+	});
+
+	it('keeps the on-disk wire format that existing transcripts were written with', () => {
+		// Changing this string orphans every transcript already on disk.
+		expect(EMBEDDED_SYSTEM_PROMPT_SEPARATOR).toBe('\n\n---\n\n# User Request\n\n');
+	});
+
+	it('preserves a multi-line user request verbatim', () => {
+		const prompt = 'line one\n\n---\n\nline two';
+		expect(stripEmbeddedSystemPrompt(embedSystemPromptInPrompt(SYSTEM_PROMPT, prompt))).toBe(
+			prompt
+		);
+	});
+});
+
+describe('stripEmbeddedSystemPrompt', () => {
+	it('leaves an ordinary message untouched', () => {
+		expect(stripEmbeddedSystemPrompt('just a question')).toBe('just a question');
+	});
+
+	it('leaves empty text untouched', () => {
+		expect(stripEmbeddedSystemPrompt('')).toBe('');
+	});
+
+	it('does not strip a message that OPENS with the heading', () => {
+		// Nothing precedes the separator, so this was never wrapped - stripping
+		// would delete the user's own first line.
+		const text = '# User Request\n\nplease look at the build';
+		expect(stripEmbeddedSystemPrompt(text)).toBe(text);
+	});
+
+	it('honours the first separator only, so the user can use the marker themselves', () => {
+		const prompt = 'compare these two\n\n---\n\n# User Request\n\nsecond one';
+		expect(stripEmbeddedSystemPrompt(embedSystemPromptInPrompt(SYSTEM_PROMPT, prompt))).toBe(
+			prompt
+		);
+	});
+});
+
+describe('hasEmbeddedSystemPrompt', () => {
+	it('reports the envelope only when something precedes the separator', () => {
+		expect(hasEmbeddedSystemPrompt(embedSystemPromptInPrompt(SYSTEM_PROMPT, 'hi'))).toBe(true);
+		expect(hasEmbeddedSystemPrompt('# User Request\n\nhi')).toBe(false);
+		expect(hasEmbeddedSystemPrompt('plain message')).toBe(false);
+		expect(hasEmbeddedSystemPrompt('')).toBe(false);
+	});
+});

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -20,6 +20,7 @@ import {
 import { sanitizeSessionId } from '../../shared/history';
 import { buildExpandedPath, buildExpandedEnv } from '../../shared/pathUtils';
 import { isWindows, getWhichCommand } from '../../shared/platformDetection';
+import { embedSystemPromptInPrompt } from '../../shared/embeddedSystemPrompt';
 import { applyAgentConfigOverrides } from '../../main/utils/agent-args';
 import { buildCliWakaTimeHeartbeat } from './wakatime';
 import {
@@ -895,7 +896,7 @@ async function spawnJsonLineAgent(
 			: resolvedArgs;
 	const effectivePrompt =
 		overrides.appendSystemPrompt && !supportsNativeSystemPrompt && !isResume
-			? `${overrides.appendSystemPrompt}\n\n---\n\n# User Request\n\n${prompt}`
+			? embedSystemPromptInPrompt(overrides.appendSystemPrompt, prompt)
 			: prompt;
 
 	const noPromptSeparator = !!def?.noPromptSeparator;

--- a/src/main/ipc/handlers/process.ts
+++ b/src/main/ipc/handlers/process.ts
@@ -17,6 +17,7 @@ import {
 import { getClaudeTokenMode } from '../../../shared/claudeTokenMode';
 import { resolveConfigDirKey } from '../../stores/claudeUsageStore';
 import { isWindows } from '../../../shared/platformDetection';
+import { embedSystemPromptInPrompt } from '../../../shared/embeddedSystemPrompt';
 import { REGEX_AI_SUFFIX } from '../../constants';
 import {
 	getFailoverOverlay,
@@ -603,8 +604,11 @@ export function registerProcessHandlers(deps: ProcessHandlerDependencies): void 
 							}
 						);
 					} else if (effectivePrompt) {
-						// Fallback: embed system prompt in user message
-						effectivePrompt = `${config.appendSystemPrompt}\n\n---\n\n# User Request\n\n${effectivePrompt}`;
+						// Fallback: embed system prompt in user message. The envelope is
+						// built by the shared helper because the transcript renderer has
+						// to take it back apart again when a tab is hydrated from disk
+						// (see src/shared/embeddedSystemPrompt.ts).
+						effectivePrompt = embedSystemPromptInPrompt(config.appendSystemPrompt, effectivePrompt);
 						logger.debug('Embedding system prompt in user message (fallback)', LOG_CONTEXT, {
 							agentId: agent?.id,
 							systemPromptLength: config.appendSystemPrompt.length,

--- a/src/renderer/utils/transcriptMessages.ts
+++ b/src/renderer/utils/transcriptMessages.ts
@@ -13,6 +13,7 @@
  */
 
 import type { LogEntry } from '../types';
+import { stripEmbeddedSystemPrompt } from '../../shared/embeddedSystemPrompt';
 import { generateId } from './ids';
 
 /**
@@ -74,24 +75,41 @@ export function stripSynopsisTurns<T extends { type: string; role?: string; cont
  * text content or reconstructed images. Tool-use-only messages (empty text, no
  * images) are skipped - restored tabs start with thinking off, so there is
  * nothing useful to render for those entries.
+ *
+ * A user turn is unwrapped on the way through (`stripEmbeddedSystemPrompt`).
+ * Every provider except Claude Code lacks a system-prompt flag, so the spawn
+ * path embeds the whole Maestro system prompt in the FIRST user turn, and that
+ * turn is what the provider writes to disk. Rendering it verbatim showed the
+ * system prompt, the conductor profile and the injected context as if the user
+ * had typed them, and buried the prompt they really sent at the bottom of it
+ * (issue #1533). Stripping here rather than at each call site is what keeps
+ * resume and backfill producing identical entries for the same message; it also
+ * makes a hydrated first turn match the clean entry a live tab logged, which is
+ * what `selectOlderEntries` needs to find its splice point.
+ *
+ * The strip runs BEFORE the empty check: a turn that carried nothing but the
+ * envelope has no user text to show and should drop out entirely.
  */
 export function transcriptMessagesToLogEntries(messages: TranscriptMessage[]): LogEntry[] {
 	return messages
+		.map((msg) => {
+			const source = msg.type === 'user' ? ('user' as const) : ('stdout' as const);
+			return {
+				// Storage should always supply a uuid; the fallback keeps keys unique if
+				// one is missing. Entries that fall back cannot be matched by id across
+				// two reads, which is why `selectOlderEntries` also compares source+text.
+				id: msg.uuid || generateId(),
+				timestamp: new Date(msg.timestamp).getTime(),
+				source,
+				text: source === 'user' ? stripEmbeddedSystemPrompt(msg.content) : msg.content,
+				...(msg.images && msg.images.length > 0 && { images: msg.images }),
+			};
+		})
 		.filter(
-			(msg) =>
-				(msg.content && msg.content.trim().length > 0) ||
-				(msg.images != null && msg.images.length > 0)
-		)
-		.map((msg) => ({
-			// Storage should always supply a uuid; the fallback keeps keys unique if
-			// one is missing. Entries that fall back cannot be matched by id across
-			// two reads, which is why `selectOlderEntries` also compares source+text.
-			id: msg.uuid || generateId(),
-			timestamp: new Date(msg.timestamp).getTime(),
-			source: msg.type === 'user' ? ('user' as const) : ('stdout' as const),
-			text: msg.content,
-			...(msg.images && msg.images.length > 0 && { images: msg.images }),
-		}));
+			(entry) =>
+				(entry.text && entry.text.trim().length > 0) ||
+				(entry.images != null && entry.images.length > 0)
+		);
 }
 
 /**

--- a/src/shared/embeddedSystemPrompt.ts
+++ b/src/shared/embeddedSystemPrompt.ts
@@ -1,0 +1,60 @@
+/**
+ * The envelope Maestro uses to deliver its system prompt to a provider that has
+ * no `--append-system-prompt` flag, and the reader that takes it back apart.
+ *
+ * Only `claude-code` declares `supportsAppendSystemPrompt`. For every other
+ * provider the spawn path has nowhere to put system content except the first
+ * user turn, so it sends the whole Maestro system prompt, a `---` rule, and a
+ * `# User Request` heading ahead of whatever the human actually typed. That
+ * turn is real conversation as far as the provider is concerned: it is written
+ * verbatim into the session transcript on disk and read back whenever a tab is
+ * hydrated from it.
+ *
+ * Which is the bug this module exists to close (issue #1533). A tab that ran
+ * live shows the clean prompt, because the renderer logged the user's own text
+ * before wrapping it. The same conversation hydrated from disk - resuming a
+ * session, or scrolling to the top and paging older history in - showed the
+ * envelope instead: the entire system prompt, the conductor profile, the cwd,
+ * the history file path, and the agent's own id, rendered as if the user had
+ * typed them. So the two creation paths disagreed about the same turn, and the
+ * hydrated one leaked injected context the user never wrote.
+ *
+ * Producing and reading the envelope therefore live together. Two spawn sites
+ * used to build the string by hand (the desktop IPC spawn and the CLI's
+ * `agent-spawner`), and a third copy on the reading side would be free to drift
+ * from both. The module is import-free so the CLI bundle can use it too.
+ */
+
+/**
+ * Separates the embedded system prompt from the user's own request. Changing
+ * this string changes what is already on disk in every existing transcript, so
+ * treat it as a wire format: old sessions keep the old separator forever.
+ */
+export const EMBEDDED_SYSTEM_PROMPT_SEPARATOR = '\n\n---\n\n# User Request\n\n';
+
+/** Build the first-turn prompt for a provider with no system-prompt flag. */
+export function embedSystemPromptInPrompt(systemPrompt: string, userPrompt: string): string {
+	return `${systemPrompt}${EMBEDDED_SYSTEM_PROMPT_SEPARATOR}${userPrompt}`;
+}
+
+/**
+ * Recover the user's own request from a transcript message that carries the
+ * envelope, or return the text untouched when it does not.
+ *
+ * The separator has to be preceded by something for this to be an envelope at
+ * all: a message that OPENS with `# User Request` was never wrapped, and
+ * stripping there would delete the user's first line. Only the first occurrence
+ * is honoured, because the spawn path emits exactly one and anything further
+ * down belongs to the user's own text.
+ */
+export function stripEmbeddedSystemPrompt(text: string): string {
+	if (!text) return text;
+	const index = text.indexOf(EMBEDDED_SYSTEM_PROMPT_SEPARATOR);
+	if (index <= 0) return text;
+	return text.slice(index + EMBEDDED_SYSTEM_PROMPT_SEPARATOR.length);
+}
+
+/** True when `text` carries the envelope (and so hides a user request inside). */
+export function hasEmbeddedSystemPrompt(text: string): boolean {
+	return !!text && text.indexOf(EMBEDDED_SYSTEM_PROMPT_SEPARATOR) > 0;
+}


### PR DESCRIPTION
closes #1533

## What was happening

Only `claude-code` declares `supportsAppendSystemPrompt`. Every other provider (codex, opencode, copilot-cli, grok, ...) has no flag for system content, so the spawn path embeds it in the **first user turn**:

```
<the whole Maestro system prompt>

---

# User Request

<what the human actually typed>
```

The provider treats that as ordinary conversation and writes it into its session file verbatim.

That is why the two creation paths disagreed about the same turn. A tab that ran live in front of you shows the clean prompt, because the renderer logged the user's own text *before* wrapping it. The same conversation hydrated from disk did not:

- **resuming a session** into a tab, and
- **scrolling to the top** and paging older history in (`useTranscriptBackfill`)

both render whatever `agentSessions.read` returns, so they showed the envelope: the full system prompt, the conductor profile, the cwd, the history file path, and the agent's own id, all presented as if the user had typed them, with the prompt they really sent buried at the bottom.

A CLI-created tab hits this immediately because it holds only the turn the CLI dispatched, so the very first scroll up crosses into disk-hydrated history.

## The fix

`transcriptMessagesToLogEntries` now unwraps a user turn on the way through. Doing it there rather than at each call site fixes resume and backfill in one place and keeps them producing byte-identical entries for the same message, which is a standing requirement of that module (the backfill matches what it reads against what is on screen to find its splice point).

There is a second benefit: a hydrated first turn now matches the clean entry a live tab logged, so `selectOlderEntries` can actually line the two up instead of falling through to its timestamp fallback.

The envelope was being built by hand at two spawn sites (`src/main/ipc/handlers/process.ts` and the CLI's `src/cli/services/agent-spawner.ts`), and a third copy on the reading side would have been free to drift from both. The format moves into one import-free shared module, `src/shared/embeddedSystemPrompt.ts`, that both producers and the reader use.

Guards worth naming:

- The separator is a **wire format**. It is already on disk in every existing transcript, so a test pins the exact string.
- A message that *opens* with `# User Request` was never wrapped, so nothing is stripped there. Otherwise a user whose first line happened to be that heading would lose it.
- Only the **first** separator is honoured, so a user request that itself contains the marker survives intact.
- Only **user** turns are unwrapped. An agent explaining the format in its answer keeps its text.
- The strip runs **before** the empty check, so a turn that carried nothing but the envelope drops out rather than rendering blank.

## Scope note

The Agent Sessions browser (`SessionMessagesView`) renders the same raw messages and has the same exposure. Left alone here since this issue is about the tab transcript; happy to follow up.

## Validation

- `npm run lint`, `npm run lint:eslint`, `npx prettier --check` all clean
- Full suite green: 36,970 passed / 110 skipped
- New coverage: `src/__tests__/shared/embeddedSystemPrompt.test.ts` plus four cases in `src/__tests__/renderer/utils/transcriptMessages.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transcript hydration for providers that embed system prompts in user messages.
  - Embedded prompt wrappers are now removed from restored conversation history, keeping displayed user messages clean.
  - Envelope-only messages are omitted instead of appearing as empty user turns.
  - Assistant messages containing similar formatting remain unchanged.
  - Live tabs and restored history now display matching conversation content.

- **Compatibility**
  - Standardized embedded system-prompt formatting across supported agent execution paths, including multiline and empty requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->