### PR TITLE
fix(context): one context surface at a time, and the timeline closes on hover-out

### DIFF
--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -142,6 +142,8 @@ Messages and Duration are the same figures the [HTML export](#tab-export) prints
 
 The same two figures appear in `maestro-cli sessions <agent-id>` for every session Maestro has a tab for.
 
+Click the gauge to swap Context Details for the **Context Timeline**, a turn-by-turn record of how the context window filled. The Timeline opens in the space the popover held and closes as soon as you move the pointer off it, or when you click the gauge again or press `Esc`. The two never show at the same time. Drag an edge to resize the Timeline: the size is remembered for every agent and across restarts, and double-clicking an edge resets it.
+
 ## Compact & Continue
 
 When your conversation approaches context limits, you can compress it while preserving essential information:

--- a/src/__tests__/renderer/components/ContextTimelinePanel.test.tsx
+++ b/src/__tests__/renderer/components/ContextTimelinePanel.test.tsx
@@ -12,14 +12,17 @@
  */
 
 import React from 'react';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { ContextTimelinePanel } from '../../../renderer/components/ContextTimelinePanel';
 import { LayerStackProvider } from '../../../renderer/contexts/LayerStackContext';
 import {
 	useContextTimelineStore,
+	CONTEXT_SURFACE_CLOSE_DELAY_MS,
+	CONTEXT_SURFACE_WIDTH,
 	type ContextTimelinePointInput,
 } from '../../../renderer/stores/contextTimelineStore';
+import { useSettingsStore } from '../../../renderer/stores/settingsStore';
 import { computeOverLimitDisplay } from '../../../renderer/utils/contextUsage';
 import type { Theme } from '../../../renderer/types';
 
@@ -76,6 +79,7 @@ function reset() {
 		minimized: false,
 		view: 'bar',
 		anchorRect: null,
+		sourceSize: null,
 		buffers: {},
 	});
 }
@@ -385,5 +389,133 @@ describe('ContextTimelinePanel view toggle and empty state', () => {
 		expect(screen.getByTestId('timeline-graph-readout')).toHaveTextContent('75% · 150.0K / 200.0K');
 		fireEvent.mouseEnter(screen.getAllByTestId('timeline-graph-hit')[0]);
 		expect(screen.getByTestId('timeline-graph-readout')).toHaveTextContent('50% · 100.0K / 200.0K');
+	});
+});
+
+describe('ContextTimelinePanel size and hover-dismiss', () => {
+	beforeEach(() => {
+		reset();
+		useSettingsStore.setState({ modalSizes: {} });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		document.querySelectorAll('[data-testid="header-context-widget"]').forEach((el) => el.remove());
+	});
+
+	function panelElement(): HTMLElement {
+		return document.querySelector('[data-modal-resize-key="context-timeline"]') as HTMLElement;
+	}
+
+	function advance(ms: number) {
+		act(() => {
+			vi.advanceTimersByTime(ms);
+		});
+	}
+
+	const panelSessionId = () => useContextTimelineStore.getState().panelSessionId;
+
+	it('opens at the size of the Context Details popover the click replaced', () => {
+		useContextTimelineStore.getState().openPanel(SID, null, { width: 432, height: 511 });
+		renderPanel();
+		expect(panelElement().style.width).toBe('432px');
+		expect(panelElement().style.height).toBe('511px');
+	});
+
+	it('falls back to the shared surface width when nothing was measured', () => {
+		useContextTimelineStore.getState().openPanel(SID);
+		renderPanel();
+		expect(panelElement().style.width).toBe(`${CONTEXT_SURFACE_WIDTH}px`);
+	});
+
+	it('keeps a size the user dragged over the measured popover size', () => {
+		useSettingsStore.setState({ modalSizes: { 'context-timeline': { width: 700, height: 400 } } });
+		useContextTimelineStore.getState().openPanel(SID, null, { width: 432, height: 511 });
+		renderPanel();
+		expect(panelElement().style.width).toBe('700px');
+		expect(panelElement().style.height).toBe('400px');
+	});
+
+	it('closes once the pointer leaves it, after the grace period', () => {
+		vi.useFakeTimers();
+		useContextTimelineStore.getState().openPanel(SID);
+		renderPanel();
+
+		fireEvent.mouseOver(panelElement());
+		fireEvent.mouseOver(document.body);
+		advance(CONTEXT_SURFACE_CLOSE_DELAY_MS - 1);
+		expect(panelSessionId()).toBe(SID);
+
+		advance(1);
+		expect(panelSessionId()).toBeNull();
+	});
+
+	it('stays open when the pointer comes back within the grace period', () => {
+		vi.useFakeTimers();
+		useContextTimelineStore.getState().openPanel(SID);
+		renderPanel();
+
+		fireEvent.mouseOver(panelElement());
+		fireEvent.mouseOver(document.body);
+		advance(CONTEXT_SURFACE_CLOSE_DELAY_MS / 2);
+		fireEvent.mouseOver(panelElement());
+		advance(CONTEXT_SURFACE_CLOSE_DELAY_MS * 4);
+		expect(panelSessionId()).toBe(SID);
+	});
+
+	it('treats the gauge that opened it as part of the panel', () => {
+		vi.useFakeTimers();
+		const gauge = document.createElement('div');
+		gauge.setAttribute('data-testid', 'header-context-widget');
+		document.body.appendChild(gauge);
+		useContextTimelineStore.getState().openPanel(SID);
+		renderPanel();
+
+		fireEvent.mouseOver(panelElement());
+		fireEvent.mouseOver(gauge);
+		advance(CONTEXT_SURFACE_CLOSE_DELAY_MS * 4);
+		expect(panelSessionId()).toBe(SID);
+	});
+
+	it('does not close for a pointer that was never over it (keyboard open)', () => {
+		vi.useFakeTimers();
+		useContextTimelineStore.getState().openPanel(SID);
+		renderPanel();
+
+		fireEvent.mouseOver(document.body);
+		advance(CONTEXT_SURFACE_CLOSE_DELAY_MS * 4);
+		expect(panelSessionId()).toBe(SID);
+	});
+
+	it('closes when the pointer leaves the window', () => {
+		vi.useFakeTimers();
+		useContextTimelineStore.getState().openPanel(SID);
+		renderPanel();
+
+		fireEvent.mouseOver(panelElement());
+		fireEvent.mouseOut(panelElement(), { relatedTarget: null });
+		advance(CONTEXT_SURFACE_CLOSE_DELAY_MS);
+		expect(panelSessionId()).toBeNull();
+	});
+
+	it('holds open through a resize drag, then closes if the drag ended outside', () => {
+		vi.useFakeTimers();
+		useContextTimelineStore.getState().openPanel(SID);
+		renderPanel();
+
+		fireEvent.mouseOver(panelElement());
+		fireEvent.mouseDown(screen.getByTestId('modal-resize-handle-e'), {
+			clientX: 400,
+			clientY: 100,
+		});
+		// Growing the panel drags the pointer well outside it.
+		fireEvent.mouseOver(document.body);
+		fireEvent.mouseMove(document.body, { clientX: 900, clientY: 100 });
+		advance(CONTEXT_SURFACE_CLOSE_DELAY_MS * 4);
+		expect(panelSessionId()).toBe(SID);
+
+		fireEvent.mouseUp(document);
+		advance(CONTEXT_SURFACE_CLOSE_DELAY_MS);
+		expect(panelSessionId()).toBeNull();
 	});
 });

--- a/src/__tests__/renderer/components/MainPanel.test.tsx
+++ b/src/__tests__/renderer/components/MainPanel.test.tsx
@@ -14,6 +14,7 @@ import { useUIStore } from '../../../renderer/stores/uiStore';
 import { useCenterFlashStore } from '../../../renderer/stores/centerFlashStore';
 import { useSettingsStore } from '../../../renderer/stores/settingsStore';
 import { useSessionStore } from '../../../renderer/stores/sessionStore';
+import { useContextTimelineStore } from '../../../renderer/stores/contextTimelineStore';
 import { WindowProvider } from '../../../renderer/contexts/WindowContext';
 import type { WindowState } from '../../../shared/window-types';
 import {
@@ -2074,6 +2075,64 @@ describe('MainPanel', () => {
 
 			// Tooltip should still be visible
 			expect(screen.getByText('Context Details')).toBeInTheDocument();
+		});
+
+		it('should hide Context Details while the Context Timeline is open', async () => {
+			renderMainPanel();
+
+			fireEvent.mouseEnter(screen.getByTestId('header-context-widget'));
+			await waitFor(() => {
+				expect(screen.getByText('Context Details')).toBeInTheDocument();
+			});
+
+			try {
+				// The two surfaces share one spot under the gauge, so an open timeline
+				// wins over a hover that is still in progress.
+				act(() => {
+					useContextTimelineStore.getState().openPanel('any-agent');
+				});
+				expect(screen.queryByText('Context Details')).not.toBeInTheDocument();
+			} finally {
+				act(() => {
+					useContextTimelineStore.getState().closePanel();
+				});
+			}
+		});
+
+		it('should swap Context Details for the Timeline on click, at the popover size', async () => {
+			renderMainPanel();
+
+			const contextWidget = screen.getByTestId('header-context-widget');
+			fireEvent.mouseEnter(contextWidget);
+			await waitFor(() => {
+				expect(screen.getByText('Context Details')).toBeInTheDocument();
+			});
+
+			// jsdom lays nothing out, so give the popover a real box to be measured.
+			const rectSpy = vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+				x: 0,
+				y: 0,
+				top: 0,
+				left: 0,
+				bottom: 512,
+				right: 480,
+				width: 480,
+				height: 512,
+				toJSON: () => ({}),
+			} as DOMRect);
+			try {
+				fireEvent.click(contextWidget);
+
+				const state = useContextTimelineStore.getState();
+				expect(state.panelSessionId).not.toBeNull();
+				expect(state.sourceSize).toEqual({ width: 480, height: 512 });
+				expect(screen.queryByText('Context Details')).not.toBeInTheDocument();
+			} finally {
+				rectSpy.mockRestore();
+				act(() => {
+					useContextTimelineStore.getState().closePanel();
+				});
+			}
 		});
 
 		it('should display token stats in context tooltip', async () => {

--- a/src/__tests__/renderer/stores/contextTimelineStore.test.ts
+++ b/src/__tests__/renderer/stores/contextTimelineStore.test.ts
@@ -40,6 +40,7 @@ function reset() {
 	useContextTimelineStore.setState({
 		panelSessionId: null,
 		anchorRect: null,
+		sourceSize: null,
 		buffers: {},
 	});
 }
@@ -141,6 +142,32 @@ describe('contextTimelineStore', () => {
 		const s = useContextTimelineStore.getState();
 		expect(s.panelSessionId).toBe('other');
 		expect(s.buffers.other).toEqual({ points: [], trimmed: false });
+	});
+
+	it('togglePanel carries the measured popover size, and closing clears it', () => {
+		const rect = { top: 10, left: 20, bottom: 30, right: 120, width: 100, height: 20 };
+		const size = { width: 480, height: 512 };
+		const store = useContextTimelineStore.getState();
+
+		store.togglePanel(SID, rect, size);
+		expect(useContextTimelineStore.getState().sourceSize).toEqual(size);
+
+		store.togglePanel(SID, rect, size);
+		expect(useContextTimelineStore.getState().sourceSize).toBeNull();
+	});
+
+	it('an open with nothing measured does not inherit the previous open size', () => {
+		const store = useContextTimelineStore.getState();
+		store.openPanel(SID, null, { width: 480, height: 512 });
+		store.openPanel(SID);
+		expect(useContextTimelineStore.getState().sourceSize).toBeNull();
+	});
+
+	it('closePanel clears the measured size', () => {
+		const store = useContextTimelineStore.getState();
+		store.openPanel(SID, null, { width: 480, height: 512 });
+		store.closePanel();
+		expect(useContextTimelineStore.getState().sourceSize).toBeNull();
 	});
 
 	it('closePanel hides the panel but KEEPS the history', () => {

--- a/src/renderer/components/ContextTimelinePanel.tsx
+++ b/src/renderer/components/ContextTimelinePanel.tsx
@@ -17,14 +17,22 @@
  * Anchored bottom-LEFT so it never collides with the Thought Stream (which docks
  * bottom-right inside the Right Panel). Closing hides it but KEEPS the history;
  * "Clear" wipes the focused session's recorded points.
+ *
+ * It is a HOVER surface, not a window: it closes once the pointer leaves both it
+ * and the gauge, and it never shares the screen with the Context Details popover
+ * the same gauge shows on hover (MainPanelHeader hides that one while this is
+ * open). The two are alternatives for one spot, so they default to one size.
  */
 
-import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 import { Gauge, Trash2, BarChart3, LineChart } from 'lucide-react';
 import type { Theme } from '../types';
 import {
 	useContextTimelineStore,
 	selectPoints,
+	CONTEXT_SURFACE_CLOSE_DELAY_MS,
+	CONTEXT_SURFACE_GAP,
+	CONTEXT_SURFACE_WIDTH,
 	type ContextTimelinePoint,
 	type TimelineAnchorRect,
 } from '../stores/contextTimelineStore';
@@ -49,19 +57,16 @@ interface ContextTimelinePanelProps {
 }
 
 /**
- * Default panel size. The width is set by the WIDEST single line the body draws,
- * not by taste: the per-turn breakdown is `in / cache r / cache w / out` plus a
- * cost, each chip `whitespace-nowrap`, and the subtitle names the window and the
- * provider-reported caveat. At the old 360px both wrapped on every row, which
- * doubled the height of a row whose whole job is to be scanned quickly.
+ * Height used only when the panel opens with no Context Details popover on screen
+ * to measure (keyboard, programmatic open). The width is always
+ * CONTEXT_SURFACE_WIDTH, which that popover shares - see its doc in the store.
  */
-const PANEL_WIDTH = 560;
-const PANEL_HEIGHT = 620;
+const PANEL_FALLBACK_HEIGHT = 620;
 /** Narrower than this and the breakdown line starts wrapping again. */
 const PANEL_MIN_WIDTH = 380;
 const PANEL_MIN_HEIGHT = 260;
 const VIEWPORT_MARGIN = 8;
-const ANCHOR_GAP = 8;
+const ANCHOR_GAP = CONTEXT_SURFACE_GAP;
 /** Key under which the user's dragged size is remembered (settingsStore.modalSizes). */
 const PANEL_RESIZE_KEY = 'context-timeline';
 /** The header context gauge that opens this panel; re-queried for its live rect. */
@@ -133,14 +138,17 @@ export function ContextTimelinePanel({ theme }: ContextTimelinePanelProps) {
 	);
 	const closePanel = useContextTimelineStore((s) => s.closePanel);
 	const clearSession = useContextTimelineStore((s) => s.clearSession);
+	const sourceSize = useContextTimelineStore((s) => s.sourceSize);
 
-	// Drag-to-resize, remembered per user in settingsStore.modalSizes. `topLeft`
+	// Drag-to-resize, remembered per user in settingsStore.modalSizes - one key for
+	// every agent, so a size set on one is the size on all of them. `topLeft`
 	// rather than the default `center`: this panel is pinned to the gauge and
 	// grows from one edge, so a centered scale factor would move it twice as fast
-	// as the cursor.
+	// as the cursor. The DEFAULT is the popover the click replaced, so the swap
+	// lands in the same space; a dragged size still wins over it.
 	const resizable = useResizableModal({
 		resizeKey: PANEL_RESIZE_KEY,
-		defaultSize: { width: PANEL_WIDTH, height: PANEL_HEIGHT },
+		defaultSize: sourceSize ?? { width: CONTEXT_SURFACE_WIDTH, height: PANEL_FALLBACK_HEIGHT },
 		minSize: { width: PANEL_MIN_WIDTH, height: PANEL_MIN_HEIGHT },
 		anchor: 'topLeft',
 	});
@@ -212,8 +220,8 @@ export function ContextTimelinePanel({ theme }: ContextTimelinePanelProps) {
 	// above lower-z dialogs (Create PR, expanded Auto Run) that own the foreground.
 	const { hasOpenModal } = useLayerStack();
 
-	// The context gauge is now the only open/close control, so Escape is the
-	// keyboard's way out. Handled locally rather than through the layer stack for
+	// The gauge opens and closes it and moving the pointer away dismisses it, so
+	// Escape is the keyboard's way out. Handled locally rather than through the layer stack for
 	// the reason above, and gated on the panel actually being on screen: while a
 	// modal is open this component renders nothing, and swallowing that modal's
 	// Escape from behind it would be indistinguishable from the modal hanging.
@@ -224,6 +232,92 @@ export function ContextTimelinePanel({ theme }: ContextTimelinePanelProps) {
 		e.stopPropagation();
 		closePanel();
 	});
+
+	// Hover-dismiss. The panel closes once the pointer has left BOTH it and the
+	// gauge that opened it, after the same grace period the Context Details popover
+	// uses, so crossing the gap between them is not leaving. It is tracked from one
+	// window-level `mouseover` rather than onMouseLeave on each element because the
+	// gauge lives in MainPanelHeader and this panel in AppShell, and "is the pointer
+	// over either?" needs a single place to be asked. `mouseover`, not `mousemove`:
+	// a browser tab's <webview> keeps its pointer events to itself, so moving from
+	// the panel onto one produces no host mousemove at all, while the host still
+	// sees a mouseover targeting the webview element.
+	//
+	// Two things must NOT dismiss it. A resize drag routinely carries the pointer
+	// outside, so nothing closes while one is in progress and the check re-runs
+	// when it ends. And a panel opened from the keyboard, with the pointer parked
+	// elsewhere, stays until the pointer has actually been over it: `armed` is what
+	// separates hovering away from never having hovered at all.
+	const pointerInsideRef = useRef(false);
+	const hoverArmedRef = useRef(false);
+	const hoverDismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	const cancelHoverDismiss = useCallback(() => {
+		if (hoverDismissTimerRef.current) {
+			clearTimeout(hoverDismissTimerRef.current);
+			hoverDismissTimerRef.current = null;
+		}
+	}, []);
+
+	const evaluateHoverDismiss = useCallback(() => {
+		if (pointerInsideRef.current) hoverArmedRef.current = true;
+		if (!panelSessionId || resizable.isResizing || pointerInsideRef.current) {
+			cancelHoverDismiss();
+			return;
+		}
+		if (!hoverArmedRef.current || hoverDismissTimerRef.current) return;
+		hoverDismissTimerRef.current = setTimeout(() => {
+			hoverDismissTimerRef.current = null;
+			closePanel();
+		}, CONTEXT_SURFACE_CLOSE_DELAY_MS);
+	}, [panelSessionId, resizable.isResizing, cancelHoverDismiss, closePanel]);
+
+	// Each open starts from where the pointer actually is. A click leaves the gauge
+	// hovered (`:hover` also covers the popover, which is the gauge's descendant),
+	// so a mouse open is armed at once; a keyboard open is not. Declared before the
+	// re-check below so that effect reads this open's state, not the last one's.
+	useEffect(() => {
+		cancelHoverDismiss();
+		const gauge = panelSessionId ? document.querySelector(HEADER_CONTEXT_WIDGET_SELECTOR) : null;
+		const overGauge = !!gauge?.matches(':hover');
+		pointerInsideRef.current = overGauge;
+		hoverArmedRef.current = overGauge;
+	}, [panelSessionId, cancelHoverDismiss]);
+
+	// Re-check when the inputs change - chiefly a resize drag ending with the
+	// pointer already outside, which produces no further event to react to.
+	useEffect(() => {
+		evaluateHoverDismiss();
+	}, [evaluateHoverDismiss]);
+
+	useEffect(() => cancelHoverDismiss, [cancelHoverDismiss]);
+
+	useEventListener(
+		'mouseover',
+		(event: Event) => {
+			// Hidden behind a modal, the pointer is necessarily "outside" a panel that
+			// is not drawn, and that must not close it out from under the user.
+			if (hasOpenModal()) return;
+			const target = event.target instanceof Node ? event.target : null;
+			const panel = resizable.modalRef.current;
+			const gauge = document.querySelector(HEADER_CONTEXT_WIDGET_SELECTOR);
+			pointerInsideRef.current =
+				!!target && (!!panel?.contains(target) || !!gauge?.contains(target));
+			evaluateHoverDismiss();
+		},
+		{ enabled: !!panelSessionId }
+	);
+
+	// Leaving the window entirely targets nothing, so no mouseover fires for it.
+	useEventListener(
+		'mouseout',
+		(event: Event) => {
+			if ((event as MouseEvent).relatedTarget !== null || hasOpenModal()) return;
+			pointerInsideRef.current = false;
+			evaluateHoverDismiss();
+		},
+		{ enabled: !!panelSessionId }
+	);
 
 	// Auto-tail: when pinned to the top, follow new turns (newest is at the top).
 	useEffect(() => {

--- a/src/renderer/components/MainPanel/MainPanelHeader.tsx
+++ b/src/renderer/components/MainPanel/MainPanelHeader.tsx
@@ -25,6 +25,9 @@ import { useViewportBreakpoint } from '../../hooks/ui/useViewportBreakpoint';
 import { isWebDesktop } from '../../utils/runtimeContext';
 import {
 	useContextTimelineStore,
+	CONTEXT_SURFACE_CLOSE_DELAY_MS,
+	CONTEXT_SURFACE_GAP,
+	CONTEXT_SURFACE_WIDTH,
 	type TimelineAnchorRect,
 } from '../../stores/contextTimelineStore';
 import type { Session, Theme, BatchRunState, AITab } from '../../types';
@@ -170,14 +173,41 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 	// pills (SSH host + branch) means either one opens the menu, and it also
 	// excludes them from click-outside so clicking a pill can't close it.
 	const gitPillRef = useRef<HTMLDivElement>(null);
-	const contextTooltip = useHoverTooltip(150);
+	const contextTooltip = useHoverTooltip(CONTEXT_SURFACE_CLOSE_DELAY_MS);
+
+	// The gauge has two surfaces - Context Details on hover, the Context Timeline
+	// on click - and they are alternatives for one spot, never a stack. The popover
+	// stays hidden while ANY timeline panel is open (there is one app-wide, and it
+	// anchors under this gauge), whatever the hover state says.
+	const timelinePanelOpen = useContextTimelineStore((s) => s.panelSessionId !== null);
+	const contextDetailsVisible = contextTooltip.isOpen && !timelinePanelOpen;
+	// The popover's bordered box, measured at click time so the timeline opens in
+	// exactly the space the popover held.
+	const contextDetailsRef = useRef<HTMLDivElement>(null);
+	const closeContextTooltip = contextTooltip.close;
+
+	// Swap one surface for the other. The popover's size is read while it is still
+	// laid out, then it is closed before the toggle. A toggle with no popover on
+	// screen (keyboard focus) passes no size and the timeline uses its default.
+	const toggleContextTimeline = useCallback(
+		(gauge: HTMLElement) => {
+			const box = contextDetailsRef.current?.getBoundingClientRect();
+			const sourceSize =
+				box && box.width > 0 && box.height > 0
+					? { width: Math.round(box.width), height: Math.round(box.height) }
+					: null;
+			closeContextTooltip();
+			useContextTimelineStore.getState().togglePanel(activeSession.id, rectOf(gauge), sourceSize);
+		},
+		[activeSession.id, closeContextTooltip]
+	);
 
 	// Message count and elapsed span for the tab in view - the same figures the
 	// HTML export prints, so they can be read without exporting. Walking the log
-	// array costs O(entries), so it only runs while the popover is actually open.
+	// array costs O(entries), so it only runs while the popover is on screen.
 	const conversationStats = useMemo(
-		() => (contextTooltip.isOpen ? computeTabConversationStats(activeTab?.logs) : null),
-		[contextTooltip.isOpen, activeTab?.logs]
+		() => (contextDetailsVisible ? computeTabConversationStats(activeTab?.logs) : null),
+		[contextDetailsVisible, activeTab?.logs]
 	);
 
 	// The git menu opens on hover. The open delay keeps it from popping up while
@@ -502,17 +532,11 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 							tabIndex={0}
 							aria-label="Toggle context timeline"
 							{...contextTooltip.triggerHandlers}
-							onClick={(e) =>
-								useContextTimelineStore
-									.getState()
-									.togglePanel(activeSession.id, rectOf(e.currentTarget))
-							}
+							onClick={(e) => toggleContextTimeline(e.currentTarget)}
 							onKeyDown={(e) => {
 								if (e.key === 'Enter' || e.key === ' ') {
 									e.preventDefault();
-									useContextTimelineStore
-										.getState()
-										.togglePanel(activeSession.id, rectOf(e.currentTarget));
+									toggleContextTimeline(e.currentTarget);
 								}
 							}}
 						>
@@ -528,7 +552,7 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 							</span>
 
 							{/* Context Window Tooltip */}
-							{contextTooltip.isOpen && activeSession.inputMode === 'ai' && (
+							{contextDetailsVisible && activeSession.inputMode === 'ai' && (
 								<>
 									{/* Invisible bridge to prevent hover gap */}
 									<div
@@ -536,13 +560,15 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 										style={{ top: '100%' }}
 										{...contextTooltip.contentHandlers}
 									/>
+									{/* Same width and gap as the Context Timeline, so a click swaps
+									    one surface for the other in place. */}
 									<div
-										className={`absolute top-full right-0 pt-2 z-50 pointer-events-auto ${
-											showBatchUsage && batchUsageSnapshot ? 'w-72' : 'w-64'
-										}`}
+										className="absolute top-full right-0 z-50 pointer-events-auto"
+										style={{ paddingTop: CONTEXT_SURFACE_GAP, width: CONTEXT_SURFACE_WIDTH }}
 										{...contextTooltip.contentHandlers}
 									>
 										<div
+											ref={contextDetailsRef}
 											className="border rounded-lg p-3 shadow-xl"
 											style={{
 												backgroundColor: theme.colors.bgSidebar,

--- a/src/renderer/stores/contextTimelineStore.ts
+++ b/src/renderer/stores/contextTimelineStore.ts
@@ -27,6 +27,7 @@
 
 import { create } from 'zustand';
 import { generateId } from '../utils/ids';
+import type { ModalSize } from '../utils/modalSizing';
 
 /**
  * One turn's normalized context accounting. The provider-specific math
@@ -96,6 +97,27 @@ export type ContextTimelinePointInput = Omit<ContextTimelinePoint, 'id' | 'times
 export type ContextTimelineHydrationPoint = ContextTimelinePointInput & { timestamp: number };
 
 /**
+ * Shared footprint of the two surfaces the header context gauge opens: the
+ * Context Details popover (on hover) and the Timeline panel (on click). They are
+ * alternatives for ONE spot on screen, so they share a width, a gap under the
+ * gauge and a close delay - a click that swaps one for the other should land in
+ * the same space rather than resize it.
+ *
+ * The width is set by the Timeline's per-turn breakdown line (`in / cache r /
+ * cache w / out` plus cost), which wraps below it and doubles every row's height.
+ * The popover's label/value rows have room to spare at the same width.
+ */
+export const CONTEXT_SURFACE_WIDTH = 480;
+/** Gap between the bottom of the gauge and the top of either surface (px). */
+export const CONTEXT_SURFACE_GAP = 8;
+/**
+ * Grace period after the pointer leaves a surface and its gauge. Covers the trip
+ * across the gap between them, and is short enough that moving away reads as
+ * dismissing it.
+ */
+export const CONTEXT_SURFACE_CLOSE_DELAY_MS = 150;
+
+/**
  * A plain (structured-clone-safe) copy of the trigger element's viewport rect,
  * so the panel can anchor itself to the header gauge that opened it instead of
  * always docking bottom-left. Stored as plain numbers - never a live DOMRect.
@@ -123,6 +145,13 @@ interface ContextTimelineState {
 	view: ContextTimelineView;
 	/** Viewport rect of the element that opened the panel (null = dock bottom-left). */
 	anchorRect: TimelineAnchorRect | null;
+	/**
+	 * Measured size of the Context Details popover when the gauge was clicked. It
+	 * is the panel's DEFAULT size, so the swap lands in the space the popover held.
+	 * Null when nothing was on screen to measure (keyboard, programmatic open). A
+	 * size the user dragged still wins over it.
+	 */
+	sourceSize: ModalSize | null;
 	/** Per-session capture buffers (capture runs for all sessions, always). */
 	buffers: Record<string, ContextTimelineBuffer>;
 
@@ -139,7 +168,11 @@ interface ContextTimelineState {
 		trimmed: boolean
 	) => void;
 	/** Open (or refocus) the inspector for a session, optionally anchored to a rect. */
-	openPanel: (sessionId: string, anchorRect?: TimelineAnchorRect | null) => void;
+	openPanel: (
+		sessionId: string,
+		anchorRect?: TimelineAnchorRect | null,
+		sourceSize?: ModalSize | null
+	) => void;
 	/**
 	 * Open the inspector, or close it when this same session's panel is already
 	 * showing. The context gauge is the ONLY open/close control the panel has, so
@@ -150,7 +183,11 @@ interface ContextTimelineState {
 	 * than closing, because that click asked to see a DIFFERENT agent's history,
 	 * not to dismiss the one on screen.
 	 */
-	togglePanel: (sessionId: string, anchorRect?: TimelineAnchorRect | null) => void;
+	togglePanel: (
+		sessionId: string,
+		anchorRect?: TimelineAnchorRect | null,
+		sourceSize?: ModalSize | null
+	) => void;
 	/** Switch between the bar list and the line graph. */
 	setView: (view: ContextTimelineView) => void;
 	/** Hide the panel. History is KEPT so reopening shows it again. */
@@ -165,6 +202,7 @@ export const useContextTimelineStore = create<ContextTimelineState>((set) => ({
 	panelSessionId: null,
 	view: 'bar',
 	anchorRect: null,
+	sourceSize: null,
 	buffers: {},
 
 	appendPoint: (sessionId, point) =>
@@ -227,24 +265,26 @@ export const useContextTimelineStore = create<ContextTimelineState>((set) => ({
 			};
 		}),
 
-	openPanel: (sessionId, anchorRect = null) =>
+	openPanel: (sessionId, anchorRect = null, sourceSize = null) =>
 		set((state) => ({
 			panelSessionId: sessionId,
 			anchorRect,
+			sourceSize,
 			// Preserve any history already captured for this session.
 			buffers: state.buffers[sessionId]
 				? state.buffers
 				: { ...state.buffers, [sessionId]: { points: [], trimmed: false } },
 		})),
 
-	togglePanel: (sessionId, anchorRect = null) =>
+	togglePanel: (sessionId, anchorRect = null, sourceSize = null) =>
 		set((state) => {
 			if (state.panelSessionId === sessionId) {
-				return { panelSessionId: null, anchorRect: null };
+				return { panelSessionId: null, anchorRect: null, sourceSize: null };
 			}
 			return {
 				panelSessionId: sessionId,
 				anchorRect,
+				sourceSize,
 				buffers: state.buffers[sessionId]
 					? state.buffers
 					: { ...state.buffers, [sessionId]: { points: [], trimmed: false } },
@@ -253,7 +293,7 @@ export const useContextTimelineStore = create<ContextTimelineState>((set) => ({
 
 	setView: (view) => set({ view }),
 
-	closePanel: () => set({ panelSessionId: null, anchorRect: null }),
+	closePanel: () => set({ panelSessionId: null, anchorRect: null, sourceSize: null }),
 
 	clearSession: (sessionId) =>
 		set((state) => ({


### PR DESCRIPTION
## Problem

The header context gauge opens two surfaces: **Context Details** on hover and the **Context Timeline** on click.

1. They could show at the same time. A click opened the timeline without dismissing the popover.
2. The timeline was sticky. It closed only on a second gauge click or Escape, while the popover closes as soon as the pointer leaves.
3. The two used different sizes, so the click swap jumped.

## Fix

- **Mutually exclusive.** `MainPanelHeader` hides the popover while the timeline panel is open, and a gauge click closes the popover before toggling the timeline.
- **Hover-dismiss.** `ContextTimelinePanel` closes once the pointer leaves both the panel and the gauge, after the same 150ms grace the popover uses (`CONTEXT_SURFACE_CLOSE_DELAY_MS`).
  - Tracked from a window-level `mouseover`, not `mousemove`. A browser tab's `<webview>` keeps its pointer events, so `mousemove` would leave the panel stuck open over one.
  - A resize drag holds it open, then re-checks when the drag ends.
  - A keyboard open waits until the pointer has been over the panel before it can dismiss.
- **Same footprint.** Both surfaces share `CONTEXT_SURFACE_WIDTH` (480px) and `CONTEXT_SURFACE_GAP`. The timeline's default size is the popover's measured size at click time (`sourceSize` on the store). A dragged size still wins and stays remembered under `modalSizes['context-timeline']` for every agent across restarts.

> [!NOTE]
> A user with a size already saved from before keeps it. Double-click any timeline edge to reset it to the new default.

## Tests

- `ContextTimelinePanel.test.tsx`: opens at the measured popover size, falls back to the shared width, a dragged size beats the measured one, closes after the grace period, survives a quick return, treats the gauge as inside, ignores a pointer that never entered, closes on leaving the window, holds through a resize drag.
- `contextTimelineStore.test.ts`: `sourceSize` carried on toggle, not inherited by a later unmeasured open, cleared on close.
- `MainPanel.test.tsx`: popover hidden while the timeline is open; click swaps them and passes the popover's size.

Local: the 3 files pass (202 tests); pre-push ran the full suite, 42,792 passed.

Docs: one paragraph in `docs/context-management.md` under Context Details.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Context Timeline that displays how the context window fills over successive turns.
  - Open the timeline by clicking or keyboard-activating the context gauge.
  - The timeline remembers custom panel dimensions and adapts to the Context Details popover size.
  - Improved panel dismissal when the pointer leaves the panel and gauge, with support for resize interactions and keyboard access.
  - Context Details is automatically hidden while the timeline is open.

- **Documentation**
  - Added guidance describing Context Timeline behavior, opening and closing interactions, resizing, and saved dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->