### PR TITLE
feat(settings): add Requesty as a built-in LLM provider

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -199,6 +199,29 @@ Because the layers are edited in different places, no single screen shows the re
 
 This is the quickest way to catch the case where an agent behaves oddly because an `ANTHROPIC_BASE_URL` or API key from a layer you forgot about is overriding the one you just set. Values that look like credentials are masked until you click the eye on that row.
 
+## Built-in LLM Provider
+
+Some built-in AI features call an LLM directly (rather than going through a coding
+agent). The provider for these features is configured under **Settings → LLM** via the
+**LLM Provider** dropdown, a **Model Slug** field, and an **API Key** field. A **Test
+Connection** button sends a short prompt to verify connectivity and configuration.
+
+| Provider   | Base URL                        | API style         | Example model slug            |
+| ---------- | ------------------------------- | ----------------- | ----------------------------- |
+| OpenRouter | `https://openrouter.ai/api/v1`  | OpenAI-compatible | `anthropic/claude-3.5-sonnet` |
+| Requesty   | `https://router.requesty.ai/v1` | OpenAI-compatible | `openai/gpt-4o-mini`          |
+| Anthropic  | `https://api.anthropic.com/v1`  | Messages API      | `claude-3-5-sonnet-20241022`  |
+| Ollama     | `http://localhost:11434`        | Ollama (local)    | `llama3:latest`               |
+
+OpenRouter and Requesty both use OpenAI-compatible `provider/model` slugs and a
+`Bearer` API key. For Requesty, create a key at
+[app.requesty.ai/api-keys](https://app.requesty.ai/api-keys) and list available models
+with `GET https://router.requesty.ai/v1/models`. See the
+[Requesty docs](https://docs.requesty.ai) for details.
+
+API keys are stored locally in your Maestro settings file (see [Storage
+Location](#storage-location)).
+
 ## Checking for Updates
 
 Maestro checks for updates automatically on startup (configurable in Settings → General → **Check for updates on startup**).

--- a/src/__tests__/renderer/stores/settingsStore.test.ts
+++ b/src/__tests__/renderer/stores/settingsStore.test.ts
@@ -288,6 +288,12 @@ describe('settingsStore', () => {
 				expect(window.maestro.settings.set).toHaveBeenCalledWith('llmProvider', 'anthropic');
 			});
 
+			it('setLlmProvider accepts requesty without a cast', () => {
+				useSettingsStore.getState().setLlmProvider('requesty');
+				expect(useSettingsStore.getState().llmProvider).toBe('requesty');
+				expect(window.maestro.settings.set).toHaveBeenCalledWith('llmProvider', 'requesty');
+			});
+
 			it('setModelSlug updates state and persists', () => {
 				useSettingsStore.getState().setModelSlug('gpt-4');
 				expect(useSettingsStore.getState().modelSlug).toBe('gpt-4');

--- a/src/renderer/components/Settings/SettingsModal.tsx
+++ b/src/renderer/components/Settings/SettingsModal.tsx
@@ -41,7 +41,7 @@ import type { SearchableSetting } from './searchableSettings';
 
 // Feature flags - set to true to enable dormant features
 const FEATURE_FLAGS = {
-	LLM_SETTINGS: false, // LLM provider configuration (OpenRouter, Anthropic, Ollama)
+	LLM_SETTINGS: false, // LLM provider configuration (OpenRouter, Requesty, Anthropic, Ollama)
 };
 
 type SettingsTabId =
@@ -377,6 +377,39 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 					status: 'success',
 					message: 'Successfully connected to OpenRouter!',
 				});
+			} else if (llmProvider === 'requesty') {
+				if (!apiKey) {
+					throw new Error('API key is required for Requesty');
+				}
+
+				response = await fetch('https://router.requesty.ai/v1/chat/completions', {
+					method: 'POST',
+					headers: {
+						Authorization: `Bearer ${apiKey}`,
+						'Content-Type': 'application/json',
+						'HTTP-Referer': 'https://maestro.local',
+					},
+					body: JSON.stringify({
+						model: modelSlug || 'openai/gpt-4o-mini',
+						messages: [{ role: 'user', content: testPrompt }],
+						max_tokens: 50,
+					}),
+				});
+
+				if (!response.ok) {
+					const error = await response.json();
+					throw new Error(error.error?.message || `Requesty API error: ${response.status}`);
+				}
+
+				const data = await response.json();
+				if (!data.choices?.[0]?.message?.content) {
+					throw new Error('Invalid response from Requesty');
+				}
+
+				setTestResult({
+					status: 'success',
+					message: 'Successfully connected to Requesty!',
+				});
 			} else if (llmProvider === 'anthropic') {
 				if (!apiKey) {
 					throw new Error('API key is required for Anthropic');
@@ -560,6 +593,7 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 										style={{ borderColor: theme.colors.border }}
 									>
 										<option value="openrouter">OpenRouter</option>
+										<option value="requesty">Requesty</option>
 										<option value="anthropic">Anthropic</option>
 										<option value="ollama">Ollama (Local)</option>
 									</select>
@@ -575,7 +609,11 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 										className="w-full p-2 rounded border bg-transparent outline-none"
 										style={{ borderColor: theme.colors.border }}
 										placeholder={
-											llmProvider === 'ollama' ? 'llama3:latest' : 'anthropic/claude-3.5-sonnet'
+											llmProvider === 'ollama'
+												? 'llama3:latest'
+												: llmProvider === 'requesty'
+													? 'openai/gpt-4o-mini'
+													: 'anthropic/claude-3.5-sonnet'
 										}
 									/>
 								</div>

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -87,7 +87,7 @@ export type SettingsTab =
 	| 'prompts';
 // Note: ScratchPadMode was removed as part of the Scratchpad → Auto Run migration
 export type FocusArea = 'sidebar' | 'main' | 'right';
-export type LLMProvider = 'openrouter' | 'anthropic' | 'ollama';
+export type LLMProvider = 'openrouter' | 'requesty' | 'anthropic' | 'ollama';
 
 // Inline wizard types for per-session/per-tab wizard state
 export type WizardMode = 'new' | 'iterate' | null;

--- a/src/shared/settingsMetadata.ts
+++ b/src/shared/settingsMetadata.ts
@@ -554,7 +554,8 @@ export const SETTINGS_METADATA: Record<string, SettingMetadata> = {
 
 	// --- LLM / Provider ---
 	llmProvider: {
-		description: 'LLM provider for built-in AI features. E.g., openrouter, anthropic, openai.',
+		description:
+			'LLM provider for built-in AI features. E.g., openrouter, requesty, anthropic, ollama.',
 		type: 'string',
 		default: 'openrouter',
 		category: 'advanced',


### PR DESCRIPTION
## Add Requesty provider

This re-adds [Requesty](https://requesty.ai) as a built-in LLM provider, alongside the existing OpenRouter / Anthropic / Ollama options.

Context: the same change was merged as #1112 on 2026-07-15, but the merge commit is no longer in `main` after the history reset later that month (the `git log` gap between 2026-07-09 and 2026-07-23), so the provider quietly disappeared. This PR reapplies it on top of current `main`, adjusted to the code as it is today.

Requesty is an OpenAI-compatible model gateway that uses the same `provider/model` identifier format as OpenRouter, so it is implemented by mirroring the existing OpenRouter provider (only the base URL differs).

### Changes
- `src/renderer/types/index.ts`: extend `LLMProvider` union with `'requesty'`.
- `src/renderer/components/Settings/SettingsModal.tsx`: add the Requesty option and a `requesty` branch in `testLLMConnection()` that POSTs to `https://router.requesty.ai/v1/chat/completions` with the user's key (default model `openai/gpt-4o-mini`), mirroring the OpenRouter branch. The Model Slug placeholder shows `openai/gpt-4o-mini` when Requesty is selected.
- `src/shared/settingsMetadata.ts`: list `requesty` in the `llmProvider` description (the old text also said `openai`, which is not a valid value, so that is corrected while here).
- `docs/configuration.md`: document the built-in LLM providers including Requesty (key at https://app.requesty.ai/api-keys, model list via `GET https://router.requesty.ai/v1/models`).

Default provider is left as `openrouter`. This adds Requesty and does not replace anything.

### Testing
- `npm run lint` (tsc across the three tsconfigs) clean; `eslint` and `prettier --check` clean on the changed files.
- `vitest` on the SettingsModal, settingsStore, defaults, types, useSettings and fonts suites: 533/533 pass.
- `npm run docs:verify`: 321 paths checked, 0 missing.
- Live endpoint: `POST https://router.requesty.ai/v1/chat/completions` with `model: openai/gpt-4o-mini` returns HTTP 200 with a real completion.

### Disclosure
I work at Requesty. Happy to adjust anything to match project conventions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Requesty as a supported LLM provider.
  - Added Requesty model selection, connection testing, API request handling, and success/error feedback.

- **Documentation**
  - Added guidance for configuring providers, models, API keys, supported endpoints, Requesty usage, and local API-key storage.
  - Updated LLM provider setting descriptions to include Requesty and Ollama.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->