### PR TITLE
fix(autorun): re-read task counts from disk when the document list is refreshed

### DIFF
--- a/src/__tests__/renderer/hooks/batch/useAutoRunHandlers.refresh.test.ts
+++ b/src/__tests__/renderer/hooks/batch/useAutoRunHandlers.refresh.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression tests for `handleAutoRunRefresh`.
+ *
+ * "Refresh document list" re-reads the Auto Run folder. The per-document task
+ * counts live in a separate cache in the batch store that was never
+ * invalidated, so a document edited on disk kept its stale count until the app
+ * was restarted (#1529).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAutoRunHandlers } from '../../../../renderer/hooks';
+import type { Session } from '../../../../renderer/types';
+import { createMockSession } from '../../../helpers/mockSession';
+import { useBatchStore } from '../../../../renderer/stores/batchStore';
+
+const createSession = (overrides: Partial<Session> = {}): Session =>
+	createMockSession({
+		id: 'session-1',
+		autoRunFolderPath: '/projects/autorun-docs',
+		...overrides,
+	});
+
+const createDeps = () => ({
+	setSessions: vi.fn(),
+	setAutoRunDocumentList: vi.fn(),
+	setAutoRunDocumentTree: vi.fn(),
+	setAutoRunIsLoadingDocuments: vi.fn(),
+	setAutoRunSetupModalOpen: vi.fn(),
+	setBatchRunnerModalOpen: vi.fn(),
+	setActiveRightTab: vi.fn(),
+	setRightPanelOpen: vi.fn(),
+	setActiveFocus: vi.fn(),
+	setSuccessFlashNotification: vi.fn(),
+	autoRunDocumentList: ['Phase 1'],
+	startBatchRun: vi.fn(),
+});
+
+describe('handleAutoRunRefresh', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		useBatchStore.getState().setDocumentTaskCounts(
+			new Map([
+				['Phase 1', { completed: 1, total: 4 }],
+				['Phase 2', { completed: 0, total: 2 }],
+			])
+		);
+	});
+
+	it('invalidates the cached task counts so edited documents are re-read from disk', async () => {
+		vi.mocked(window.maestro.autorun.listDocs).mockResolvedValueOnce({
+			success: true,
+			files: ['Phase 1', 'Phase 2'],
+			tree: [],
+		});
+		const deps = createDeps();
+		const { result } = renderHook(() => useAutoRunHandlers(createSession(), deps));
+
+		await act(async () => {
+			await result.current.handleAutoRunRefresh({ silent: true });
+		});
+
+		expect(deps.setAutoRunDocumentList).toHaveBeenCalledWith(['Phase 1', 'Phase 2']);
+		expect(useBatchStore.getState().documentTaskCounts.size).toBe(0);
+	});
+
+	it('keeps the cached task counts when listing the folder fails', async () => {
+		vi.mocked(window.maestro.autorun.listDocs).mockResolvedValueOnce({
+			success: false,
+			error: 'boom',
+		});
+		const deps = createDeps();
+		const { result } = renderHook(() => useAutoRunHandlers(createSession(), deps));
+
+		await act(async () => {
+			await result.current.handleAutoRunRefresh({ silent: true });
+		});
+
+		expect(deps.setAutoRunDocumentList).not.toHaveBeenCalled();
+		expect(useBatchStore.getState().documentTaskCounts.size).toBe(2);
+	});
+});

--- a/src/__tests__/renderer/hooks/batch/useAutoRunHandlers.refresh.test.ts
+++ b/src/__tests__/renderer/hooks/batch/useAutoRunHandlers.refresh.test.ts
@@ -106,6 +106,40 @@ describe('handleAutoRunRefresh', () => {
 		});
 	});
 
+	it('leaves the loading flag to the newer refresh when an older one settles late', async () => {
+		type ListResult = { success: boolean; files: string[]; tree: never[] };
+		const resolvers: Array<(value: ListResult) => void> = [];
+		vi.mocked(window.maestro.autorun.listDocs).mockImplementation(
+			() =>
+				new Promise<ListResult>((resolve) => {
+					resolvers.push(resolve);
+				}) as never
+		);
+		const deps = createDeps();
+		const { result } = renderHook(() => useAutoRunHandlers(createSession(), deps));
+
+		let first: Promise<void> = Promise.resolve();
+		let second: Promise<void> = Promise.resolve();
+		act(() => {
+			first = result.current.handleAutoRunRefresh({ silent: true });
+			second = result.current.handleAutoRunRefresh({ silent: true });
+		});
+		await act(async () => {
+			resolvers[0]({ success: true, files: ['Phase 1'], tree: [] });
+			await first;
+		});
+		// The superseded refresh settled, but the newer one is still loading.
+		expect(deps.setAutoRunIsLoadingDocuments).not.toHaveBeenCalledWith(false);
+		expect(deps.setAutoRunDocumentList).not.toHaveBeenCalled();
+
+		await act(async () => {
+			resolvers[1]({ success: true, files: ['Phase 1', 'Phase 2'], tree: [] });
+			await second;
+		});
+		expect(deps.setAutoRunDocumentList).toHaveBeenCalledWith(['Phase 1', 'Phase 2']);
+		expect(deps.setAutoRunIsLoadingDocuments).toHaveBeenLastCalledWith(false);
+	});
+
 	it('discards a refresh that finishes after the user switched to another session', async () => {
 		let resolveList: (value: {
 			success: boolean;

--- a/src/__tests__/renderer/hooks/batch/useAutoRunHandlers.refresh.test.ts
+++ b/src/__tests__/renderer/hooks/batch/useAutoRunHandlers.refresh.test.ts
@@ -2,9 +2,10 @@
  * Regression tests for `handleAutoRunRefresh`.
  *
  * "Refresh document list" re-reads the Auto Run folder. The per-document task
- * counts live in a separate cache in the batch store that was never
- * invalidated, so a document edited on disk kept its stale count until the app
- * was restarted (#1529).
+ * counts live in a separate cache in the batch store that was never refreshed,
+ * so a document edited on disk kept its stale count until the app was
+ * restarted (#1529). A refresh now re-reads the counts the same way the
+ * document loader does.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
@@ -12,6 +13,7 @@ import { useAutoRunHandlers } from '../../../../renderer/hooks';
 import type { Session } from '../../../../renderer/types';
 import { createMockSession } from '../../../helpers/mockSession';
 import { useBatchStore } from '../../../../renderer/stores/batchStore';
+import { useSessionStore } from '../../../../renderer/stores/sessionStore';
 
 const createSession = (overrides: Partial<Session> = {}): Session =>
 	createMockSession({
@@ -35,18 +37,31 @@ const createDeps = () => ({
 	startBatchRun: vi.fn(),
 });
 
+const DOC_CONTENT: Record<string, string> = {
+	'Phase 1.md': '- [x] done\n- [ ] todo\n- [ ] todo again\n',
+	'Phase 2.md': '- [x] a\n- [x] b\n',
+};
+
 describe('handleAutoRunRefresh', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		const session = createSession();
+		useSessionStore.setState({ sessions: [session], activeSessionId: session.id } as any);
 		useBatchStore.getState().setDocumentTaskCounts(
 			new Map([
 				['Phase 1', { completed: 1, total: 4 }],
 				['Phase 2', { completed: 0, total: 2 }],
 			])
 		);
+		vi.mocked(window.maestro.autorun.readDoc).mockImplementation(
+			async (_folder: string, file: string) => ({
+				success: true,
+				content: DOC_CONTENT[file] ?? '',
+			})
+		);
 	});
 
-	it('invalidates the cached task counts so edited documents are re-read from disk', async () => {
+	it('re-reads the task counts from disk so edited documents show fresh counts', async () => {
 		vi.mocked(window.maestro.autorun.listDocs).mockResolvedValueOnce({
 			success: true,
 			files: ['Phase 1', 'Phase 2'],
@@ -60,7 +75,15 @@ describe('handleAutoRunRefresh', () => {
 		});
 
 		expect(deps.setAutoRunDocumentList).toHaveBeenCalledWith(['Phase 1', 'Phase 2']);
-		expect(useBatchStore.getState().documentTaskCounts.size).toBe(0);
+		expect(window.maestro.autorun.readDoc).toHaveBeenCalledWith(
+			'/projects/autorun-docs',
+			'Phase 1.md',
+			undefined
+		);
+		const counts = useBatchStore.getState().documentTaskCounts;
+		expect(counts.get('Phase 1')).toEqual({ completed: 1, total: 3 });
+		expect(counts.get('Phase 2')).toEqual({ completed: 2, total: 2 });
+		expect(counts.size).toBe(2);
 	});
 
 	it('keeps the cached task counts when listing the folder fails', async () => {
@@ -76,6 +99,44 @@ describe('handleAutoRunRefresh', () => {
 		});
 
 		expect(deps.setAutoRunDocumentList).not.toHaveBeenCalled();
-		expect(useBatchStore.getState().documentTaskCounts.size).toBe(2);
+		expect(window.maestro.autorun.readDoc).not.toHaveBeenCalled();
+		expect(useBatchStore.getState().documentTaskCounts.get('Phase 1')).toEqual({
+			completed: 1,
+			total: 4,
+		});
+	});
+
+	it('discards a refresh that finishes after the user switched to another session', async () => {
+		let resolveList: (value: {
+			success: boolean;
+			files: string[];
+			tree: never[];
+		}) => void = () => {};
+		vi.mocked(window.maestro.autorun.listDocs).mockReturnValueOnce(
+			new Promise((resolve) => {
+				resolveList = resolve;
+			})
+		);
+		const deps = createDeps();
+		const { result } = renderHook(() => useAutoRunHandlers(createSession(), deps));
+
+		let refresh: Promise<void> = Promise.resolve();
+		act(() => {
+			refresh = result.current.handleAutoRunRefresh({ silent: true });
+		});
+		// The user switches sessions while the listing is still in flight.
+		useSessionStore.setState({ activeSessionId: 'session-2' } as any);
+		await act(async () => {
+			resolveList({ success: true, files: ['Phase 1', 'Phase 2'], tree: [] });
+			await refresh;
+		});
+
+		expect(deps.setAutoRunDocumentList).not.toHaveBeenCalled();
+		expect(window.maestro.autorun.readDoc).not.toHaveBeenCalled();
+		expect(useBatchStore.getState().documentTaskCounts.get('Phase 1')).toEqual({
+			completed: 1,
+			total: 4,
+		});
+		expect(deps.setAutoRunIsLoadingDocuments).toHaveBeenLastCalledWith(false);
 	});
 });

--- a/src/renderer/hooks/batch/useAutoRunDocumentLoader.ts
+++ b/src/renderer/hooks/batch/useAutoRunDocumentLoader.ts
@@ -37,6 +37,60 @@ const REMOTE_POLL_INTERVAL_MS = 20000;
 // Hook implementation
 // ============================================================================
 
+/**
+ * Reads each Auto Run document once, counts its markdown tasks, and optionally
+ * captures the content of a single document so callers don't have to re-read
+ * it. `captureInList` tells the caller whether the requested capture target
+ * was part of the documents list (so they can decide whether to fall back to
+ * an explicit read for a stale selectedFile).
+ *
+ * Shared by the document loader (initial load, file watcher, SSH poll) and
+ * the manual "Refresh document list" handler so both refresh the per-document
+ * task counts the same way.
+ */
+export async function readTaskCountsAndContent(
+	folderPath: string,
+	documents: string[],
+	sshRemoteId: string | undefined,
+	captureContentFor?: string
+): Promise<{
+	counts: Map<string, { completed: number; total: number }>;
+	capturedContent: string | undefined;
+	captureInList: boolean;
+}> {
+	const counts = new Map<string, { completed: number; total: number }>();
+	let capturedContent: string | undefined;
+	const captureInList = !!captureContentFor && documents.includes(captureContentFor);
+
+	await Promise.all(
+		documents.map(async (docPath) => {
+			try {
+				const result = await window.maestro.autorun.readDoc(
+					folderPath,
+					docPath + '.md',
+					sshRemoteId
+				);
+				if (result.success && result.content) {
+					const taskCount = countMarkdownTasks(result.content);
+					if (taskCount.total > 0) {
+						counts.set(docPath, {
+							completed: taskCount.checked,
+							total: taskCount.total,
+						});
+					}
+					if (captureContentFor && captureContentFor === docPath) {
+						capturedContent = result.content;
+					}
+				}
+			} catch {
+				// Ignore errors for individual documents
+			}
+		})
+	);
+
+	return { counts, capturedContent, captureInList };
+}
+
 export function useAutoRunDocumentLoader(): UseAutoRunDocumentLoaderReturn {
 	const loadSequenceRef = useRef(0);
 	// Last (sessionId|folder|sshRemoteId) tuple - lets us distinguish a true
@@ -57,60 +111,13 @@ export function useAutoRunDocumentLoader(): UseAutoRunDocumentLoaderReturn {
 		setDocumentTaskCounts: setAutoRunDocumentTaskCounts,
 	} = useBatchStore.getState();
 
-	// Internal helper: reads each doc once, counts tasks, and optionally
-	// captures content for a single doc so callers don't have to re-read it.
-	// `captureInList` tells the caller whether the requested capture target was
-	// part of the documents list (so they can decide whether to fall back to an
-	// explicit read for a stale selectedFile).
-	const readTaskCountsAndContent = useCallback(
-		async (
-			folderPath: string,
-			documents: string[],
-			sshRemoteId: string | undefined,
-			captureContentFor?: string
-		) => {
-			const counts = new Map<string, { completed: number; total: number }>();
-			let capturedContent: string | undefined;
-			const captureInList = !!captureContentFor && documents.includes(captureContentFor);
-
-			await Promise.all(
-				documents.map(async (docPath) => {
-					try {
-						const result = await window.maestro.autorun.readDoc(
-							folderPath,
-							docPath + '.md',
-							sshRemoteId
-						);
-						if (result.success && result.content) {
-							const taskCount = countMarkdownTasks(result.content);
-							if (taskCount.total > 0) {
-								counts.set(docPath, {
-									completed: taskCount.checked,
-									total: taskCount.total,
-								});
-							}
-							if (captureContentFor && captureContentFor === docPath) {
-								capturedContent = result.content;
-							}
-						}
-					} catch {
-						// Ignore errors for individual documents
-					}
-				})
-			);
-
-			return { counts, capturedContent, captureInList };
-		},
-		[]
-	);
-
 	// Public API: load task counts for all documents (back-compat signature)
 	const loadTaskCounts = useCallback(
 		async (folderPath: string, documents: string[], sshRemoteId?: string) => {
 			const { counts } = await readTaskCountsAndContent(folderPath, documents, sshRemoteId);
 			return counts;
 		},
-		[readTaskCountsAndContent]
+		[]
 	);
 
 	// Helper: update a session's autoRunContent if it actually changed.
@@ -247,7 +254,6 @@ export function useAutoRunDocumentLoader(): UseAutoRunDocumentLoaderReturn {
 		activeSession?.autoRunSelectedFile,
 		activeSession?.sshRemoteId,
 		activeSession?.sessionSshRemoteConfig?.remoteId,
-		readTaskCountsAndContent,
 	]);
 
 	// File watching for Auto Run - watch whenever a folder is configured
@@ -367,7 +373,6 @@ export function useAutoRunDocumentLoader(): UseAutoRunDocumentLoaderReturn {
 		activeSession?.autoRunFolderPath,
 		activeSession?.sshRemoteId,
 		activeSession?.sessionSshRemoteConfig?.remoteId,
-		readTaskCountsAndContent,
 		applySelectedContent,
 	]);
 

--- a/src/renderer/hooks/batch/useAutoRunHandlers.ts
+++ b/src/renderer/hooks/batch/useAutoRunHandlers.ts
@@ -5,6 +5,7 @@ import { notifyToast } from '../../stores/notificationStore';
 import { spawnWorktreeAgentAndDispatch } from '../../utils/worktreeSpawn';
 import { countMarkdownTasks } from './batchUtils';
 import { logger } from '../../utils/logger';
+import { useBatchStore } from '../../stores/batchStore';
 
 /**
  * Tree node structure for Auto Run document tree
@@ -432,6 +433,12 @@ export function useAutoRunHandlers(
 					const newFiles = result.files || [];
 					setAutoRunDocumentList(newFiles);
 					setAutoRunDocumentTree(result.tree || []);
+					// The per-document task counts are cached in the batch store and
+					// only (re)computed for documents missing from that cache, so a
+					// document edited on disk kept its stale count until a restart.
+					// A refresh re-reads the folder; drop the cache so the counts are
+					// re-read from disk as well.
+					useBatchStore.getState().setDocumentTaskCounts(new Map());
 
 					// Show flash notification with result
 					const diff = newFiles.length - previousCount;

--- a/src/renderer/hooks/batch/useAutoRunHandlers.ts
+++ b/src/renderer/hooks/batch/useAutoRunHandlers.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import type { Session, BatchRunConfig } from '../../types';
 import { useSessionStore, selectSessionById } from '../../stores/sessionStore';
 import { notifyToast } from '../../stores/notificationStore';
@@ -6,6 +6,7 @@ import { spawnWorktreeAgentAndDispatch } from '../../utils/worktreeSpawn';
 import { countMarkdownTasks } from './batchUtils';
 import { logger } from '../../utils/logger';
 import { useBatchStore } from '../../stores/batchStore';
+import { readTaskCountsAndContent } from './useAutoRunDocumentLoader';
 
 /**
  * Tree node structure for Auto Run document tree
@@ -95,6 +96,7 @@ export function useAutoRunHandlers(
 	activeSession: Session | null,
 	deps: UseAutoRunHandlersDeps
 ): UseAutoRunHandlersReturn {
+	const refreshSequenceRef = useRef(0);
 	const {
 		setSessions,
 		setAutoRunDocumentList,
@@ -421,24 +423,34 @@ export function useAutoRunHandlers(
 		async (options?: { silent?: boolean }) => {
 			if (!activeSession?.autoRunFolderPath) return;
 			const silent = options?.silent === true;
+			const sessionId = activeSession.id;
+			const folderPath = activeSession.autoRunFolderPath;
 			const sshRemoteId = getSshRemoteId(activeSession);
 			const previousCount = autoRunDocumentList.length;
+			// The list and the task counts are written after awaits. A refresh
+			// that was overtaken by a newer one, or whose session is no longer
+			// active, must not write another session's data into the shared
+			// stores (same guard as loadSequenceRef in useAutoRunDocumentLoader).
+			const refreshSequence = ++refreshSequenceRef.current;
+			const isStale = () =>
+				refreshSequence !== refreshSequenceRef.current ||
+				useSessionStore.getState().activeSessionId !== sessionId;
 			setAutoRunIsLoadingDocuments(true);
 			try {
-				const result = await window.maestro.autorun.listDocs(
-					activeSession.autoRunFolderPath,
-					sshRemoteId
-				);
+				const result = await window.maestro.autorun.listDocs(folderPath, sshRemoteId);
+				if (isStale()) return;
 				if (result.success) {
 					const newFiles = result.files || [];
 					setAutoRunDocumentList(newFiles);
 					setAutoRunDocumentTree(result.tree || []);
 					// The per-document task counts are cached in the batch store and
-					// only (re)computed for documents missing from that cache, so a
-					// document edited on disk kept its stale count until a restart.
-					// A refresh re-reads the folder; drop the cache so the counts are
-					// re-read from disk as well.
-					useBatchStore.getState().setDocumentTaskCounts(new Map());
+					// only (re)computed by the Batch Runner for documents missing from
+					// that cache, so a document edited on disk kept its stale count
+					// until a restart. A refresh re-reads the folder; re-read the
+					// counts from disk as well, the same way the document loader does.
+					const { counts } = await readTaskCountsAndContent(folderPath, newFiles, sshRemoteId);
+					if (isStale()) return;
+					useBatchStore.getState().setDocumentTaskCounts(counts);
 
 					// Show flash notification with result
 					const diff = newFiles.length - previousCount;
@@ -462,6 +474,7 @@ export function useAutoRunHandlers(
 			// Note: Use primitive values (remoteId) not object refs (sessionSshRemoteConfig) to avoid infinite re-render loops
 		},
 		[
+			activeSession?.id,
 			activeSession?.autoRunFolderPath,
 			activeSession?.sshRemoteId,
 			activeSession?.sessionSshRemoteConfig?.remoteId,

--- a/src/renderer/hooks/batch/useAutoRunHandlers.ts
+++ b/src/renderer/hooks/batch/useAutoRunHandlers.ts
@@ -469,7 +469,11 @@ export function useAutoRunHandlers(
 					return;
 				}
 			} finally {
-				setAutoRunIsLoadingDocuments(false);
+				// A superseded refresh must not clear the loading flag the newer
+				// refresh still owns.
+				if (refreshSequence === refreshSequenceRef.current) {
+					setAutoRunIsLoadingDocuments(false);
+				}
 			}
 			// Note: Use primitive values (remoteId) not object refs (sessionSshRemoteConfig) to avoid infinite re-render loops
 		},


### PR DESCRIPTION
## Summary

Fixes #1529

"Refresh document list" (`handleAutoRunRefresh` in `useAutoRunHandlers.ts`) re-lists the Auto Run folder via `autorun:listDocs`, but the per-document task counts live in a separate cache in the batch store (`documentTaskCounts`) that the refresh never touched. `BatchRunnerModal` only computes counts for documents that are missing from that cache, so a Playbook edited on disk kept its stale count (or `0`) after Refresh or after reselecting it in the Add Docs picker; only a full restart (which recreates the store) picked up the new checkboxes.

The refresh now drops the cached counts when the folder listing succeeds, so the counts are re-read from the current file contents together with the list. A failed listing leaves the cache as it was.

## Testing

- New `src/__tests__/renderer/hooks/batch/useAutoRunHandlers.refresh.test.ts`: a successful refresh clears `documentTaskCounts` (fails on `main`), a failed listing keeps it. The existing `useAutoRunHandlers.worktree.test.ts` still passes (42 tests across both files).
- `npm run lint` (tsc, `tsconfig.lint.json`), `npx eslint` on the hook, `prettier --check` on both files.
- Not exercised in the running app (macOS build of the dev app not set up here); the change is limited to the refresh handler.

## Type of change

- [x] Bug fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Auto Run document refreshes now reload task counts from disk, ensuring updated information is reflected.
  - Cached task counts remain available when refreshing the folder list fails.
  - Outdated results are ignored when the active session changes or a newer refresh completes.
  - Loading indicators now remain accurate during overlapping refreshes and session changes.

- **Tests**
  - Added regression coverage for task-count caching and stale refresh results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->