### PR TITLE
fix(gh): detect a gh shim and honor the configured gh path

### DIFF
--- a/src/__tests__/main/ipc/handlers/feedback.test.ts
+++ b/src/__tests__/main/ipc/handlers/feedback.test.ts
@@ -56,6 +56,10 @@ vi.mock('../../../../main/stores/getters', () => ({
 	getSettingsStore: vi.fn(() => ({ get: vi.fn(() => '') })),
 }));
 
+vi.mock('../../../../main/stores/instances', () => ({
+	isInitialized: vi.fn(() => true),
+}));
+
 vi.mock('../../../../main/utils/execFile', () => ({
 	execFileNoThrow: vi.fn(),
 }));
@@ -77,6 +81,7 @@ import {
 } from '../../../../main/utils/cliDetection';
 import { execFileNoThrow } from '../../../../main/utils/execFile';
 import { getSettingsStore } from '../../../../main/stores/getters';
+import { isInitialized } from '../../../../main/stores/instances';
 import {
 	cleanupTempFiles,
 	saveImageToTempFile,
@@ -529,6 +534,26 @@ describe('feedback handlers', () => {
 			undefined,
 			expect.anything()
 		);
+	});
+
+	// The guard is a predicate rather than a try/catch so that a REAL settings
+	// failure still surfaces instead of silently running some other binary.
+	it('falls back to auto-detection when the stores are not initialised', async () => {
+		vi.mocked(isInitialized).mockReturnValue(false);
+		vi.mocked(getCachedGhStatus).mockReturnValue(null);
+		vi.mocked(isGhInstalled).mockResolvedValue(true);
+		vi.mocked(execFileNoThrow).mockResolvedValue({
+			exitCode: 0,
+			stdout: '',
+			stderr: '',
+		} as any);
+
+		const handler = registeredHandlers.get('feedback:check-gh-auth');
+		const result = await handler!({});
+
+		expect(getSettingsStore).not.toHaveBeenCalled();
+		expect(isGhInstalled).toHaveBeenCalled();
+		expect(result).toEqual({ authenticated: true });
 	});
 
 	describe('feedback:get-conversation-prompt', () => {

--- a/src/__tests__/main/ipc/handlers/feedback.test.ts
+++ b/src/__tests__/main/ipc/handlers/feedback.test.ts
@@ -49,6 +49,11 @@ vi.mock('../../../../main/utils/cliDetection', () => ({
 	setCachedGhStatus: vi.fn(),
 	getCachedGhStatus: vi.fn(),
 	getExpandedEnv: vi.fn(() => ({ PATH: '/usr/bin' })),
+	resolveGhPath: vi.fn(async (customPath?: string) => customPath ?? 'gh'),
+}));
+
+vi.mock('../../../../main/stores/getters', () => ({
+	getSettingsStore: vi.fn(() => ({ get: vi.fn(() => '') })),
 }));
 
 vi.mock('../../../../main/utils/execFile', () => ({
@@ -71,6 +76,7 @@ import {
 	setCachedGhStatus,
 } from '../../../../main/utils/cliDetection';
 import { execFileNoThrow } from '../../../../main/utils/execFile';
+import { getSettingsStore } from '../../../../main/stores/getters';
 import {
 	cleanupTempFiles,
 	saveImageToTempFile,
@@ -471,6 +477,58 @@ describe('feedback handlers', () => {
 		});
 		expect(setCachedGhStatus).toHaveBeenCalledWith(true, true);
 		expect(result).toEqual({ authenticated: true });
+	});
+
+	// Regression: every gh call in the feedback handler used to hardcode the bare
+	// string 'gh', so Settings > GitHub CLI (gh) Path was silently ignored and
+	// feedback reported "not installed" on installs where gh is not on PATH.
+	it('honors a configured custom gh path when probing auth', async () => {
+		vi.mocked(getSettingsStore).mockReturnValue({
+			get: vi.fn(() => '/custom/bin/gh'),
+		} as any);
+		vi.mocked(getCachedGhStatus).mockReturnValue(null);
+		vi.mocked(execFileNoThrow).mockResolvedValue({
+			exitCode: 0,
+			stdout: '',
+			stderr: '',
+		} as any);
+
+		const handler = registeredHandlers.get('feedback:check-gh-auth');
+		const result = await handler!({});
+
+		// A configured path is authoritative, so `which`-based detection is skipped
+		// and the binary itself is probed instead.
+		expect(isGhInstalled).not.toHaveBeenCalled();
+		expect(execFileNoThrow).toHaveBeenCalledWith('/custom/bin/gh', ['--version'], undefined, {
+			PATH: '/usr/bin',
+		});
+		expect(execFileNoThrow).toHaveBeenCalledWith('/custom/bin/gh', ['auth', 'status'], undefined, {
+			PATH: '/usr/bin',
+		});
+		expect(result).toEqual({ authenticated: true });
+	});
+
+	it('falls back to which-based detection when no custom path is configured', async () => {
+		vi.mocked(getSettingsStore).mockReturnValue({ get: vi.fn(() => '   ') } as any);
+		vi.mocked(getCachedGhStatus).mockReturnValue(null);
+		vi.mocked(isGhInstalled).mockResolvedValue(true);
+		vi.mocked(execFileNoThrow).mockResolvedValue({
+			exitCode: 0,
+			stdout: '',
+			stderr: '',
+		} as any);
+
+		const handler = registeredHandlers.get('feedback:check-gh-auth');
+		await handler!({});
+
+		// A whitespace-only setting means "unset", not a path.
+		expect(isGhInstalled).toHaveBeenCalled();
+		expect(execFileNoThrow).not.toHaveBeenCalledWith(
+			expect.anything(),
+			['--version'],
+			undefined,
+			expect.anything()
+		);
 	});
 
 	describe('feedback:get-conversation-prompt', () => {

--- a/src/__tests__/main/ipc/handlers/feedback.test.ts
+++ b/src/__tests__/main/ipc/handlers/feedback.test.ts
@@ -111,6 +111,7 @@ describe('feedback handlers', () => {
 		const result = await handler!({});
 
 		expect(result).toEqual({ authenticated: true });
+		expect(getCachedGhStatus).toHaveBeenCalledWith('gh');
 		expect(isGhInstalled).not.toHaveBeenCalled();
 	});
 
@@ -480,7 +481,7 @@ describe('feedback handlers', () => {
 		expect(execFileNoThrow).toHaveBeenCalledWith('gh', ['auth', 'status'], undefined, {
 			PATH: '/usr/bin',
 		});
-		expect(setCachedGhStatus).toHaveBeenCalledWith(true, true);
+		expect(setCachedGhStatus).toHaveBeenCalledWith('gh', true, true);
 		expect(result).toEqual({ authenticated: true });
 	});
 
@@ -511,6 +512,31 @@ describe('feedback handlers', () => {
 			PATH: '/usr/bin',
 		});
 		expect(result).toEqual({ authenticated: true });
+	});
+
+	// Regression: the cache was path-agnostic, so a verdict the renderer's
+	// checkGhCli() reached against the PATH-resolved gh answered for a configured
+	// custom path, and a failed custom-path probe answered for everyone else.
+	it('keys the cached verdict by the configured custom gh path', async () => {
+		vi.mocked(getSettingsStore).mockReturnValue({
+			get: vi.fn(() => '/custom/bin/gh'),
+		} as any);
+		vi.mocked(getCachedGhStatus).mockReturnValue(null);
+		vi.mocked(execFileNoThrow).mockResolvedValue({
+			exitCode: 1,
+			stdout: '',
+			stderr: 'no such file',
+		} as any);
+
+		const handler = registeredHandlers.get('feedback:check-gh-auth');
+		const result = await handler!({});
+
+		expect(getCachedGhStatus).toHaveBeenCalledWith('/custom/bin/gh');
+		expect(setCachedGhStatus).toHaveBeenCalledWith('/custom/bin/gh', false, false);
+		expect(result).toEqual({
+			authenticated: false,
+			message: expect.stringContaining('not installed'),
+		});
 	});
 
 	it('falls back to which-based detection when no custom path is configured', async () => {

--- a/src/__tests__/main/ipc/handlers/git.test.ts
+++ b/src/__tests__/main/ipc/handlers/git.test.ts
@@ -49,6 +49,7 @@ vi.mock('../../../../main/utils/cliDetection', () => ({
 	resolveGhPath: vi.fn().mockResolvedValue('gh'),
 	getCachedGhStatus: vi.fn().mockReturnValue(null),
 	setCachedGhStatus: vi.fn(),
+	getExpandedEnv: vi.fn().mockReturnValue({ PATH: '/expanded/path:/usr/bin' }),
 }));
 
 // Mock fs/promises
@@ -3497,8 +3498,12 @@ export function Component() {
 			const handler = handlers.get('git:checkGhCli');
 			const result = await handler!({} as any);
 
-			expect(execFile.execFileNoThrow).toHaveBeenCalledWith('gh', ['--version']);
-			expect(execFile.execFileNoThrow).toHaveBeenCalledWith('gh', ['auth', 'status']);
+			expect(execFile.execFileNoThrow).toHaveBeenCalledWith('gh', ['--version'], undefined, {
+				PATH: '/expanded/path:/usr/bin',
+			});
+			expect(execFile.execFileNoThrow).toHaveBeenCalledWith('gh', ['auth', 'status'], undefined, {
+				PATH: '/expanded/path:/usr/bin',
+			});
 			expect(result).toEqual({
 				installed: true,
 				authenticated: true,
@@ -3517,7 +3522,9 @@ export function Component() {
 			const result = await handler!({} as any);
 
 			expect(execFile.execFileNoThrow).toHaveBeenCalledTimes(1);
-			expect(execFile.execFileNoThrow).toHaveBeenCalledWith('gh', ['--version']);
+			expect(execFile.execFileNoThrow).toHaveBeenCalledWith('gh', ['--version'], undefined, {
+				PATH: '/expanded/path:/usr/bin',
+			});
 			expect(result).toEqual({
 				installed: false,
 				authenticated: false,
@@ -3542,8 +3549,12 @@ export function Component() {
 			const handler = handlers.get('git:checkGhCli');
 			const result = await handler!({} as any);
 
-			expect(execFile.execFileNoThrow).toHaveBeenCalledWith('gh', ['--version']);
-			expect(execFile.execFileNoThrow).toHaveBeenCalledWith('gh', ['auth', 'status']);
+			expect(execFile.execFileNoThrow).toHaveBeenCalledWith('gh', ['--version'], undefined, {
+				PATH: '/expanded/path:/usr/bin',
+			});
+			expect(execFile.execFileNoThrow).toHaveBeenCalledWith('gh', ['auth', 'status'], undefined, {
+				PATH: '/expanded/path:/usr/bin',
+			});
 			expect(result).toEqual({
 				installed: true,
 				authenticated: false,
@@ -3597,11 +3608,18 @@ export function Component() {
 
 			// Should bypass cache and check with custom path
 			expect(cliDetection.resolveGhPath).toHaveBeenCalledWith('/opt/homebrew/bin/gh');
-			expect(execFile.execFileNoThrow).toHaveBeenCalledWith('/opt/homebrew/bin/gh', ['--version']);
-			expect(execFile.execFileNoThrow).toHaveBeenCalledWith('/opt/homebrew/bin/gh', [
-				'auth',
-				'status',
-			]);
+			expect(execFile.execFileNoThrow).toHaveBeenCalledWith(
+				'/opt/homebrew/bin/gh',
+				['--version'],
+				undefined,
+				{ PATH: '/expanded/path:/usr/bin' }
+			);
+			expect(execFile.execFileNoThrow).toHaveBeenCalledWith(
+				'/opt/homebrew/bin/gh',
+				['auth', 'status'],
+				undefined,
+				{ PATH: '/expanded/path:/usr/bin' }
+			);
 			expect(result).toEqual({
 				installed: true,
 				authenticated: false,

--- a/src/__tests__/main/ipc/handlers/git.test.ts
+++ b/src/__tests__/main/ipc/handlers/git.test.ts
@@ -3573,6 +3573,8 @@ export function Component() {
 
 			// Should not call execFileNoThrow because cached result is used
 			expect(execFile.execFileNoThrow).not.toHaveBeenCalled();
+			// The verdict is keyed by the resolved command, not shared across binaries.
+			expect(cliDetection.getCachedGhStatus).toHaveBeenCalledWith('gh');
 			expect(result).toEqual({
 				installed: true,
 				authenticated: true,
@@ -3647,7 +3649,7 @@ export function Component() {
 			await handler!({} as any);
 
 			// Should cache the result
-			expect(cliDetection.setCachedGhStatus).toHaveBeenCalledWith(true, true);
+			expect(cliDetection.setCachedGhStatus).toHaveBeenCalledWith('gh', true, true);
 		});
 
 		it('should not cache result when using custom ghPath', async () => {

--- a/src/__tests__/main/ipc/handlers/git.test.ts
+++ b/src/__tests__/main/ipc/handlers/git.test.ts
@@ -3676,6 +3676,62 @@ export function Component() {
 		});
 	});
 
+	describe('git:createGist', () => {
+		// The gist call passes BOTH the gist body on stdin and the expanded PATH,
+		// which only works via the structured option object. Dropping either one
+		// breaks it silently: no env means a gh shim cannot reach its parent tool,
+		// and no input means an empty gist.
+		it('sends the content on stdin AND the expanded env', async () => {
+			const cliDetection = await import('../../../../main/utils/cliDetection');
+			vi.mocked(cliDetection.resolveGhPath).mockResolvedValue('gh');
+			vi.mocked(execFile.execFileNoThrow).mockResolvedValueOnce({
+				stdout: 'https://gist.github.com/user/abc123\n',
+				stderr: '',
+				exitCode: 0,
+			});
+
+			const handler = handlers.get('git:createGist');
+			const result = await handler!(
+				{} as any,
+				'log.txt',
+				'gist body contents',
+				'a description',
+				false
+			);
+
+			expect(execFile.execFileNoThrow).toHaveBeenCalledWith(
+				'gh',
+				expect.arrayContaining(['gist', 'create', '--filename', 'log.txt']),
+				undefined,
+				{ input: 'gist body contents', env: { PATH: '/expanded/path:/usr/bin' } }
+			);
+			expect(result).toEqual({
+				success: true,
+				gistUrl: 'https://gist.github.com/user/abc123',
+			});
+		});
+
+		it('honors a custom ghPath', async () => {
+			const cliDetection = await import('../../../../main/utils/cliDetection');
+			vi.mocked(cliDetection.resolveGhPath).mockResolvedValue('/custom/bin/gh');
+			vi.mocked(execFile.execFileNoThrow).mockResolvedValueOnce({
+				stdout: 'https://gist.github.com/user/def456\n',
+				stderr: '',
+				exitCode: 0,
+			});
+
+			const handler = handlers.get('git:createGist');
+			await handler!({} as any, 'log.txt', 'body', '', false, '/custom/bin/gh');
+
+			expect(execFile.execFileNoThrow).toHaveBeenCalledWith(
+				'/custom/bin/gh',
+				expect.any(Array),
+				undefined,
+				expect.objectContaining({ env: { PATH: '/expanded/path:/usr/bin' } })
+			);
+		});
+	});
+
 	describe('git:getDefaultBranch', () => {
 		it('should return branch from remote when HEAD branch is available', async () => {
 			vi.mocked(execFile.execFileNoThrow).mockResolvedValueOnce({

--- a/src/__tests__/main/utils/cliDetection.test.ts
+++ b/src/__tests__/main/utils/cliDetection.test.ts
@@ -30,6 +30,7 @@ import {
 	setCachedGhStatus,
 	clearGhCache,
 	resolveGhPath,
+	isGhInstalled,
 } from '../../../main/utils/cliDetection';
 import { execFileNoThrow } from '../../../main/utils/execFile';
 
@@ -557,6 +558,29 @@ describe('cliDetection.ts', () => {
 			vi.advanceTimersByTime(60001);
 
 			expect(getCachedGhStatus()).toBeNull();
+		});
+
+		// Expiring the verdict is not enough on its own: isGhInstalled() returns
+		// early on any non-null detection cache, so a stale `false` left behind
+		// would make the next lookup answer from the result that just expired
+		// instead of probing again.
+		it('re-probes after a NEGATIVE verdict expires, rather than reusing it', async () => {
+			vi.useFakeTimers();
+			setCachedGhStatus(false, false);
+
+			vi.advanceTimersByTime(60001);
+			expect(getCachedGhStatus()).toBeNull();
+
+			// The shim is resolvable now that its parent tool is reachable.
+			mockedExecFileNoThrow.mockResolvedValue({
+				stdout: '/home/testuser/.asdf/shims/gh\n',
+				stderr: '',
+				exitCode: 0,
+			});
+
+			await expect(isGhInstalled()).resolves.toBe(true);
+			expect(mockedExecFileNoThrow).toHaveBeenCalled();
+			await expect(resolveGhPath()).resolves.toBe('/home/testuser/.asdf/shims/gh');
 		});
 
 		it('expires a positive verdict once the TTL elapses', () => {

--- a/src/__tests__/main/utils/cliDetection.test.ts
+++ b/src/__tests__/main/utils/cliDetection.test.ts
@@ -26,6 +26,10 @@ import {
 	isCloudflaredInstalled,
 	getCloudflaredPath,
 	clearCloudflaredCache,
+	getCachedGhStatus,
+	setCachedGhStatus,
+	clearGhCache,
+	resolveGhPath,
 } from '../../../main/utils/cliDetection';
 import { execFileNoThrow } from '../../../main/utils/execFile';
 
@@ -514,6 +518,67 @@ describe('cliDetection.ts', () => {
 			await isCloudflaredInstalled();
 
 			expect(getCloudflaredPath()).toBe('/home/user@domain/bin/cloudflared');
+		});
+	});
+	describe('gh status cache', () => {
+		beforeEach(() => {
+			clearGhCache();
+			vi.useRealTimers();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+			clearGhCache();
+		});
+
+		it('returns null before anything has been cached', () => {
+			expect(getCachedGhStatus()).toBeNull();
+		});
+
+		it('serves a positive verdict from cache inside the TTL', () => {
+			setCachedGhStatus(true, true);
+
+			expect(getCachedGhStatus()).toEqual({ installed: true, authenticated: true });
+		});
+
+		it('serves a negative verdict from cache inside the TTL', () => {
+			setCachedGhStatus(false, false);
+
+			expect(getCachedGhStatus()).toEqual({ installed: false, authenticated: false });
+		});
+
+		// Regression: a negative verdict used to skip the TTL check entirely, so one
+		// failed probe at startup made gh unavailable for the whole app run.
+		it('expires a NEGATIVE verdict once the TTL elapses', () => {
+			vi.useFakeTimers();
+			setCachedGhStatus(false, false);
+			expect(getCachedGhStatus()).toEqual({ installed: false, authenticated: false });
+
+			vi.advanceTimersByTime(60001);
+
+			expect(getCachedGhStatus()).toBeNull();
+		});
+
+		it('expires a positive verdict once the TTL elapses', () => {
+			vi.useFakeTimers();
+			setCachedGhStatus(true, true);
+
+			vi.advanceTimersByTime(60001);
+
+			expect(getCachedGhStatus()).toBeNull();
+		});
+
+		it('clearGhCache drops a cached verdict immediately', () => {
+			setCachedGhStatus(true, true);
+
+			clearGhCache();
+
+			expect(getCachedGhStatus()).toBeNull();
+		});
+
+		it('resolveGhPath returns a custom path without probing the filesystem', async () => {
+			await expect(resolveGhPath('/custom/bin/gh')).resolves.toBe('/custom/bin/gh');
+			expect(mockedExecFileNoThrow).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/__tests__/main/utils/cliDetection.test.ts
+++ b/src/__tests__/main/utils/cliDetection.test.ts
@@ -532,32 +532,73 @@ describe('cliDetection.ts', () => {
 			clearGhCache();
 		});
 
+		const DEFAULT_GH = '/opt/homebrew/bin/gh';
+		const CUSTOM_GH = '/custom/bin/gh';
+
 		it('returns null before anything has been cached', () => {
-			expect(getCachedGhStatus()).toBeNull();
+			expect(getCachedGhStatus(DEFAULT_GH)).toBeNull();
 		});
 
 		it('serves a positive verdict from cache inside the TTL', () => {
-			setCachedGhStatus(true, true);
+			setCachedGhStatus(DEFAULT_GH, true, true);
 
-			expect(getCachedGhStatus()).toEqual({ installed: true, authenticated: true });
+			expect(getCachedGhStatus(DEFAULT_GH)).toEqual({ installed: true, authenticated: true });
 		});
 
 		it('serves a negative verdict from cache inside the TTL', () => {
-			setCachedGhStatus(false, false);
+			setCachedGhStatus(DEFAULT_GH, false, false);
 
-			expect(getCachedGhStatus()).toEqual({ installed: false, authenticated: false });
+			expect(getCachedGhStatus(DEFAULT_GH)).toEqual({ installed: false, authenticated: false });
+		});
+
+		// Regression: the verdict used to be path-agnostic, so a probe of the
+		// PATH-resolved gh answered for a configured custom path and vice versa.
+		it('treats a verdict reached against a different command as a miss', () => {
+			setCachedGhStatus(DEFAULT_GH, false, false);
+
+			expect(getCachedGhStatus(CUSTOM_GH)).toBeNull();
+		});
+
+		it('does not let a failed custom-path probe answer for the default gh', () => {
+			setCachedGhStatus(CUSTOM_GH, false, false);
+
+			expect(getCachedGhStatus(DEFAULT_GH)).toBeNull();
+			expect(getCachedGhStatus(CUSTOM_GH)).toEqual({ installed: false, authenticated: false });
+		});
+
+		// The status verdict and the `which` detection cache are separate: caching
+		// a custom-path failure must not mark the PATH-resolved gh as missing.
+		it('does not let a failed custom-path probe poison PATH detection', async () => {
+			mockedExecFileNoThrow.mockResolvedValue({
+				stdout: `${DEFAULT_GH}\n`,
+				stderr: '',
+				exitCode: 0,
+			});
+
+			setCachedGhStatus(CUSTOM_GH, false, false);
+
+			await expect(isGhInstalled()).resolves.toBe(true);
+			await expect(resolveGhPath()).resolves.toBe(DEFAULT_GH);
+		});
+
+		it('replaces a verdict for one command with a verdict for another', () => {
+			setCachedGhStatus(DEFAULT_GH, true, true);
+			setCachedGhStatus(CUSTOM_GH, true, false);
+
+			expect(getCachedGhStatus(DEFAULT_GH)).toBeNull();
+			expect(getCachedGhStatus(CUSTOM_GH)).toEqual({ installed: true, authenticated: false });
 		});
 
 		// Regression: a negative verdict used to skip the TTL check entirely, so one
 		// failed probe at startup made gh unavailable for the whole app run.
 		it('expires a NEGATIVE verdict once the TTL elapses', () => {
 			vi.useFakeTimers();
-			setCachedGhStatus(false, false);
-			expect(getCachedGhStatus()).toEqual({ installed: false, authenticated: false });
+			setCachedGhStatus(DEFAULT_GH, false, false);
+			expect(getCachedGhStatus(DEFAULT_GH)).toEqual({ installed: false, authenticated: false });
 
 			vi.advanceTimersByTime(60001);
 
-			expect(getCachedGhStatus()).toBeNull();
+			expect(getCachedGhStatus(DEFAULT_GH)).toBeNull();
 		});
 
 		// Expiring the verdict is not enough on its own: isGhInstalled() returns
@@ -566,12 +607,17 @@ describe('cliDetection.ts', () => {
 		// instead of probing again.
 		it('re-probes after a NEGATIVE verdict expires, rather than reusing it', async () => {
 			vi.useFakeTimers();
-			setCachedGhStatus(false, false);
+
+			// Startup: the shim cannot reach its parent tool, so `which` fails.
+			mockedExecFileNoThrow.mockResolvedValue({ stdout: '', stderr: '', exitCode: 1 });
+			await expect(isGhInstalled()).resolves.toBe(false);
+			setCachedGhStatus('gh', false, false);
 
 			vi.advanceTimersByTime(60001);
-			expect(getCachedGhStatus()).toBeNull();
+			expect(getCachedGhStatus('gh')).toBeNull();
 
 			// The shim is resolvable now that its parent tool is reachable.
+			mockedExecFileNoThrow.mockClear();
 			mockedExecFileNoThrow.mockResolvedValue({
 				stdout: '/home/testuser/.asdf/shims/gh\n',
 				stderr: '',
@@ -585,19 +631,19 @@ describe('cliDetection.ts', () => {
 
 		it('expires a positive verdict once the TTL elapses', () => {
 			vi.useFakeTimers();
-			setCachedGhStatus(true, true);
+			setCachedGhStatus(DEFAULT_GH, true, true);
 
 			vi.advanceTimersByTime(60001);
 
-			expect(getCachedGhStatus()).toBeNull();
+			expect(getCachedGhStatus(DEFAULT_GH)).toBeNull();
 		});
 
 		it('clearGhCache drops a cached verdict immediately', () => {
-			setCachedGhStatus(true, true);
+			setCachedGhStatus(DEFAULT_GH, true, true);
 
 			clearGhCache();
 
-			expect(getCachedGhStatus()).toBeNull();
+			expect(getCachedGhStatus(DEFAULT_GH)).toBeNull();
 		});
 
 		it('resolveGhPath returns a custom path without probing the filesystem', async () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -176,6 +176,7 @@ import {
 import { isAgentBusy } from './utils/agent-busy';
 import { createTimeZoneWatcher } from './utils/timezone-watcher';
 import { noteSystemSuspend, noteSystemResume } from './utils/sleep-tracker';
+import { clearGhCache } from './utils/cliDetection';
 // Phase 3 refactoring - process listeners
 import { setupProcessListeners as setupProcessListenersModule } from './process-listeners';
 import { setupWakaTimeListener } from './process-listeners/wakatime-listener';
@@ -474,6 +475,11 @@ const settingsWatcher = createSettingsWatcher({
 		if (keepDisplayAwake !== powerManager.isKeepingDisplayAwake()) {
 			powerManager.setKeepDisplayAwake(keepDisplayAwake);
 		}
+		// A CLI or hand write can repoint ghPath without going through
+		// settings:set, which is where the cache is otherwise invalidated. The
+		// clear is unconditional because the previous value is not available
+		// here, and the only cost of an unnecessary one is a single `which`.
+		clearGhCache();
 	},
 });
 

--- a/src/main/ipc/handlers/feedback.ts
+++ b/src/main/ipc/handlers/feedback.ts
@@ -486,8 +486,14 @@ export function registerFeedbackHandlers(_deps: FeedbackHandlerDependencies): vo
 		withIpcErrorLogging(
 			handlerOpts('check-gh-auth'),
 			async (): Promise<{ authenticated: boolean; message?: string }> => {
+				// A configured custom path is authoritative: it exists precisely for
+				// binaries that PATH lookup cannot find. Resolve it before reading the
+				// cache, because the cache is keyed by the command a verdict was reached
+				// against, and the other gh callers probe the PATH-resolved binary.
+				const ghCommand = await resolveFeedbackGhCommand();
+
 				// Prefer cache when available
-				const cached = getCachedGhStatus();
+				const cached = getCachedGhStatus(ghCommand);
 				if (cached) {
 					if (!cached.installed) {
 						return { authenticated: false, message: GH_NOT_INSTALLED_MESSAGE };
@@ -498,24 +504,22 @@ export function registerFeedbackHandlers(_deps: FeedbackHandlerDependencies): vo
 					return { authenticated: true };
 				}
 
-				// Check if gh is installed. A configured custom path is authoritative:
-				// it exists precisely for binaries that PATH lookup cannot find, so probe
-				// it directly rather than asking `which` about a name it will never see.
-				const ghCommand = await resolveFeedbackGhCommand();
+				// Check if gh is installed. Probe a custom path directly rather than
+				// asking `which` about a name it will never see.
 				const env = getExpandedEnv();
 				const installed =
 					ghCommand === 'gh'
 						? await isGhInstalled()
 						: (await execFileNoThrow(ghCommand, ['--version'], undefined, env)).exitCode === 0;
 				if (!installed) {
-					setCachedGhStatus(false, false);
+					setCachedGhStatus(ghCommand, false, false);
 					return { authenticated: false, message: GH_NOT_INSTALLED_MESSAGE };
 				}
 
 				// Check auth status (command output ignored; exit code is the signal)
 				const authResult = await execFileNoThrow(ghCommand, ['auth', 'status'], undefined, env);
 				const authenticated = authResult.exitCode === 0;
-				setCachedGhStatus(true, authenticated);
+				setCachedGhStatus(ghCommand, true, authenticated);
 
 				if (!authenticated) {
 					return { authenticated: false, message: GH_NOT_AUTHENTICATED_MESSAGE };

--- a/src/main/ipc/handlers/feedback.ts
+++ b/src/main/ipc/handlers/feedback.ts
@@ -18,8 +18,10 @@ import {
 	setCachedGhStatus,
 	getCachedGhStatus,
 	getExpandedEnv,
+	resolveGhPath,
 } from '../../utils/cliDetection';
 import { execFileNoThrow } from '../../utils/execFile';
+import { getSettingsStore } from '../../stores/getters';
 import { generateDebugPackage, type DebugPackageDependencies } from '../../debug-package';
 import { captureException } from '../../utils/sentry';
 import type { MaestroCliManager } from '../../maestro-cli-manager';
@@ -212,9 +214,30 @@ function buildEnvironmentSummary(payload: FeedbackSubmitPayload): FeedbackEnviro
 	};
 }
 
+/**
+ * Resolve the gh binary this handler should invoke.
+ *
+ * Honours the user's configured Settings > GitHub CLI (gh) Path, falling back to
+ * auto-detection. Every gh call in this file must go through here: a bare 'gh'
+ * literal silently ignores that setting, which is the whole reason it exists for
+ * installs where gh is not on the expanded PATH.
+ */
+async function resolveFeedbackGhCommand(): Promise<string> {
+	let customPath: string | undefined;
+	try {
+		const configured = getSettingsStore().get('ghPath');
+		customPath =
+			typeof configured === 'string' && configured.trim() ? configured.trim() : undefined;
+	} catch {
+		// Stores are not initialised in every context (unit tests, early startup).
+		// Auto-detection is the correct fallback there.
+	}
+	return resolveGhPath(customPath);
+}
+
 async function getGitHubLogin(): Promise<string> {
 	const result = await execFileNoThrow(
-		'gh',
+		await resolveFeedbackGhCommand(),
 		['api', 'user', '--jq', '.login'],
 		undefined,
 		getExpandedEnv()
@@ -242,7 +265,7 @@ function parseAttachmentDataUrl(attachment: FeedbackAttachmentInput): {
 
 async function ensureAttachmentsRepo(owner: string): Promise<void> {
 	const repoCheck = await execFileNoThrow(
-		'gh',
+		await resolveFeedbackGhCommand(),
 		['api', `repos/${owner}/${ATTACHMENTS_REPO}`],
 		undefined,
 		getExpandedEnv()
@@ -252,7 +275,7 @@ async function ensureAttachmentsRepo(owner: string): Promise<void> {
 	}
 
 	const repoCreate = await execFileNoThrow(
-		'gh',
+		await resolveFeedbackGhCommand(),
 		[
 			'api',
 			'user/repos',
@@ -304,7 +327,7 @@ async function uploadAttachments(
 			'utf8'
 		);
 		const uploadResult = await execFileNoThrow(
-			'gh',
+			await resolveFeedbackGhCommand(),
 			[
 				'api',
 				`repos/${owner}/${ATTACHMENTS_REPO}/contents/${repoPath}`,
@@ -344,7 +367,7 @@ async function composeFeedbackPrompt(
 
 async function ensureFeedbackLabel(): Promise<void> {
 	const labelCheck = await execFileNoThrow(
-		'gh',
+		await resolveFeedbackGhCommand(),
 		['api', 'repos/RunMaestro/Maestro/labels/Maestro-feedback'],
 		undefined,
 		getExpandedEnv()
@@ -354,7 +377,7 @@ async function ensureFeedbackLabel(): Promise<void> {
 	}
 
 	const labelCreate = await execFileNoThrow(
-		'gh',
+		await resolveFeedbackGhCommand(),
 		[
 			'label',
 			'create',
@@ -472,20 +495,22 @@ export function registerFeedbackHandlers(_deps: FeedbackHandlerDependencies): vo
 					return { authenticated: true };
 				}
 
-				// Check if gh is installed
-				const installed = await isGhInstalled();
+				// Check if gh is installed. A configured custom path is authoritative:
+				// it exists precisely for binaries that PATH lookup cannot find, so probe
+				// it directly rather than asking `which` about a name it will never see.
+				const ghCommand = await resolveFeedbackGhCommand();
+				const env = getExpandedEnv();
+				const installed =
+					ghCommand === 'gh'
+						? await isGhInstalled()
+						: (await execFileNoThrow(ghCommand, ['--version'], undefined, env)).exitCode === 0;
 				if (!installed) {
 					setCachedGhStatus(false, false);
 					return { authenticated: false, message: GH_NOT_INSTALLED_MESSAGE };
 				}
 
 				// Check auth status (command output ignored; exit code is the signal)
-				const authResult = await execFileNoThrow(
-					'gh',
-					['auth', 'status'],
-					undefined,
-					getExpandedEnv()
-				);
+				const authResult = await execFileNoThrow(ghCommand, ['auth', 'status'], undefined, env);
 				const authenticated = authResult.exitCode === 0;
 				setCachedGhStatus(true, authenticated);
 
@@ -593,7 +618,7 @@ export function registerFeedbackHandlers(_deps: FeedbackHandlerDependencies): vo
 
 				const searchPromises = searchQueries.map(async (q) => {
 					const result = await execFileNoThrow(
-						'gh',
+						await resolveFeedbackGhCommand(),
 						[
 							'search',
 							'issues',
@@ -658,7 +683,7 @@ export function registerFeedbackHandlers(_deps: FeedbackHandlerDependencies): vo
 
 				// Add a +1 reaction to show interest
 				await execFileNoThrow(
-					'gh',
+					await resolveFeedbackGhCommand(),
 					[
 						'api',
 						`repos/RunMaestro/Maestro/issues/${issueNumber}/reactions`,
@@ -674,7 +699,7 @@ export function registerFeedbackHandlers(_deps: FeedbackHandlerDependencies): vo
 				// Add a comment if provided
 				if (comment && comment.trim()) {
 					const commentResult = await execFileNoThrow(
-						'gh',
+						await resolveFeedbackGhCommand(),
 						[
 							'issue',
 							'comment',
@@ -802,7 +827,7 @@ export function registerFeedbackHandlers(_deps: FeedbackHandlerDependencies): vo
 					'utf8'
 				);
 				const issueCreate = await execFileNoThrow(
-					'gh',
+					await resolveFeedbackGhCommand(),
 					[
 						'issue',
 						'create',
@@ -980,7 +1005,7 @@ export function registerFeedbackHandlers(_deps: FeedbackHandlerDependencies): vo
 								'utf8'
 							);
 							const uploadResult = await execFileNoThrow(
-								'gh',
+								await resolveFeedbackGhCommand(),
 								[
 									'api',
 									`repos/${owner}/${ATTACHMENTS_REPO}/contents/${repoPath}`,
@@ -1036,7 +1061,7 @@ export function registerFeedbackHandlers(_deps: FeedbackHandlerDependencies): vo
 
 				try {
 					const issueCreate = await execFileNoThrow(
-						'gh',
+						await resolveFeedbackGhCommand(),
 						[
 							'issue',
 							'create',

--- a/src/main/ipc/handlers/feedback.ts
+++ b/src/main/ipc/handlers/feedback.ts
@@ -22,6 +22,7 @@ import {
 } from '../../utils/cliDetection';
 import { execFileNoThrow } from '../../utils/execFile';
 import { getSettingsStore } from '../../stores/getters';
+import { isInitialized } from '../../stores/instances';
 import { generateDebugPackage, type DebugPackageDependencies } from '../../debug-package';
 import { captureException } from '../../utils/sentry';
 import type { MaestroCliManager } from '../../maestro-cli-manager';
@@ -223,15 +224,17 @@ function buildEnvironmentSummary(payload: FeedbackSubmitPayload): FeedbackEnviro
  * installs where gh is not on the expanded PATH.
  */
 async function resolveFeedbackGhCommand(): Promise<string> {
-	let customPath: string | undefined;
-	try {
-		const configured = getSettingsStore().get('ghPath');
-		customPath =
-			typeof configured === 'string' && configured.trim() ? configured.trim() : undefined;
-	} catch {
-		// Stores are not initialised in every context (unit tests, early startup).
-		// Auto-detection is the correct fallback there.
+	// Guard on the predicate rather than catching. The stores genuinely are not
+	// initialised in every context (unit tests, early startup), and falling back
+	// to auto-detection there is correct, but a blanket catch would also swallow
+	// a real store failure and silently run some other binary.
+	if (!isInitialized()) {
+		return resolveGhPath();
 	}
+
+	const configured = getSettingsStore().get('ghPath');
+	const customPath =
+		typeof configured === 'string' && configured.trim() ? configured.trim() : undefined;
 	return resolveGhPath(customPath);
 }
 

--- a/src/main/ipc/handlers/git.ts
+++ b/src/main/ipc/handlers/git.ts
@@ -13,7 +13,12 @@ import {
 	createIpcHandler,
 	CreateHandlerOptions,
 } from '../../utils/ipcHandler';
-import { resolveGhPath, getCachedGhStatus, setCachedGhStatus } from '../../utils/cliDetection';
+import {
+	resolveGhPath,
+	getCachedGhStatus,
+	setCachedGhStatus,
+	getExpandedEnv,
+} from '../../utils/cliDetection';
 import { getShellPath } from '../../runtime/getShellPath';
 import { captureMessage } from '../../utils/sentry';
 import { WINDOWS_LOCKED_SYSTEM_FILES } from '../../utils/watcher-ignore';
@@ -1273,8 +1278,14 @@ export function registerGitHandlers(_deps: GitHandlerDependencies): void {
 			const ghCommand = await resolveGhPath(ghPath);
 			logger.debug(`Checking gh CLI at: ${ghCommand}`, LOG_CONTEXT);
 
-			// Check if gh is installed by running gh --version
-			const versionResult = await execFileNoThrow(ghCommand, ['--version']);
+			// Check if gh is installed by running gh --version.
+			// The expanded env is required, not optional: gh is frequently a shim
+			// (asdf, mise, rbenv-style) that re-execs its parent tool, so it only runs
+			// if that parent is on PATH. A GUI-launched Electron process does not
+			// inherit the user's shell PATH, so probing without it reports a perfectly
+			// good install as missing.
+			const env = getExpandedEnv();
+			const versionResult = await execFileNoThrow(ghCommand, ['--version'], undefined, env);
 			if (versionResult.exitCode !== 0) {
 				logger.warn(
 					`gh CLI not found at ${ghCommand}: exit=${versionResult.exitCode}, stderr=${versionResult.stderr}`,
@@ -1287,7 +1298,7 @@ export function registerGitHandlers(_deps: GitHandlerDependencies): void {
 			logger.debug(`gh CLI found: ${versionResult.stdout.trim().split('\n')[0]}`, LOG_CONTEXT);
 
 			// Check if gh is authenticated by running gh auth status
-			const authResult = await execFileNoThrow(ghCommand, ['auth', 'status']);
+			const authResult = await execFileNoThrow(ghCommand, ['auth', 'status'], undefined, env);
 			const authenticated = authResult.exitCode === 0;
 			logger.debug(
 				`gh auth status: ${authenticated ? 'authenticated' : 'not authenticated'}`,
@@ -1942,7 +1953,10 @@ export function registerGitHandlers(_deps: GitHandlerDependencies): void {
 				}
 				args.push('-'); // Read from stdin
 
-				const gistResult = await execFileNoThrow(ghCommand, args, undefined, { input: content });
+				const gistResult = await execFileNoThrow(ghCommand, args, undefined, {
+					input: content,
+					env: getExpandedEnv(),
+				});
 
 				if (gistResult.exitCode !== 0) {
 					// Check if gh CLI is not installed

--- a/src/main/ipc/handlers/git.ts
+++ b/src/main/ipc/handlers/git.ts
@@ -1262,9 +1262,14 @@ export function registerGitHandlers(_deps: GitHandlerDependencies): void {
 	ipcMain.handle(
 		'git:checkGhCli',
 		withIpcErrorLogging(handlerOpts('checkGhCli'), async (ghPath?: string) => {
+			// Resolve gh CLI path (uses cached detection or custom path). This comes
+			// before the cache read because the cached verdict is keyed by the command
+			// it was reached against.
+			const ghCommand = await resolveGhPath(ghPath);
+
 			// Check cache first (skip if custom path provided)
 			if (!ghPath) {
-				const cached = getCachedGhStatus();
+				const cached = getCachedGhStatus(ghCommand);
 				if (cached !== null) {
 					logger.debug(
 						`Using cached gh CLI status: installed=${cached.installed}, authenticated=${cached.authenticated}`,
@@ -1274,8 +1279,6 @@ export function registerGitHandlers(_deps: GitHandlerDependencies): void {
 				}
 			}
 
-			// Resolve gh CLI path (uses cached detection or custom path)
-			const ghCommand = await resolveGhPath(ghPath);
 			logger.debug(`Checking gh CLI at: ${ghCommand}`, LOG_CONTEXT);
 
 			// Check if gh is installed by running gh --version.
@@ -1292,7 +1295,7 @@ export function registerGitHandlers(_deps: GitHandlerDependencies): void {
 					LOG_CONTEXT
 				);
 				const result = { installed: false, authenticated: false };
-				if (!ghPath) setCachedGhStatus(false, false);
+				if (!ghPath) setCachedGhStatus(ghCommand, false, false);
 				return result;
 			}
 			logger.debug(`gh CLI found: ${versionResult.stdout.trim().split('\n')[0]}`, LOG_CONTEXT);
@@ -1307,7 +1310,7 @@ export function registerGitHandlers(_deps: GitHandlerDependencies): void {
 
 			// Cache the result (only if not using custom path)
 			if (!ghPath) {
-				setCachedGhStatus(true, authenticated);
+				setCachedGhStatus(ghCommand, true, authenticated);
 			}
 
 			return { installed: true, authenticated };

--- a/src/main/ipc/handlers/persistence.ts
+++ b/src/main/ipc/handlers/persistence.ts
@@ -28,6 +28,7 @@ export type { MaestroSettings, SessionsData, GroupsData } from '../../stores/typ
 import type { MaestroSettings, SessionsData, GroupsData, StoredSession } from '../../stores/types';
 import type { Group, SessionCliActivity } from '../../../shared/types';
 import { relocateSessionImages, resolveToDataUrl } from '../../storage/session-image-store';
+import { clearGhCache } from '../../utils/cliDetection';
 
 /**
  * Shallow-compare cliActivity for the diff broadcast.
@@ -155,6 +156,14 @@ export function registerPersistenceHandlers(deps: PersistenceHandlerDependencies
 		logger.info(`Settings updated: ${key}`, 'Settings', { key, value });
 
 		notifyPeerWindows(event?.sender?.id);
+
+		// Pointing at a different gh binary invalidates every cached gh fact:
+		// detection, resolved path, and auth status were all reached against the
+		// old one. Without this the new path is ignored until the app restarts.
+		if (key === 'ghPath') {
+			clearGhCache();
+			logger.info('Cleared gh CLI detection cache after ghPath change', 'Settings');
+		}
 
 		const webServer = getWebServer();
 		// Broadcast theme changes to connected web clients

--- a/src/main/utils/cliDetection.ts
+++ b/src/main/utils/cliDetection.ts
@@ -103,24 +103,28 @@ export async function resolveGhPath(customPath?: string): Promise<string> {
  * Returns null if cache is empty or expired.
  */
 export function getCachedGhStatus(): { installed: boolean; authenticated: boolean } | null {
-	if (ghInstalledCache === null) {
+	if (ghInstalledCache === null || ghStatusCacheTime === null) {
 		return null;
 	}
 
-	// If not installed, we don't need to check TTL
+	// Every cached verdict expires, including a negative one. A failed probe is
+	// usually environmental rather than permanent (a shim that could not reach its
+	// parent tool, a PATH that had not been expanded yet), so a sticky
+	// "not installed" would keep gh unavailable for the rest of the app run with
+	// no way to recover short of a restart.
+	if (Date.now() - ghStatusCacheTime >= GH_STATUS_CACHE_TTL_MS) {
+		return null;
+	}
+
 	if (!ghInstalledCache) {
 		return { installed: false, authenticated: false };
 	}
 
-	// Check if authenticated cache is valid
-	if (ghAuthenticatedCache !== null && ghStatusCacheTime !== null) {
-		const age = Date.now() - ghStatusCacheTime;
-		if (age < GH_STATUS_CACHE_TTL_MS) {
-			return { installed: true, authenticated: ghAuthenticatedCache };
-		}
+	if (ghAuthenticatedCache === null) {
+		return null;
 	}
 
-	return null;
+	return { installed: true, authenticated: ghAuthenticatedCache };
 }
 
 /**
@@ -130,6 +134,18 @@ export function setCachedGhStatus(installed: boolean, authenticated: boolean): v
 	ghInstalledCache = installed;
 	ghAuthenticatedCache = authenticated;
 	ghStatusCacheTime = Date.now();
+}
+
+/**
+ * Clear every cached gh CLI fact: installed, resolved path, and auth status.
+ * Call this when the configured gh path changes so the next probe re-detects
+ * instead of answering from a verdict that was reached against the old binary.
+ */
+export function clearGhCache(): void {
+	ghInstalledCache = null;
+	ghPathCache = null;
+	ghAuthenticatedCache = null;
+	ghStatusCacheTime = null;
 }
 
 // SSH CLI detection cache

--- a/src/main/utils/cliDetection.ts
+++ b/src/main/utils/cliDetection.ts
@@ -113,6 +113,11 @@ export function getCachedGhStatus(): { installed: boolean; authenticated: boolea
 	// "not installed" would keep gh unavailable for the rest of the app run with
 	// no way to recover short of a restart.
 	if (Date.now() - ghStatusCacheTime >= GH_STATUS_CACHE_TTL_MS) {
+		// Drop the detection cache too, not just the verdict. isGhInstalled()
+		// returns early on any non-null ghInstalledCache, so leaving a stale
+		// `false` there would make the next lookup skip `which` entirely and
+		// answer from the very result that just expired.
+		clearGhCache();
 		return null;
 	}
 

--- a/src/main/utils/cliDetection.ts
+++ b/src/main/utils/cliDetection.ts
@@ -6,10 +6,21 @@ import { isWindows, getWhichCommand } from '../../shared/platformDetection';
 let cloudflaredInstalledCache: boolean | null = null;
 let cloudflaredPathCache: string | null = null;
 
+// PATH detection for gh: whether `which gh` found it, and where. Written only by
+// isGhInstalled(), so it always describes the PATH-resolved binary.
 let ghInstalledCache: boolean | null = null;
 let ghPathCache: string | null = null;
-let ghAuthenticatedCache: boolean | null = null;
-let ghStatusCacheTime: number | null = null;
+
+// The last installed/authenticated verdict, and the gh command it was reached
+// against. Kept apart from the detection cache above because callers probe
+// different binaries: most use the PATH-resolved gh, but Send Feedback honours a
+// configured custom path. A verdict about one binary says nothing about another.
+let ghStatusCache: {
+	command: string;
+	installed: boolean;
+	authenticated: boolean;
+	cachedAt: number;
+} | null = null;
 const GH_STATUS_CACHE_TTL_MS = 60000; // 1 minute TTL for auth status
 
 /**
@@ -99,11 +110,21 @@ export async function resolveGhPath(customPath?: string): Promise<string> {
 }
 
 /**
- * Get cached gh CLI status (installed + authenticated).
- * Returns null if cache is empty or expired.
+ * Get the cached gh CLI status (installed + authenticated) for one gh command.
+ *
+ * `command` is the resolved gh command the caller is about to run, i.e. the
+ * result of resolveGhPath(). A verdict reached against any other command is a
+ * cache miss: the PATH-resolved gh and a configured custom path are different
+ * binaries, and answering for one from the other is how a working install got
+ * reported as missing.
+ *
+ * Returns null if nothing is cached, the verdict has expired, or it was reached
+ * against a different command.
  */
-export function getCachedGhStatus(): { installed: boolean; authenticated: boolean } | null {
-	if (ghInstalledCache === null || ghStatusCacheTime === null) {
+export function getCachedGhStatus(
+	command: string
+): { installed: boolean; authenticated: boolean } | null {
+	if (ghStatusCache === null) {
 		return null;
 	}
 
@@ -112,7 +133,7 @@ export function getCachedGhStatus(): { installed: boolean; authenticated: boolea
 	// parent tool, a PATH that had not been expanded yet), so a sticky
 	// "not installed" would keep gh unavailable for the rest of the app run with
 	// no way to recover short of a restart.
-	if (Date.now() - ghStatusCacheTime >= GH_STATUS_CACHE_TTL_MS) {
+	if (Date.now() - ghStatusCache.cachedAt >= GH_STATUS_CACHE_TTL_MS) {
 		// Drop the detection cache too, not just the verdict. isGhInstalled()
 		// returns early on any non-null ghInstalledCache, so leaving a stale
 		// `false` there would make the next lookup skip `which` entirely and
@@ -121,24 +142,23 @@ export function getCachedGhStatus(): { installed: boolean; authenticated: boolea
 		return null;
 	}
 
-	if (!ghInstalledCache) {
-		return { installed: false, authenticated: false };
-	}
-
-	if (ghAuthenticatedCache === null) {
+	if (ghStatusCache.command !== command) {
 		return null;
 	}
 
-	return { installed: true, authenticated: ghAuthenticatedCache };
+	return { installed: ghStatusCache.installed, authenticated: ghStatusCache.authenticated };
 }
 
 /**
- * Set cached gh CLI status.
+ * Cache the gh CLI status reached by probing `command`, the resolved gh
+ * command. Replaces any verdict cached for a different command.
  */
-export function setCachedGhStatus(installed: boolean, authenticated: boolean): void {
-	ghInstalledCache = installed;
-	ghAuthenticatedCache = authenticated;
-	ghStatusCacheTime = Date.now();
+export function setCachedGhStatus(
+	command: string,
+	installed: boolean,
+	authenticated: boolean
+): void {
+	ghStatusCache = { command, installed, authenticated, cachedAt: Date.now() };
 }
 
 /**
@@ -149,8 +169,7 @@ export function setCachedGhStatus(installed: boolean, authenticated: boolean): v
 export function clearGhCache(): void {
 	ghInstalledCache = null;
 	ghPathCache = null;
-	ghAuthenticatedCache = null;
-	ghStatusCacheTime = null;
+	ghStatusCache = null;
 }
 
 // SSH CLI detection cache


### PR DESCRIPTION
Fixes #1545

## The symptom

Send Feedback reports "GitHub CLI Required / gh is not installed" on a machine where `gh` is installed, authenticated, and working. Auto Run's Create PR on the same machine works fine.

Reproduced on macOS with `gh` installed via asdf (`~/.asdf/shims/gh`, github-cli 2.83.2), with Settings > GitHub CLI (gh) Path pointed at the binary. Two independent defects combine to produce it, and both are reachable by anyone whose `gh` is a wrapper or shim that needs its parent tool on `PATH` (asdf, mise, rbenv-style shims, some Nix and Homebrew wrappers).

## Defect 1: the startup probe drops the expanded PATH, then poisons a sticky cache

`useAppInitialization.ts:125` calls `git.checkGhCli()` with no `ghPath` at app start. In `git.ts`, `resolveGhPath()` locates the shim correctly, because `isGhInstalled()` runs `which` with `getExpandedEnv()`. The `--version` probe on the next line passed no env at all, so the child inherited the GUI-launched Electron `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`).

An asdf shim is a bash script ending in `exec asdf exec "gh" "$@"`, so it dies there:

```
$ env -i HOME=$HOME PATH=/usr/bin:/bin ~/.asdf/shims/gh --version
~/.asdf/shims/gh: line 3: exec: asdf: not found

$ env -i HOME=$HOME PATH=~/.asdf/shims:/opt/homebrew/bin:/usr/bin:/bin gh --version
gh version 2.83.2 (2025-12-10)
```

That failed verdict was then cached and never expired. `getCachedGhStatus()` returned early on a negative result, before the TTL check, so one bad probe at startup made `gh` unavailable for the rest of the app run with no recovery short of a restart. The 60s `GH_STATUS_CACHE_TTL_MS` only ever applied to the positive case.

The sibling call sites already did this correctly (`isGhInstalled()` and `symphony.ts`); `git.ts` was the outlier, in both its `--version` and `auth status` probes. `createGist` had the same omission one function down.

## Defect 2: the feedback handler ignored the configured gh path

Every `gh` invocation in `feedback.ts` hardcoded the bare string `'gh'` (13 call sites), so Settings > GitHub CLI (gh) Path was silently ignored there. It also read the poisoned cache first, inheriting Defect 1 verbatim.

This is precisely why Create PR worked while Feedback did not: `createPR` threads the setting through, and passing a custom path also happens to skip the cache.

## The fix

- `git.ts`: both `checkGhCli` probes now pass `getExpandedEnv()`. `createGist` too.
- `cliDetection.ts`: the TTL now applies to negative verdicts as well. A failed probe is usually environmental rather than permanent, so it self-heals instead of persisting. Adds `clearGhCache()`.
- `feedback.ts`: new `resolveFeedbackGhCommand()` reads `settings.ghPath` and resolves through `resolveGhPath()`; all 13 call sites use it. A configured path is treated as authoritative and probed directly rather than handed to `which`, since it exists precisely for binaries a `PATH` lookup will never find. A whitespace-only setting still means "unset".
- `persistence.ts`: changing `ghPath` clears the cache, so the new path applies without a restart.

## Testing

- `npm run lint`: 0 errors
- `npm run lint:eslint`: 0 errors
- `npm test`: 37,018 passed, 110 skipped, 0 failed

Adds 8 regression tests: negative-cache expiry in `cliDetection.test.ts`, and custom-path handling plus the whitespace-means-unset fallback in `feedback.test.ts`. Four existing `checkGhCli` assertions encoded the old two-argument call shape and now require the environment, which is what makes them catch a regression.

Not yet verified by launching the app end to end; the diagnosis and fix were confirmed against the shim's actual behavior from the shell, as shown above.

## Note for `rc`

`rc` carries both defects, but `git.ts` was split into a directory there, so this patch will not cherry-pick cleanly. The equivalent lines are `src/main/ipc/handlers/git/github.ts:109` (`--version`), `:122` (`auth status`), and `:166` (`createGist`). `cliDetection.ts` and `feedback.ts` are in the same place on both branches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub CLI operations now support a configured custom executable path.
  * GitHub CLI detection works more reliably in desktop-launched environments, including PATH-based shims.
* **Bug Fixes**
  * GitHub CLI status results are now tracked per executable path and refresh correctly after expiration.
  * Updating the configured GitHub CLI path immediately refreshes detection results.
  * Authentication checks validate configured custom paths directly and handle blank settings correctly.
  * GitHub CLI-powered gist creation and feedback actions now work reliably with expanded environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->