### PR TITLE
fix(cli): repair Windows installer PATH update

### DIFF
--- a/src/__tests__/main/maestro-cli-manager.test.ts
+++ b/src/__tests__/main/maestro-cli-manager.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockExecFileNoThrow } = vi.hoisted(() => ({
+	mockExecFileNoThrow: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+	app: {
+		getAppPath: vi.fn().mockReturnValue('/mock/app'),
+		getVersion: vi.fn().mockReturnValue('0.17.4'),
+	},
+}));
+
+vi.mock('../../main/utils/execFile', () => ({
+	execFileNoThrow: mockExecFileNoThrow,
+}));
+
+vi.mock('../../shared/platformDetection', () => ({
+	getWhichCommand: vi.fn().mockReturnValue('where'),
+	isWindows: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('../../main/utils/logger', () => ({
+	logger: {
+		debug: vi.fn(),
+		error: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+	},
+}));
+
+import { MaestroCliManager, normalizeVersion } from '../../main/maestro-cli-manager';
+
+describe('MaestroCliManager', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockExecFileNoThrow.mockResolvedValue({
+			exitCode: 0,
+			stderr: '',
+			stdout: '',
+		});
+	});
+
+	describe('normalizeVersion', () => {
+		it('finds a version line after incidental logger output', () => {
+			expect(
+				normalizeVersion(
+					'[Logger] File logging enabled: C:\\logs\\maestro-debug-2026-09-10.log\r\n0.17.4\r\n'
+				)
+			).toBe('0.17.4');
+		});
+
+		it('normalizes an exact v-prefixed prerelease', () => {
+			expect(normalizeVersion('v0.18.0-rc.1\n')).toBe('0.18.0-rc.1');
+		});
+	});
+
+	it('updates the Windows user PATH with PowerShell directly and valid block syntax', async () => {
+		const manager = new MaestroCliManager();
+		const ensureWindowsUserPath = (
+			manager as unknown as {
+				ensureWindowsUserPath(installDir: string): Promise<boolean>;
+			}
+		).ensureWindowsUserPath.bind(manager);
+
+		await expect(ensureWindowsUserPath("C:\\Users\\O'Brien\\.local\\bin")).resolves.toBe(true);
+
+		expect(mockExecFileNoThrow).toHaveBeenCalledOnce();
+		const [command, args] = mockExecFileNoThrow.mock.calls[0] as [string, string[]];
+		expect(command).toBe('powershell.exe');
+		expect(args.slice(0, 3)).toEqual(['-NoProfile', '-NonInteractive', '-Command']);
+
+		const script = args[3];
+		expect(script).toContain("$installDir = 'C:\\Users\\O''Brien\\.local\\bin'");
+		expect(script).toContain('if ($parts -notcontains $installDir) {\n');
+		expect(script).not.toContain('{;');
+	});
+});

--- a/src/__tests__/main/utils/logger.test.ts
+++ b/src/__tests__/main/utils/logger.test.ts
@@ -3,8 +3,12 @@ import * as os from 'os';
 import * as path from 'path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
+const { mockIsWindows } = vi.hoisted(() => ({
+	mockIsWindows: vi.fn().mockReturnValue(false),
+}));
+
 vi.mock('../../../shared/platformDetection', () => ({
-	isWindows: () => false,
+	isWindows: mockIsWindows,
 	isMacOS: () => false,
 	isLinux: () => true,
 }));
@@ -45,6 +49,7 @@ describe('Logger', () => {
 	let consoleLogSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(async () => {
+		mockIsWindows.mockReturnValue(false);
 		originalAppData = process.env.APPDATA;
 		originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
 		testConfigRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-logger-test-'));
@@ -91,6 +96,17 @@ describe('Logger', () => {
 			fs.rmSync(testConfigRoot, { recursive: true, force: true });
 			testConfigRoot = '';
 		}
+	});
+
+	describe('Platform defaults', () => {
+		it('does not enable desktop file logging in a Windows CLI process', async () => {
+			mockIsWindows.mockReturnValue(true);
+			expect(process.type).toBeUndefined();
+
+			const cliLogger = await getLogger();
+
+			expect(cliLogger.isFileLoggingEnabled()).toBe(false);
+		});
 	});
 
 	describe('Log Level Management', () => {

--- a/src/main/maestro-cli-manager.ts
+++ b/src/main/maestro-cli-manager.ts
@@ -12,8 +12,12 @@ import type { MaestroCliStatus, MaestroCliInstallResult } from '../shared/maestr
 const CLI_BINARY_NAME = 'maestro-cli';
 const LOG_CONTEXT = 'MaestroCliManager';
 
-function normalizeVersion(raw: string): string {
-	const firstLine = raw.trim().split(/\r?\n/)[0] || '';
+export function normalizeVersion(raw: string): string {
+	const lines = splitOutputLines(raw);
+	const exactVersionLine = lines.find((line) => /^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(line));
+	if (exactVersionLine) return exactVersionLine.replace(/^v/i, '');
+
+	const firstLine = lines[0] || '';
 	const semverMatch = firstLine.match(/(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)/);
 	return semverMatch?.[1] || firstLine.replace(/^v/i, '').trim();
 }
@@ -233,9 +237,11 @@ export class MaestroCliManager {
 			"  $newPath = (($parts + $installDir) | Select-Object -Unique) -join ';'",
 			"  [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')",
 			'}',
-		].join('; ');
+		].join('\n');
 
-		const result = await execFileNoThrow('powershell', [
+		// Use the executable name so execFileNoThrow does not route the command
+		// through cmd.exe, which would reinterpret PowerShell's pipe characters.
+		const result = await execFileNoThrow('powershell.exe', [
 			'-NoProfile',
 			'-NonInteractive',
 			'-Command',

--- a/src/main/utils/logger.ts
+++ b/src/main/utils/logger.ts
@@ -76,9 +76,11 @@ class Logger extends EventEmitter {
 		this.logFilePath = getLogFilePath();
 		this.currentLogDate = getTodayDateString();
 
-		// Enable file logging on Windows by default for debugging
-		// Users can also enable it on other platforms via enableFileLogging()
-		if (isWindows()) {
+		// Enable file logging in the Windows desktop main process by default.
+		// CLI bundles also import this module, but process.type is undefined when
+		// Electron runs as Node; initializing the desktop logger there pollutes
+		// command output such as `maestro-cli --version`.
+		if (isWindows() && process.type === 'browser') {
 			this.enableFileLogging();
 		}
 	}


### PR DESCRIPTION
## Summary

- execute `powershell.exe` directly so `cmd.exe` cannot reinterpret the PATH update script
- preserve PowerShell block syntax by joining statements with newlines
- keep Windows desktop file logging out of CLI processes and tolerate incidental output when parsing the CLI version
- add regression coverage for the malformed `{;` script and logger-prefixed version output seen on Windows

## Testing

- `npm run lint`
- `npm run lint:eslint`
- `npm test -- --run src/__tests__/main/maestro-cli-manager.test.ts src/__tests__/main/utils/logger.test.ts` (84 passed)
- verified `ELECTRON_RUN_AS_NODE=1` leaves `process.type` undefined

## Baseline notes

- `npm run format:check:all` currently reports 63 pre-existing formatting violations on `main`; all files changed by this PR pass Prettier.
- A full `npm test` run was stopped after unrelated baseline failures appeared, including stale `lucide-react` test mocks and a missing local native `better-sqlite3` binding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version detection when command output includes logging prefixes or prerelease versions.
  * Improved Windows PATH updates by ensuring PowerShell commands execute correctly, including paths containing apostrophes.
  * Prevented command-line processes from unnecessarily enabling desktop file logging.
* **Tests**
  * Expanded coverage for version parsing, Windows PATH handling, platform-specific logging, and command execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->