### PR TITLE
docs: explain per-agent environment variables and how Auto Run uses them

### DIFF
--- a/docs/autorun-playbooks.md
+++ b/docs/autorun-playbooks.md
@@ -167,6 +167,42 @@ This isolation is critical for playbooks with `Reset on Completion` documents th
 
 ## Environment Variables
 
+### Where a Run's Environment Comes From
+
+An Auto Run inherits the environment of **the agent it executes against**. There is no run-scoped environment: a run does not get its own variables, and the document being run cannot set any.
+
+That matters because of where the variables actually live:
+
+| To change...             | Set it here                                                                                                   |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| Every agent and terminal | **Settings → Environment** (see [Global Environment Variables](./configuration#global-environment-variables)) |
+| One agent only           | That agent's **Environment Variables (optional)** panel, in **Edit Agent** or the Create New Agent dialog     |
+
+Both are documented in [Configuration → Per-Agent Environment Variables](./configuration#per-agent-environment-variables), including the precedence between them and how to inspect the merged result.
+
+Two things Auto Run specifically does **not** give you:
+
+- **A playbook or task document cannot set environment variables.** Frontmatter in an Auto Run document is rendered as a table for you to read, never interpreted. The only in-document directives Maestro acts on are the [HITL gate](#human-in-the-loop-gates), the [halt marker](#halt-marker-agent-early-exit), and the [model and effort markers](#model-tier-and-effort) - there is no `MAESTRO:ENV` equivalent.
+- **The CLI has no per-run environment flag.** `maestro-cli playbook`, `run-doc`, `auto-run`, and `goal-run` take `--model` and `--effort` as run-scoped overrides, but no `--env`. The `--env` flag exists only on `create-agent` and `update-agent`, where it edits the agent record itself and therefore affects every later run on that agent.
+
+So if a run needs different variables, change the agent it runs against, or point the run at a different agent.
+
+### Which Agent a Run Executes Against
+
+By default an Auto Run executes against the **currently active agent**, so it picks up that agent's variables.
+
+The run configuration modal can redirect it. Under [Dispatch to a separate worktree](#run-in-worktree), the dropdown chooses a worktree target, and each option has different consequences for your environment:
+
+| Option                  | Environment the run gets                                                                                                                             |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Open in Maestro**     | An agent already open in Maestro. It runs with **that agent's own variables**, so this is the way to run one document under a different environment. |
+| **Available Worktrees** | A new agent, which **inherits the current agent's variables** verbatim                                                                               |
+| **Create New Worktree** | A new agent, which **inherits the current agent's variables** verbatim                                                                               |
+
+The distinction is easy to miss: creating a worktree does not give you a blank agent to configure. Maestro copies the parent agent's variables (along with its provider, model, and custom arguments) onto the new one, and the worktree dialog has no environment field. If you need a worktree run under a different environment, create the worktree agent first, edit its variables in **Edit Agent**, then dispatch to it with **Open in Maestro**.
+
+### Variables Maestro Sets For You
+
 Maestro sets environment variables that your agent hooks can use to customize behavior:
 
 | Variable                  | Value | Description                                                      |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,14 +147,16 @@ MY_TOOL_PATH=~/tools/custom
 
 ### Environment Variable Precedence
 
-When an agent or terminal is spawned, variables are merged in this order (highest to lowest priority):
+When an agent or terminal is spawned, the layers are merged in this order (lowest to highest priority). Each layer overrides the one before it:
 
-1. **Session-level overrides** - Temporary per-session customizations
-2. **Global environment variables** (Settings) - Applied to all agents and terminals
-3. **Agent-specific configuration** - Default settings for a particular agent
-4. **System environment** - System and parent process variables
+1. **System environment** - System and parent process variables Maestro inherits
+2. **Global environment variables** (Settings → Environment) - Applied to all agents and terminals
+3. **Provider-level configuration** - Defaults stored for a particular provider (Claude Code, Codex, and so on)
+4. **Per-agent variables** - The values on one agent's own record, set in the **Environment Variables (optional)** panel
 
-This means a session-level override will take precedence over the global setting, which takes precedence over agent defaults.
+So an agent's own value wins over a provider default, which wins over the global setting, which wins over whatever Maestro inherited from the system.
+
+In practice you set layers 2 and 4. Layer 3 is honored when present but has no editor in the current UI, so unless you have older settings carrying provider-level values, the effective order is simply: per-agent beats global beats system.
 
 ### Use Cases
 
@@ -164,13 +166,38 @@ This means a session-level override will take precedence over the global setting
 - **Debugging**: Set `DEBUG=maestro:*` → enable consistent logging across all sessions
 - **Language settings**: Set `LANG=en_US.UTF-8` → consistent text encoding
 
-### Agent-Specific Overrides
+### Per-Agent Environment Variables
 
-To override a global variable for a specific agent:
+Any one agent can carry its own variables, which override the global ones for that agent only. Use this when a single agent needs a different API key, a different base URL, or a tool path the rest of your agents should not see.
 
-1. In the agent configuration panel, scroll to **Environment Variables (optional)**
-2. Add the variable with the override value
-3. This session-specific value takes precedence over the global setting
+The panel is labeled **Environment Variables (optional)** and it appears in two places:
+
+- **When creating the agent** - in the **Create New Agent** dialog, below Working Directory.
+- **At any time afterwards** - open **Edit Agent** and scroll to the same panel. You do not have to recreate an agent to change its variables.
+
+Three ways to reach Edit Agent:
+
+| Route         | How                                                |
+| ------------- | -------------------------------------------------- |
+| Keyboard      | `Alt+Cmd+,` / `Alt+Ctrl+,` with the agent selected |
+| Left Bar      | Right-click the agent → **Edit Agent**             |
+| Quick Actions | `Cmd+K` / `Ctrl+K` → "Edit Agent"                  |
+
+You can also set them from the CLI without opening the app:
+
+```bash
+maestro-cli update-agent <agent-id> --env MY_KEY=value
+maestro-cli create-agent "Reviewer" --env ANTHROPIC_BASE_URL=https://proxy.internal
+maestro-cli update-agent <agent-id> --clear-env   # remove all per-agent variables
+```
+
+The eye button parks a variable here too: the row keeps its key and value and stays editable, but the variable is not passed to the agent. Parked variables are stored separately and are never merged into a spawned process.
+
+### Seeing What an Agent Actually Runs With
+
+Because the layers are edited in different places, no single screen shows the result. To see the merged environment for one agent, open **Quick Actions** (`Cmd+K` / `Ctrl+K`) and run **Re-authenticate Provider** for that agent, then expand the **Environment for &lt;agent&gt;** section. It lists one row per variable, badged with the layer whose value won.
+
+This is the quickest way to catch the case where an agent behaves oddly because an `ANTHROPIC_BASE_URL` or API key from a layer you forgot about is overriding the one you just set. Values that look like credentials are masked until you click the eye on that row.
 
 ## Checking for Updates
 


### PR DESCRIPTION
Closes #1548

## What prompted this

@MikeTheCanuck had to read the source to work out where an agent's environment variables are set and how a Playbook run picks them up. Digging into it turned up that the docs were not just thin here, they were wrong in one place.

## What was wrong

**`docs/configuration.md` had the precedence backwards.** It listed global environment variables as outranking agent-specific configuration. The spawner merges `global -> provider -> per-agent` with later winning, so an agent's own value actually beats the global one. The page also contradicted itself: the numbered list said global wins, and the section three paragraphs below said the agent value wins.

It also only said "in the agent configuration panel", never mentioning that **Edit Agent** can change these after creation. That is the specific thing the issue reports having to derive from source.

**`docs/autorun-playbooks.md` already had an "Environment Variables" section**, but it only documented variables Maestro *sets for you* (`MAESTRO_SESSION_RESUMED`). Anyone searching the Auto Run docs for how to set their *own* landed there and found nothing relevant.

## What this adds

`configuration.md`:
- Corrected precedence, stated lowest-to-highest so "each layer overrides the previous" matches the code comment in `process.ts`.
- Renamed the trailing section to **Per-Agent Environment Variables** and made it concrete: the panel appears both in Create New Agent and in Edit Agent, with the three routes to Edit Agent (`Alt+Cmd+,`, right-click in the Left Bar, Quick Actions), plus the `maestro-cli create-agent/update-agent --env` route.
- A short **Seeing What an Agent Actually Runs With** section pointing at the merged-environment view in the re-auth dialog, which is currently the only place that answers "which layer won?".

`autorun-playbooks.md`:
- **Where a Run's Environment Comes From** - a run inherits the target agent's environment; there is no run-scoped environment.
- States the two negatives explicitly, since both cost time to discover: a playbook/task document cannot set variables (frontmatter is rendered, never interpreted, and there is no `MAESTRO:ENV` marker), and no run command takes `--env` (`--env` exists only on `create-agent`/`update-agent`).
- **Which Agent a Run Executes Against**, including what each worktree dispatch option means for the environment.

## One correction to the issue's findings

The issue suggests worktree dispatch as the way to run a document under different env vars. That does not work as expected: `buildWorktreeSession` copies `customEnvVars` from the parent, so **Create New Worktree** and **Available Worktrees** produce an agent with the *same* variables and offer no field to change them. Only **Open in Maestro**, which targets an already-open agent, runs under a different environment. The new table spells this out, since assuming a fresh worktree agent starts blank is an easy and quiet mistake.

## Notes

- Docs only, no code changes.
- `npm run docs:verify` passes (319 asserted paths, 0 missing); prettier clean; all new anchors resolve.
- Out of scope but worth flagging: `docs/env-vars.md` exists but is absent from `docs/docs.json`, so it does not render on the docs site. It reads as an internal architecture doc (IPC handlers, testing strategy, file tables) rather than user documentation, so it probably belongs under `docs/agent-guides/` rather than in the public nav. Its line about a "Settings -> Agents" tab is also stale, as are the same references in `src/shared/agentEnvironment.ts` and a few agent guides. Left alone here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded Auto Run and Playbooks guidance on environment inheritance, agent selection, worktree behavior, and variables provided to agent hooks.
  - Clarified that playbooks and task documents cannot define environment variables, and the CLI does not support per-run environment flags.
  - Documented environment-variable precedence across system, global, provider, and per-agent settings.
  - Added guidance for configuring, editing, inspecting, parking, and masking per-agent environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->